### PR TITLE
fix: Library filter auto-load, manga/novel separator, and JS chapter …

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -518,6 +518,12 @@ class JsSource(
                 }
             }
 
+            // LNReader plugins return chapters newest-first; reverse to oldest-first
+            // so sourceOrder aligns with chapter_number (chapter 1 = index 0).
+            // The per-source "Reverse chapter list" toggle in SyncChaptersWithSource
+            // can override this if needed.
+            chapters.reverse()
+
             // Cache the result
             chaptersCache[manga.url] = chapters to now
             chapters

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -38,6 +38,7 @@ data class ExtensionInfo(
     val sourceId: Long,
     val sourceName: String,
     val isStub: Boolean = false,
+    val isNovel: Boolean = false,
 )
 
 class LibrarySettingsScreenModel(
@@ -92,6 +93,12 @@ class LibrarySettingsScreenModel(
     // Flags to track if we've attempted to load from disk cache
     private val _extensionsLoaded = AtomicBoolean(false)
     private val _tagsLoaded = AtomicBoolean(false)
+
+    init {
+        // Auto-load extensions on initialization to fix first-time loading issue
+        // This ensures data is ready when the UI is displayed
+        refreshExtensions()
+    }
 
     fun toggleFilter(preference: (LibraryPreferences) -> Preference<TriState>) {
         preference(libraryPreferences).getAndSet {
@@ -235,7 +242,7 @@ class LibrarySettingsScreenModel(
                     if (shouldInclude) {
                         // Add (JS) suffix for JS plugin sources
                         val displayName = if (source is JsSource) "${source.name} (JS)" else source.name
-                        ExtensionInfo(sourceId, displayName, isStub)
+                        ExtensionInfo(sourceId, displayName, isStub, isNovel)
                     } else null
                 }.sortedWith(
                     compareBy<ExtensionInfo> { it.sourceId != 0L && it.sourceId != 1L }

--- a/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
@@ -41,6 +41,8 @@ class SourceRepositoryImpl(
 
     override fun getSourcesWithFavoriteCount(): Flow<List<Pair<DomainSource, Long>>> {
         return combine(
+            // Triggers cause multiple table writes per operation, so debounce
+            // collapses them into a single query execution after the burst.
             handler.subscribeToDebouncedList(2.seconds) { mangasQueries.getSourceIdWithFavoriteCount() },
             sourceManager.catalogueSources,
         ) { sourceIdWithFavoriteCount, _ -> sourceIdWithFavoriteCount }


### PR DESCRIPTION
**Library Extensions Loading and UI Improvements:**

* Extensions are now auto-loaded in the `LibrarySettingsScreenModel`'s `init` block, ensuring data is ready when the UI is displayed and fixing first-time loading issues.
* The UI in `ExtensionsPage` now separates manga and novel sources when displaying the "All" type
* The `ExtensionInfo` data class now includes an `isNovel` flag.

**Chapter List Handling:**

* Jsplugins now properly return proper list order
