### PR TITLE
fix: Ascending vs Descending bugs

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -382,7 +382,7 @@ data class CustomSourceConfig(
     val novelIdSelector: String? = null,
     val novelIdAttr: String? = null,
     val novelIdPattern: String? = null,
-    val reverseChapters: Boolean = false,
+    val reverseChapters: Boolean = true,
     val useCloudflare: Boolean = true,
     val useNewChapterEndpoint: Boolean = false,
     val postSearch: Boolean = false,


### PR DESCRIPTION
Novels use ascending order, where manga in mihon defaults to descending order. This requires fixes for sanity.

# Bug
This is actually causing more bugs too. Apparently this change makes the start chapter be the last chapter, instead of the first chapter.
Changing default sort order of all novels instead of opening this rabbit hole.