### PR TITLE
Fix colors

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -49,6 +49,7 @@ object SettingsNovelReaderScreen : SearchableSettings {
                         "dark" to "Dark",
                         "sepia" to "Sepia",
                         "black" to "Black",
+                        "grey" to "Grey",
                     ).toImmutableMap(),
                     title = stringResource(MR.strings.pref_novel_theme),
                 ),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -91,6 +91,7 @@ private val novelThemes = listOf(
     "Dark" to "dark",
     "Sepia" to "sepia",
     "Black" to "black",
+    "Grey" to "grey",
     "Custom" to "custom",
 )
 
@@ -125,6 +126,7 @@ private val fontColors = listOf(
     "Gray" to 0xFF808080.toInt(),
     "Dark Gray" to 0xFF404040.toInt(),
     "Light Gray" to 0xFFC0C0C0.toInt(),
+    "OffWhite" to 0xFFCCCCCC.toInt(),
     "Sepia" to 0xFF5C4033.toInt(),
     "Custom" to Int.MIN_VALUE,
 )
@@ -139,6 +141,7 @@ private val backgroundColors = listOf(
     "Dark Gray" to 0xFF1A1A1A.toInt(),
     "Sepia" to 0xFFF4ECD8.toInt(),
     "Cream" to 0xFFFFFDD0.toInt(),
+    "Charcoal" to 0xFF292832.toInt(),
     "Custom" to Int.MIN_VALUE,
 )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -1772,6 +1772,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
             "dark" -> 0xFF121212.toInt() to 0xFFE0E0E0.toInt()
             "sepia" -> 0xFFF4ECD8.toInt() to 0xFF5B4636.toInt()
             "black" -> 0xFF000000.toInt() to 0xFFCCCCCC.toInt()
+            "grey" -> 0xFF292832.toInt() to 0xFFCCCCCC.toInt()
             "custom" -> {
                 // 0 = default, use fallback colors
                 val bg = if (backgroundColor != 0) backgroundColor else 0xFFFFFFFF.toInt()


### PR DESCRIPTION
Fixes custom color picker to retain settings instead of almost always showing default colors.
Adds the grey color theme that is one of the defaults in lnreader (The one I use).