### PR TITLE
Feat/library UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ local.properties
 
 # macOS specific files
 .DS_Store
+
+# Documentation/description files (auto-generated)
+PR_DESCRIPTIONS.md
+MANGA_IMAGE_TRANSLATION_ANALYSIS.md
+
+# Misc
+extensions-source/
+todo.txt

--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import dev.icerock.moko.resources.StringResource
-import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.LabeledCheckbox
@@ -20,19 +19,30 @@ import tachiyomi.presentation.core.i18n.stringResource
 fun DeleteLibraryMangaDialog(
     containsLocalManga: Boolean,
     onDismissRequest: () -> Unit,
-    onConfirm: (Boolean, Boolean, Boolean) -> Unit,
+    onConfirm: (Boolean, Boolean, Boolean, Boolean) -> Unit,
 ) {
-    var list by remember {
-        mutableStateOf(
-            buildList<CheckboxState.State<StringResource>> {
-                add(CheckboxState.State.None(MR.strings.manga_from_library))
-                if (!containsLocalManga) {
-                    add(CheckboxState.State.None(MR.strings.downloaded_chapters))
-                }
-                add(CheckboxState.State.None(TDMR.strings.chapters_from_database))
-            },
-        )
+    var removeFromLibrary by remember { mutableStateOf(false) }
+    var deleteDownloads by remember { mutableStateOf(false) }
+    var clearChaptersFromDb by remember { mutableStateOf(false) }
+    var deleteTranslations by remember { mutableStateOf(false) }
+
+    data class CheckboxItem(
+        val label: StringResource,
+        val checked: Boolean,
+        val onCheckedChange: (Boolean) -> Unit,
+    )
+
+    val checkboxItems = remember(containsLocalManga, removeFromLibrary, deleteDownloads, clearChaptersFromDb, deleteTranslations) {
+        buildList {
+            add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary) { removeFromLibrary = it })
+            if (!containsLocalManga) {
+                add(CheckboxItem(MR.strings.downloaded_chapters, deleteDownloads) { deleteDownloads = it })
+            }
+            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb) { clearChaptersFromDb = it })
+            add(CheckboxItem(TDMR.strings.translated_chapters, deleteTranslations) { deleteTranslations = it })
+        }
     }
+
     AlertDialog(
         onDismissRequest = onDismissRequest,
         dismissButton = {
@@ -42,13 +52,14 @@ fun DeleteLibraryMangaDialog(
         },
         confirmButton = {
             TextButton(
-                enabled = list.any { it.isChecked },
+                enabled = removeFromLibrary || deleteDownloads || clearChaptersFromDb || deleteTranslations,
                 onClick = {
                     onDismissRequest()
                     onConfirm(
-                        list[0].isChecked,
-                        list.getOrElse(1) { CheckboxState.State.None(0) }.isChecked && !containsLocalManga,
-                        list.last().isChecked,
+                        removeFromLibrary,
+                        deleteDownloads && !containsLocalManga,
+                        clearChaptersFromDb,
+                        deleteTranslations,
                     )
                 },
             ) {
@@ -60,18 +71,11 @@ fun DeleteLibraryMangaDialog(
         },
         text = {
             Column {
-                list.forEach { state ->
+                checkboxItems.forEach { item ->
                     LabeledCheckbox(
-                        label = stringResource(state.value),
-                        checked = state.isChecked,
-                        onCheckedChange = {
-                            val index = list.indexOf(state)
-                            if (index != -1) {
-                                val mutableList = list.toMutableList()
-                                mutableList[index] = state.next() as CheckboxState.State<StringResource>
-                                list = mutableList.toList()
-                            }
-                        },
+                        label = stringResource(item.label),
+                        checked = item.checked,
+                        onCheckedChange = item.onCheckedChange,
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -171,12 +171,6 @@ private fun ColumnScope.FilterPage(
         state = filterNovel,
         onClick = { screenModel.toggleFilter(LibraryPreferences::filterNovel) },
     )
-    val filterCustomExtension by screenModel.libraryPreferences.filterCustomExtension().collectAsState()
-    TriStateItem(
-        label = stringResource(MR.strings.action_filter_custom_extension),
-        state = filterCustomExtension,
-        onClick = { screenModel.toggleFilter(LibraryPreferences::filterCustomExtension) },
-    )
 
     val filterChapterCount by screenModel.libraryPreferences.filterChapterCount().collectAsState()
     val chapterCountThreshold by screenModel.libraryPreferences.filterChapterCountThreshold().collectAsState()

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -39,7 +39,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -169,6 +171,43 @@ private fun ColumnScope.FilterPage(
         state = filterNovel,
         onClick = { screenModel.toggleFilter(LibraryPreferences::filterNovel) },
     )
+    val filterCustomExtension by screenModel.libraryPreferences.filterCustomExtension().collectAsState()
+    TriStateItem(
+        label = stringResource(MR.strings.action_filter_custom_extension),
+        state = filterCustomExtension,
+        onClick = { screenModel.toggleFilter(LibraryPreferences::filterCustomExtension) },
+    )
+
+    val filterChapterCount by screenModel.libraryPreferences.filterChapterCount().collectAsState()
+    val chapterCountThreshold by screenModel.libraryPreferences.filterChapterCountThreshold().collectAsState()
+    var thresholdText by remember { mutableStateOf(chapterCountThreshold.toString()) }
+    TriStateItem(
+        label = when (filterChapterCount) {
+            TriState.ENABLED_IS -> "Chapters ≥ $chapterCountThreshold"
+            TriState.ENABLED_NOT -> "Chapters < $chapterCountThreshold"
+            else -> "Chapter count"
+        },
+        state = filterChapterCount,
+        onClick = { screenModel.toggleFilter(LibraryPreferences::filterChapterCount) },
+    )
+    if (filterChapterCount != TriState.DISABLED) {
+        OutlinedTextField(
+            value = thresholdText,
+            onValueChange = { value ->
+                thresholdText = value
+                value.toIntOrNull()?.takeIf { it > 0 }?.let {
+                    screenModel.libraryPreferences.filterChapterCountThreshold().set(it)
+                }
+            },
+            label = { Text("Threshold") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
+        )
+    }
+
     // TODO: re-enable when custom intervals are ready for stable
     if ((!isReleaseBuildType) && LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in autoUpdateMangaRestrictions) {
         val filterIntervalCustom by screenModel.libraryPreferences.filterIntervalCustom().collectAsState()

--- a/app/src/main/java/eu/kanade/presentation/library/components/BatchExportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/BatchExportEpubDialog.kt
@@ -23,9 +23,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.translation.model.TranslationMode
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.CheckboxItem
+import tachiyomi.presentation.core.components.RadioItem
 import tachiyomi.presentation.core.i18n.stringResource
 
 /**
@@ -33,7 +35,7 @@ import tachiyomi.presentation.core.i18n.stringResource
  */
 data class EpubExportOptions(
     val downloadedOnly: Boolean = false,
-    val preferTranslated: Boolean = false,
+    val translationMode: TranslationMode = TranslationMode.ORIGINAL,
     // Filename options
     val includeChapterCount: Boolean = false,
     val includeChapterRange: Boolean = false,
@@ -57,12 +59,14 @@ fun BatchExportEpubDialog(
         )
     }
     var downloadedOnly by remember { mutableStateOf(false) }
-    var preferTranslated by remember { mutableStateOf(false) }
+    var translationMode by remember { mutableStateOf(TranslationMode.ORIGINAL) }
     var includeChapterCount by remember { mutableStateOf(false) }
     var includeChapterRange by remember { mutableStateOf(false) }
     var includeStatus by remember { mutableStateOf(false) }
 
-    val mimeType = if (isSingleNovel) "application/epub+zip" else "application/zip"
+    // "Both" mode produces two EPUBs → always ZIP; multi-novel → always ZIP
+    val needsZip = !isSingleNovel || translationMode == TranslationMode.BOTH
+    val mimeType = if (needsZip) "application/zip" else "application/epub+zip"
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument(mimeType),
@@ -72,7 +76,7 @@ fun BatchExportEpubDialog(
                 uri,
                 EpubExportOptions(
                     downloadedOnly = downloadedOnly,
-                    preferTranslated = preferTranslated,
+                    translationMode = translationMode,
                     includeChapterCount = includeChapterCount,
                     includeChapterRange = includeChapterRange,
                     includeStatus = includeStatus,
@@ -139,10 +143,30 @@ fun BatchExportEpubDialog(
                     onClick = { downloadedOnly = !downloadedOnly },
                 )
 
-                CheckboxItem(
-                    label = stringResource(TDMR.strings.epub_prefer_translated),
-                    checked = preferTranslated,
-                    onClick = { preferTranslated = !preferTranslated },
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(TDMR.strings.epub_translation_mode),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_original),
+                    selected = translationMode == TranslationMode.ORIGINAL,
+                    onClick = { translationMode = TranslationMode.ORIGINAL },
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_translated),
+                    selected = translationMode == TranslationMode.TRANSLATED,
+                    onClick = { translationMode = TranslationMode.TRANSLATED },
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_both),
+                    selected = translationMode == TranslationMode.BOTH,
+                    onClick = { translationMode = TranslationMode.BOTH },
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -178,10 +202,10 @@ fun BatchExportEpubDialog(
                         stringResource(TDMR.strings.epub_downloaded_only_info)
                     } else {
                         stringResource(TDMR.strings.epub_source_info)
-                    } + if (preferTranslated) {
-                        stringResource(TDMR.strings.epub_translated_info)
-                    } else {
-                        ""
+                    } + when (translationMode) {
+                        TranslationMode.TRANSLATED -> " " + stringResource(TDMR.strings.epub_translation_translated_info)
+                        TranslationMode.BOTH -> " " + stringResource(TDMR.strings.epub_translation_both_info)
+                        else -> ""
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -191,7 +215,12 @@ fun BatchExportEpubDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    launcher.launch(filename)
+                    val launchName = if (needsZip && !filename.endsWith(".zip")) {
+                        filename.removeSuffix(".epub") + ".zip"
+                    } else {
+                        filename
+                    }
+                    launcher.launch(launchName)
                 },
             ) {
                 Text(stringResource(TDMR.strings.action_export_epub))

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -135,6 +135,9 @@ fun MangaScreen(
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
     onMultiRemoveFromDbClicked: (List<Chapter>) -> Unit,
+    onMultiDeleteTranslationClicked: (List<Chapter>) -> Unit,
+    onTranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
+    onRetranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
 
     // For chapter swipe
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -193,6 +196,9 @@ fun MangaScreen(
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
             onMultiDeleteClicked = onMultiDeleteClicked,
             onMultiRemoveFromDbClicked = onMultiRemoveFromDbClicked,
+            onMultiDeleteTranslationClicked = onMultiDeleteTranslationClicked,
+            onTranslateSelectedClicked = onTranslateSelectedClicked,
+            onRetranslateSelectedClicked = onRetranslateSelectedClicked,
             onChapterSwipe = onChapterSwipe,
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
@@ -240,6 +246,9 @@ fun MangaScreen(
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
             onMultiDeleteClicked = onMultiDeleteClicked,
             onMultiRemoveFromDbClicked = onMultiRemoveFromDbClicked,
+            onMultiDeleteTranslationClicked = onMultiDeleteTranslationClicked,
+            onTranslateSelectedClicked = onTranslateSelectedClicked,
+            onRetranslateSelectedClicked = onRetranslateSelectedClicked,
             onChapterSwipe = onChapterSwipe,
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
@@ -299,6 +308,9 @@ private fun MangaScreenSmallImpl(
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
     onMultiRemoveFromDbClicked: (List<Chapter>) -> Unit,
+    onMultiDeleteTranslationClicked: (List<Chapter>) -> Unit,
+    onTranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
+    onRetranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
 
     // For chapter swipe
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -414,6 +426,9 @@ private fun MangaScreenSmallImpl(
                 onMultiDeleteClicked = onMultiDeleteClicked,
                 onMultiRemoveFromDbClicked = onMultiRemoveFromDbClicked,
                 onDeleteRangeClicked = null, // TODO: Implement delete range dialog
+                onMultiDeleteTranslationClicked = onMultiDeleteTranslationClicked,
+                onTranslateSelectedClicked = onTranslateSelectedClicked,
+                onRetranslateSelectedClicked = onRetranslateSelectedClicked,
                 fillFraction = 1f,
             )
         },
@@ -608,6 +623,9 @@ fun MangaScreenLargeImpl(
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
     onMultiRemoveFromDbClicked: (List<Chapter>) -> Unit,
+    onMultiDeleteTranslationClicked: (List<Chapter>) -> Unit,
+    onTranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
+    onRetranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
 
     // For swipe actions
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -720,6 +738,9 @@ fun MangaScreenLargeImpl(
                     onMultiDeleteClicked = onMultiDeleteClicked,
                     onMultiRemoveFromDbClicked = onMultiRemoveFromDbClicked,
                     onDeleteRangeClicked = null, // TODO: Implement delete range dialog
+                    onMultiDeleteTranslationClicked = onMultiDeleteTranslationClicked,
+                    onTranslateSelectedClicked = onTranslateSelectedClicked,
+                    onRetranslateSelectedClicked = onRetranslateSelectedClicked,
                     fillFraction = 0.5f,
                 )
             }
@@ -873,6 +894,9 @@ private fun SharedMangaBottomActionMenu(
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
     onMultiRemoveFromDbClicked: (List<Chapter>) -> Unit,
     onDeleteRangeClicked: (() -> Unit)?,
+    onMultiDeleteTranslationClicked: ((List<Chapter>) -> Unit)? = null,
+    onTranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
+    onRetranslateSelectedClicked: ((List<Chapter>) -> Unit)? = null,
     fillFraction: Float,
     modifier: Modifier = Modifier,
 ) {
@@ -908,6 +932,27 @@ private fun SharedMangaBottomActionMenu(
             onMultiRemoveFromDbClicked(selected.fastMap { it.chapter })
         },
         onDeleteRangeClicked = onDeleteRangeClicked,
+        onDeleteTranslationClicked = onMultiDeleteTranslationClicked?.let {
+            {
+                it(selected.fastMap { item -> item.chapter })
+            }.takeIf {
+                selected.fastAny { item -> item.hasTranslation }
+            }
+        },
+        onTranslateClicked = onTranslateSelectedClicked?.let {
+            {
+                it(selected.fastMap { item -> item.chapter })
+            }.takeIf {
+                selected.fastAny { item -> item.downloadState == Download.State.DOWNLOADED }
+            }
+        },
+        onRetranslateClicked = onRetranslateSelectedClicked?.let {
+            {
+                it(selected.fastMap { item -> item.chapter })
+            }.takeIf {
+                selected.fastAny { item -> item.hasTranslation }
+            }
+        },
     )
 }
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -21,27 +22,47 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.library.components.EpubExportOptions
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.translation.model.TranslationMode
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
+import tachiyomi.presentation.core.components.CheckboxItem
+import tachiyomi.presentation.core.components.RadioItem
 import tachiyomi.presentation.core.i18n.stringResource
-import dev.icerock.moko.resources.format
 
 @Composable
 fun ExportEpubDialog(
     manga: Manga,
     chapters: List<Chapter>,
     onDismissRequest: () -> Unit,
-    onExport: (Uri) -> Unit,
+    onExport: (Uri, EpubExportOptions) -> Unit,
 ) {
     var filename by remember { mutableStateOf(sanitizeFilename(manga.title) + ".epub") }
+    var downloadedOnly by remember { mutableStateOf(false) }
+    var translationMode by remember { mutableStateOf(TranslationMode.ORIGINAL) }
+    var includeChapterCount by remember { mutableStateOf(false) }
+    var includeChapterRange by remember { mutableStateOf(false) }
+    var includeStatus by remember { mutableStateOf(false) }
+
+    // "Both" mode produces two EPUB files → request a ZIP container
+    val mimeType = if (translationMode == TranslationMode.BOTH) "application/zip" else "application/epub+zip"
 
     val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/epub+zip"),
+        contract = ActivityResultContracts.CreateDocument(mimeType),
     ) { uri ->
         if (uri != null) {
-            onExport(uri)
+            onExport(
+                uri,
+                EpubExportOptions(
+                    downloadedOnly = downloadedOnly,
+                    translationMode = translationMode,
+                    includeChapterCount = includeChapterCount,
+                    includeChapterRange = includeChapterRange,
+                    includeStatus = includeStatus,
+                ),
+            )
             onDismissRequest()
         }
     }
@@ -70,10 +91,86 @@ fun ExportEpubDialog(
                     singleLine = true,
                 )
 
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Export options
+                Text(
+                    text = stringResource(TDMR.strings.epub_content_options),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_downloaded_only),
+                    checked = downloadedOnly,
+                    onClick = { downloadedOnly = !downloadedOnly },
+                )
+
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(
-                    text = stringResource(TDMR.strings.epub_export_note),
+                    text = stringResource(TDMR.strings.epub_translation_mode),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_original),
+                    selected = translationMode == TranslationMode.ORIGINAL,
+                    onClick = { translationMode = TranslationMode.ORIGINAL },
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_translated),
+                    selected = translationMode == TranslationMode.TRANSLATED,
+                    onClick = { translationMode = TranslationMode.TRANSLATED },
+                )
+
+                RadioItem(
+                    label = stringResource(TDMR.strings.epub_translation_both),
+                    selected = translationMode == TranslationMode.BOTH,
+                    onClick = { translationMode = TranslationMode.BOTH },
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(TDMR.strings.epub_filename_options),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_chapter_count),
+                    checked = includeChapterCount,
+                    onClick = { includeChapterCount = !includeChapterCount },
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_chapter_range),
+                    checked = includeChapterRange,
+                    onClick = { includeChapterRange = !includeChapterRange },
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_status),
+                    checked = includeStatus,
+                    onClick = { includeStatus = !includeStatus },
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = if (downloadedOnly) {
+                        stringResource(TDMR.strings.epub_downloaded_only_info)
+                    } else {
+                        stringResource(TDMR.strings.epub_source_info)
+                    } + when (translationMode) {
+                        TranslationMode.TRANSLATED -> " " + stringResource(TDMR.strings.epub_translation_translated_info)
+                        TranslationMode.BOTH -> " " + stringResource(TDMR.strings.epub_translation_both_info)
+                        else -> ""
+                    },
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
@@ -81,7 +178,12 @@ fun ExportEpubDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    launcher.launch(filename)
+                    val launchName = if (translationMode == TranslationMode.BOTH) {
+                        filename.removeSuffix(".epub") + ".zip"
+                    } else {
+                        filename
+                    }
+                    launcher.launch(launchName)
                 },
             ) {
                 Text(stringResource(TDMR.strings.action_export_epub))

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -83,6 +83,9 @@ fun MangaBottomActionMenu(
     onDeleteClicked: (() -> Unit)? = null,
     onRemoveFromDbClicked: (() -> Unit)? = null,
     onDeleteRangeClicked: (() -> Unit)? = null,
+    onDeleteTranslationClicked: (() -> Unit)? = null,
+    onTranslateClicked: (() -> Unit)? = null,
+    onRetranslateClicked: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -189,7 +192,7 @@ fun MangaBottomActionMenu(
                     )
                 }
                 // Overflow menu with additional actions
-                if (onDeleteRangeClicked != null) {
+                if (onDeleteRangeClicked != null || onDeleteTranslationClicked != null || onTranslateClicked != null || onRetranslateClicked != null) {
                     var overflowMenuOpen by remember { mutableStateOf(false) }
                     Button(
                         title = stringResource(MR.strings.label_more),
@@ -203,13 +206,42 @@ fun MangaBottomActionMenu(
                             onDismissRequest = { overflowMenuOpen = false },
                             offset = DpOffset(0.dp, 0.dp),
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(TDMR.strings.action_delete_range)) },
-                                onClick = {
-                                    overflowMenuOpen = false
-                                    onDeleteRangeClicked()
-                                },
-                            )
+                            if (onDeleteRangeClicked != null) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(TDMR.strings.action_delete_range)) },
+                                    onClick = {
+                                        overflowMenuOpen = false
+                                        onDeleteRangeClicked()
+                                    },
+                                )
+                            }
+                            if (onDeleteTranslationClicked != null) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(TDMR.strings.action_delete_translation)) },
+                                    onClick = {
+                                        overflowMenuOpen = false
+                                        onDeleteTranslationClicked()
+                                    },
+                                )
+                            }
+                            if (onTranslateClicked != null) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(TDMR.strings.action_translate)) },
+                                    onClick = {
+                                        overflowMenuOpen = false
+                                        onTranslateClicked()
+                                    },
+                                )
+                            }
+                            if (onRetranslateClicked != null) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(TDMR.strings.action_retranslate)) },
+                                    onClick = {
+                                        overflowMenuOpen = false
+                                        onRetranslateClicked()
+                                    },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -101,6 +101,7 @@ import tachiyomi.domain.manga.interactor.ResetViewerFlags
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
+import tachiyomi.core.common.i18n.stringResource as contextStringResource
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
@@ -235,16 +236,16 @@ object SettingsAdvancedScreen : SearchableSettings {
         if (showDeleteTranslationsDialog) {
             AlertDialog(
                 onDismissRequest = { showDeleteTranslationsDialog = false },
-                title = { Text(text = "Delete all translations") },
+                title = { Text(text = stringResource(MR.strings.pref_delete_all_translations)) },
                 text = {
-                    Text(text = "Are you sure you want to delete all downloaded translations? This cannot be undone.")
+                    Text(text = stringResource(MR.strings.pref_delete_all_translations_confirm))
                 },
                 confirmButton = {
                     TextButton(
                         onClick = {
                             scope.launch {
                                 Injekt.get<TranslatedChapterRepository>().deleteAll()
-                                context.toast("All translations deleted")
+                                context.toast(MR.strings.pref_all_translations_deleted)
                                 showDeleteTranslationsDialog = false
                             }
                         },
@@ -263,9 +264,9 @@ object SettingsAdvancedScreen : SearchableSettings {
         if (showResetSettingsDialog) {
             AlertDialog(
                 onDismissRequest = { showResetSettingsDialog = false },
-                title = { Text(text = "Reset settings to default") },
+                title = { Text(text = stringResource(MR.strings.pref_reset_settings)) },
                 text = {
-                    Text(text = "Are you sure you want to reset all app settings to their default values? This will not delete your library data, downloads, or backups. The app will restart afterwards.")
+                    Text(text = stringResource(MR.strings.pref_reset_settings_confirm))
                 },
                 confirmButton = {
                     TextButton(
@@ -291,7 +292,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                             }
                         },
                     ) {
-                        Text(text = "Reset")
+                        Text(text = stringResource(MR.strings.pref_reset_settings_action))
                     }
                 },
                 dismissButton = {
@@ -818,8 +819,8 @@ object SettingsAdvancedScreen : SearchableSettings {
                     onClick = { navigator.push(ClearDatabaseScreen()) },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Database statistics",
-                    subtitle = "Show detailed database size breakdown",
+                    title = stringResource(MR.strings.pref_db_statistics),
+                    subtitle = stringResource(MR.strings.pref_db_statistics_subtitle),
                     onClick = {
                         scope.launch {
                             try {
@@ -915,8 +916,8 @@ object SettingsAdvancedScreen : SearchableSettings {
                     },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Database maintenance",
-                    subtitle = "VACUUM, REINDEX, and ANALYZE database",
+                    title = stringResource(MR.strings.pref_db_maintenance),
+                    subtitle = stringResource(MR.strings.pref_db_maintenance_subtitle),
                     onClick = {
                         scope.launch {
                             try {
@@ -963,23 +964,23 @@ object SettingsAdvancedScreen : SearchableSettings {
                     },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Normalize manga URLs",
-                    subtitle = "Removes trailing slashes from all manga URLs in database",
+                    title = stringResource(MR.strings.pref_normalize_urls),
+                    subtitle = stringResource(MR.strings.pref_normalize_urls_subtitle),
                     onClick = { showNormalizeUrlsDialog = true },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Remove duplicate URL entries",
-                    subtitle = "Unfavorite manga that would conflict after URL normalization",
+                    title = stringResource(MR.strings.pref_remove_duplicate_urls),
+                    subtitle = stringResource(MR.strings.pref_remove_duplicate_urls_subtitle),
                     onClick = { showRemoveDuplicatesDialog = true },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Delete all translations",
-                    subtitle = "Deletes all downloaded translations",
+                    title = stringResource(MR.strings.pref_delete_all_translations),
+                    subtitle = stringResource(MR.strings.pref_delete_all_translations_subtitle),
                     onClick = { showDeleteTranslationsDialog = true },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Clear temp files",
-                    subtitle = "Clears temporary files from app cache (epub exports, network cache, etc.)",
+                    title = stringResource(MR.strings.pref_clear_temp_files),
+                    subtitle = stringResource(MR.strings.pref_clear_temp_files_subtitle),
                     onClick = {
                         scope.launch {
                             var clearedSize = 0L
@@ -1015,26 +1016,32 @@ object SettingsAdvancedScreen : SearchableSettings {
                                     it.delete()
                                 }
 
+                                // Clear translation temp (.tmp) files
+                                try {
+                                    val translationRepo = Injekt.get<TranslatedChapterRepository>()
+                                    clearedSize += translationRepo.clearTmpFiles()
+                                } catch (_: Exception) { }
+
                                 val sizeString = when {
                                     clearedSize >= 1024 * 1024 -> "%.2f MB".format(clearedSize / (1024.0 * 1024.0))
                                     clearedSize >= 1024 -> "%.2f KB".format(clearedSize / 1024.0)
                                     else -> "$clearedSize bytes"
                                 }
                                 withUIContext {
-                                    context.toast("Cleared $sizeString of temp files")
+                                    context.toast(context.contextStringResource(MR.strings.pref_temp_files_cleared, sizeString))
                                 }
                             } catch (e: Exception) {
                                 logcat(LogPriority.ERROR, e)
                                 withUIContext {
-                                    context.toast("Error clearing temp files")
+                                    context.toast(MR.strings.pref_temp_files_error)
                                 }
                             }
                         }
                     },
                 ),
                 Preference.PreferenceItem.TextPreference(
-                    title = "Bulk remove by URL",
-                    subtitle = "Remove multiple entries from library by URL list",
+                    title = stringResource(MR.strings.pref_bulk_remove_url),
+                    subtitle = stringResource(MR.strings.pref_bulk_remove_url_subtitle),
                     onClick = { showBulkRemovalDialog = true },
                 ),
                 Preference.PreferenceItem.TextPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -50,6 +50,7 @@ object SettingsDownloadScreen : SearchableSettings {
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
         val parallelSourceLimit by downloadPreferences.parallelSourceLimit().collectAsState()
         val parallelPageLimit by downloadPreferences.parallelPageLimit().collectAsState()
+        val epubCompressionLevel by downloadPreferences.epubCompressionLevel().collectAsState()
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.downloadOnlyOverWifi(),
@@ -76,6 +77,21 @@ object SettingsDownloadScreen : SearchableSettings {
                 title = stringResource(MR.strings.pref_download_concurrent_pages),
                 subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
                 onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
+            ),
+            Preference.PreferenceItem.SliderPreference(
+                value = epubCompressionLevel + 1, // shift -1..9 to 0..10 for slider
+                valueRange = 0..10,
+                title = stringResource(MR.strings.pref_epub_compression_level),
+                subtitle = when (epubCompressionLevel) {
+                    -1 -> stringResource(MR.strings.pref_epub_compression_default)
+                    0 -> stringResource(MR.strings.pref_epub_compression_none)
+                    in 1..3 -> stringResource(MR.strings.pref_epub_compression_low)
+                    in 4..6 -> stringResource(MR.strings.pref_epub_compression_medium)
+                    in 7..9 -> stringResource(MR.strings.pref_epub_compression_high)
+                    else -> stringResource(MR.strings.pref_epub_compression_level_label, epubCompressionLevel)
+                },
+                valueString = if (epubCompressionLevel == -1) stringResource(MR.strings.pref_epub_compression_default_label) else "$epubCompressionLevel",
+                onValueChanged = { downloadPreferences.epubCompressionLevel().set(it - 1) },
             ),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
@@ -29,9 +29,11 @@ import mihon.core.archive.EpubWriter
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.model.TranslationMode
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -51,6 +53,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
     private val downloadProvider: DownloadProvider = Injekt.get()
     private val networkHelper: NetworkHelper = Injekt.get()
     private val translatedChapterRepository: TranslatedChapterRepository = Injekt.get()
+    private val downloadPreferences: DownloadPreferences = Injekt.get()
 
     private val notificationBuilder = context.notificationBuilder(Notifications.CHANNEL_EPUB_EXPORT) {
         setSmallIcon(android.R.drawable.ic_menu_save)
@@ -64,12 +67,14 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         val mangaIds = inputData.getLongArray(KEY_MANGA_IDS)?.toList() ?: return Result.failure()
         val uriString = inputData.getString(KEY_OUTPUT_URI) ?: return Result.failure()
         val downloadedOnly = inputData.getBoolean(KEY_DOWNLOADED_ONLY, false)
-        val preferTranslated = inputData.getBoolean(KEY_PREFER_TRANSLATED, false)
+        val translationMode = TranslationMode.fromKey(
+            inputData.getString(KEY_TRANSLATION_MODE) ?: TranslationMode.ORIGINAL.key,
+        )
         val includeChapterCount = inputData.getBoolean(KEY_INCLUDE_CHAPTER_COUNT, false)
         val includeChapterRange = inputData.getBoolean(KEY_INCLUDE_CHAPTER_RANGE, false)
         val includeStatus = inputData.getBoolean(KEY_INCLUDE_STATUS, false)
 
-        logcat(LogPriority.INFO) { "EPUB Export starting: ${mangaIds.size} novels, downloadedOnly=$downloadedOnly" }
+        logcat(LogPriority.INFO) { "EPUB Export starting: ${mangaIds.size} novels, downloadedOnly=$downloadedOnly, translationMode=$translationMode" }
 
         try {
             setForegroundSafely()
@@ -83,7 +88,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                     mangaIds = mangaIds,
                     outputUri = Uri.parse(uriString),
                     downloadedOnly = downloadedOnly,
-                    preferTranslated = preferTranslated,
+                    translationMode = translationMode,
                     includeChapterCount = includeChapterCount,
                     includeChapterRange = includeChapterRange,
                     includeStatus = includeStatus,
@@ -117,12 +122,12 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         mangaIds: List<Long>,
         outputUri: Uri,
         downloadedOnly: Boolean,
-        preferTranslated: Boolean,
+        translationMode: TranslationMode,
         includeChapterCount: Boolean,
         includeChapterRange: Boolean,
         includeStatus: Boolean,
     ) {
-        logcat(LogPriority.INFO) { "performExport called with ${mangaIds.size} manga IDs, outputUri=$outputUri" }
+        logcat(LogPriority.INFO) { "performExport called with ${mangaIds.size} manga IDs, outputUri=$outputUri, translationMode=$translationMode" }
 
         val mangaList = mangaIds.mapNotNull { mangaRepository.getMangaById(it) }
         if (mangaList.isEmpty()) {
@@ -161,16 +166,23 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                         continue
                     }
 
-                    val epubChapters = mutableListOf<EpubWriter.Chapter>()
-                    var firstChapterNum = Double.MAX_VALUE
-                    var lastChapterNum = Double.MIN_VALUE
+                    // ── Collect content per chapter ──────────────────────
+                    data class ChapterContent(
+                        val name: String,
+                        val chapterNumber: Double,
+                        val order: Int,
+                        val originalContent: String?,
+                        val translatedContent: String?,
+                    )
 
-                    // Get translated chapter IDs if preferTranslated is enabled
-                    val translatedChapterIds = if (preferTranslated) {
-                        translatedChapterRepository.getTranslatedChapterIds(manga.id)
+                    // Identify which chapters have translations
+                    val translatedChapterIds = if (translationMode != TranslationMode.ORIGINAL) {
+                        translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
                     } else {
                         emptySet()
                     }
+
+                    val chapterContents = mutableListOf<ChapterContent>()
 
                     for ((chapterIndex, chapter) in chapters.withIndex()) {
                         val isDownloaded = downloadManager.isChapterDownloaded(
@@ -187,7 +199,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                             logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: isDownloaded=$isDownloaded, hasTranslation=$hasTranslation" }
                         }
 
-                        // Skip undownloaded chapters if downloadedOnly
+                        // Skip undownloaded chapters if downloadedOnly and no translation available
                         if (downloadedOnly && !isDownloaded && !hasTranslation) {
                             if (chapterIndex < 3) {
                                 logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: skipping - not downloaded and downloadedOnly=true" }
@@ -195,146 +207,52 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                             continue
                         }
 
-                        // If not downloadedOnly, also try to include undownloaded chapters
-                        // but only if we have some content for them
+                        // ── Original content ──
+                        var originalContent: String? = null
+                        if (translationMode != TranslationMode.TRANSLATED && isDownloaded) {
+                            originalContent = readOriginalContent(manga, chapter, source)
+                        }
 
-                        // Try to get content
-                        var content: String? = null
-
-                        // Try translated content first
-                        if (preferTranslated && hasTranslation) {
+                        // ── Translated content ──
+                        var translatedContent: String? = null
+                        if (translationMode != TranslationMode.ORIGINAL && hasTranslation) {
                             try {
                                 val translations = translatedChapterRepository.getAllTranslationsForChapter(chapter.id)
-                                content = translations.firstOrNull()?.translatedContent
+                                translatedContent = translations.firstOrNull()?.translatedContent
                             } catch (e: Exception) {
                                 logcat(LogPriority.WARN, e) { "Failed to get translation for chapter: ${chapter.name}" }
                             }
                         }
 
-                        // Fall back to downloaded content
-                        if (content == null && isDownloaded) {
-                            try {
-                                // First try to find the chapter directory (uncompressed or cbz)
-                                val chapterDirOrCbz = downloadProvider.findChapterDir(
-                                    chapter.name,
-                                    chapter.scanlator,
-                                    chapter.url,
-                                    manga.title,
-                                    source,
-                                )
-
-                                logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: chapterDir found=${chapterDirOrCbz != null}, exists=${chapterDirOrCbz?.exists()}, name=${chapterDirOrCbz?.name}" }
-
-                                if (chapterDirOrCbz != null) {
-                                    // Check if it's a CBZ file
-                                    val isCbz = chapterDirOrCbz.name?.endsWith(".cbz") == true
-
-                                    if (isCbz) {
-                                        // Read content from CBZ archive
-                                        logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: reading from CBZ archive" }
-                                        content = readContentFromCbz(chapterDirOrCbz.uri)
-                                    } else {
-                                        // It's a directory, list files
-                                        val allFiles = chapterDirOrCbz.listFiles() ?: emptyArray()
-                                        logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: found ${allFiles.size} files in dir" }
-
-                                        val htmlFiles = allFiles.filter {
-                                            it.isFile && it.name?.endsWith(".html") == true
-                                        }.sortedBy { it.name }
-
-                                        // Also check for .txt files as fallback
-                                        val txtFiles = allFiles.filter {
-                                            it.isFile && it.name?.endsWith(".txt") == true
-                                        }.sortedBy { it.name }
-
-                                        logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: htmlFiles=${htmlFiles.size}, txtFiles=${txtFiles.size}" }
-                                        allFiles.take(5).forEach { file ->
-                                            logcat(LogPriority.DEBUG) { "  - ${file.name}" }
-                                        }
-
-                                        val filesToRead = htmlFiles.ifEmpty { txtFiles }
-
-                                        if (filesToRead.isNotEmpty()) {
-                                            val sb = StringBuilder()
-                                            filesToRead.forEachIndexed { i, file ->
-                                                val fileContent = context.contentResolver.openInputStream(file.uri)?.use {
-                                                    it.bufferedReader().readText()
-                                                } ?: ""
-                                                sb.append(fileContent)
-                                                if (i < filesToRead.size - 1) {
-                                                    sb.append("\n\n")
-                                                }
-                                            }
-                                            content = sb.toString()
-                                            logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: read content length=${content?.length ?: 0}" }
-                                        }
-                                    }
-                                }
-
-                                // If no content found, try CBZ archive in manga directory
-                                if (content == null) {
-                                    val mangaDir = downloadProvider.findMangaDir(manga.title, source)
-                                    if (mangaDir != null) {
-                                        val cbzFiles = mangaDir.listFiles()?.filter {
-                                            it.isFile && it.name?.endsWith(".cbz") == true
-                                        } ?: emptyList()
-
-                                        // Find CBZ file matching this chapter
-                                        val chapterDirNames = downloadProvider.getValidChapterDirNames(
-                                            chapter.name,
-                                            chapter.scanlator,
-                                            chapter.url,
-                                        )
-
-                                        val matchingCbz = cbzFiles.find { cbzFile ->
-                                            val cbzBaseName = cbzFile.name?.removeSuffix(".cbz") ?: ""
-                                            chapterDirNames.any { it == cbzBaseName }
-                                        }
-
-                                        if (matchingCbz != null) {
-                                            logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: found CBZ archive ${matchingCbz.name}" }
-                                            content = readContentFromCbz(matchingCbz.uri)
-                                            if (content == null) {
-                                                logcat(LogPriority.WARN) { "${manga.title} ch ${chapter.name}: CBZ found but no readable content" }
-                                            }
-                                        } else {
-                                            logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: no matching CBZ found. Available: ${cbzFiles.map { it.name }}" }
-                                            logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: looking for: $chapterDirNames" }
-                                        }
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                logcat(LogPriority.ERROR, e) { "Failed to read downloaded chapter: ${chapter.name}" }
-                            }
+                        // For ORIGINAL mode -> need original; for TRANSLATED mode -> need translated;
+                        // for BOTH -> gather whatever is available
+                        val hasUsableContent = when (translationMode) {
+                            TranslationMode.ORIGINAL -> originalContent != null && originalContent.isNotBlank()
+                            TranslationMode.TRANSLATED -> translatedContent != null && translatedContent.isNotBlank()
+                            TranslationMode.BOTH -> (originalContent != null && originalContent.isNotBlank()) ||
+                                (translatedContent != null && translatedContent.isNotBlank())
                         }
 
-                        if (content == null && isDownloaded) {
-                            logcat(LogPriority.WARN) { "${manga.title} ch ${chapter.name}: marked as downloaded but no content could be read" }
-                        }
-
-                        if (content != null && content.isNotBlank()) {
-                            val chNum = chapter.chapterNumber
-                            if (chNum < firstChapterNum) firstChapterNum = chNum
-                            if (chNum > lastChapterNum) lastChapterNum = chNum
-
-                            epubChapters.add(
-                                EpubWriter.Chapter(
-                                    title = chapter.name,
-                                    content = content,
+                        if (hasUsableContent) {
+                            chapterContents.add(
+                                ChapterContent(
+                                    name = chapter.name,
+                                    chapterNumber = chapter.chapterNumber,
                                     order = chapterIndex,
+                                    originalContent = originalContent?.takeIf { it.isNotBlank() },
+                                    translatedContent = translatedContent?.takeIf { it.isNotBlank() },
                                 ),
                             )
                         }
                     }
 
-                    // Skip novels without any exported chapters
-                    if (epubChapters.isEmpty()) {
-                        logcat(LogPriority.WARN) { "${manga.title}: No chapters could be exported (chapters=${chapters.size}, downloadedOnly=$downloadedOnly)" }
+                    if (chapterContents.isEmpty()) {
+                        logcat(LogPriority.WARN) { "${manga.title}: No chapters could be exported (chapters=${chapters.size}, downloadedOnly=$downloadedOnly, translationMode=$translationMode)" }
                         skippedCount++
                         continue
                     }
 
-                    logcat(LogPriority.INFO) { "${manga.title}: Exporting ${epubChapters.size} chapters" }
+                    logcat(LogPriority.INFO) { "${manga.title}: Exporting ${chapterContents.size} chapters (mode=$translationMode)" }
 
                     // Get cover image
                     val coverImage = try {
@@ -356,55 +274,114 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                         publisher = source.name,
                     )
 
-                    // Build filename
-                    val filenameBuilder = StringBuilder(sanitizeFilename(manga.title))
-                    if (includeChapterCount) {
-                        filenameBuilder.append(" [${epubChapters.size}ch]")
-                    }
-                    if (includeChapterRange && firstChapterNum != Double.MAX_VALUE) {
-                        val firstCh = if (firstChapterNum == firstChapterNum.toLong().toDouble()) {
-                            firstChapterNum.toLong().toString()
-                        } else {
-                            firstChapterNum.toString()
+                    // ── Build EPUB file(s) based on translation mode ──
+                    fun buildFilename(suffix: String? = null): String {
+                        val filenameBuilder = StringBuilder(sanitizeFilename(manga.title))
+                        if (includeChapterCount) {
+                            filenameBuilder.append(" [${chapterContents.size}ch]")
                         }
-                        val lastCh = if (lastChapterNum == lastChapterNum.toLong().toDouble()) {
-                            lastChapterNum.toLong().toString()
-                        } else {
-                            lastChapterNum.toString()
+                        if (includeChapterRange) {
+                            val firstChapterNum = chapterContents.minOf { it.chapterNumber }
+                            val lastChapterNum = chapterContents.maxOf { it.chapterNumber }
+                            val firstCh = if (firstChapterNum == firstChapterNum.toLong().toDouble()) {
+                                firstChapterNum.toLong().toString()
+                            } else {
+                                firstChapterNum.toString()
+                            }
+                            val lastCh = if (lastChapterNum == lastChapterNum.toLong().toDouble()) {
+                                lastChapterNum.toLong().toString()
+                            } else {
+                                lastChapterNum.toString()
+                            }
+                            if (firstCh != lastCh) {
+                                filenameBuilder.append(" [ch$firstCh-$lastCh]")
+                            } else {
+                                filenameBuilder.append(" [ch$firstCh]")
+                            }
                         }
-                        if (firstCh != lastCh) {
-                            filenameBuilder.append(" [ch$firstCh-$lastCh]")
-                        } else {
-                            filenameBuilder.append(" [ch$firstCh]")
+                        if (includeStatus) {
+                            val statusStr = when (manga.status) {
+                                SManga.ONGOING.toLong() -> "Ongoing"
+                                SManga.COMPLETED.toLong() -> "Completed"
+                                SManga.LICENSED.toLong() -> "Licensed"
+                                SManga.PUBLISHING_FINISHED.toLong() -> "Finished"
+                                SManga.CANCELLED.toLong() -> "Cancelled"
+                                SManga.ON_HIATUS.toLong() -> "Hiatus"
+                                else -> null
+                            }
+                            statusStr?.let { filenameBuilder.append(" [$it]") }
                         }
-                    }
-                    if (includeStatus) {
-                        val statusStr = when (manga.status) {
-                            SManga.ONGOING.toLong() -> "Ongoing"
-                            SManga.COMPLETED.toLong() -> "Completed"
-                            SManga.LICENSED.toLong() -> "Licensed"
-                            SManga.PUBLISHING_FINISHED.toLong() -> "Finished"
-                            SManga.CANCELLED.toLong() -> "Cancelled"
-                            SManga.ON_HIATUS.toLong() -> "Hiatus"
-                            else -> null
-                        }
-                        statusStr?.let { filenameBuilder.append(" [$it]") }
-                    }
-                    filenameBuilder.append(".epub")
-
-                    // Write EPUB to temp file
-                    val filename = filenameBuilder.toString()
-                    val tempFile = File(tempDir, filename)
-                    tempFile.outputStream().use { outputStream ->
-                        EpubWriter().write(
-                            outputStream = outputStream,
-                            metadata = metadata,
-                            chapters = epubChapters,
-                            coverImage = coverImage,
-                        )
+                        suffix?.let { filenameBuilder.append(" [$it]") }
+                        filenameBuilder.append(".epub")
+                        return filenameBuilder.toString()
                     }
 
-                    logcat(LogPriority.INFO) { "Exported ${manga.title}: ${epubChapters.size} chapters" }
+                    fun writeEpub(
+                        filename: String,
+                        epubMetadata: EpubWriter.Metadata,
+                        chapters: List<EpubWriter.Chapter>,
+                        cover: ByteArray?,
+                    ) {
+                        val tempFile = File(tempDir, filename)
+                        val deflateLevel = downloadPreferences.epubCompressionLevel().get()
+                        tempFile.outputStream().use { outputStream ->
+                            EpubWriter(deflateLevel).write(
+                                outputStream = outputStream,
+                                metadata = epubMetadata,
+                                chapters = chapters,
+                                coverImage = cover,
+                            )
+                        }
+                    }
+
+                    when (translationMode) {
+                        TranslationMode.ORIGINAL -> {
+                            val epubChapters = chapterContents.mapNotNull { ch ->
+                                ch.originalContent?.let {
+                                    EpubWriter.Chapter(title = ch.name, content = it, order = ch.order)
+                                }
+                            }
+                            if (epubChapters.isNotEmpty()) {
+                                writeEpub(buildFilename(), metadata, epubChapters, coverImage)
+                            }
+                        }
+                        TranslationMode.TRANSLATED -> {
+                            val epubChapters = chapterContents.mapNotNull { ch ->
+                                ch.translatedContent?.let {
+                                    EpubWriter.Chapter(title = ch.name, content = it, order = ch.order)
+                                }
+                            }
+                            if (epubChapters.isNotEmpty()) {
+                                writeEpub(buildFilename(), metadata, epubChapters, coverImage)
+                            }
+                        }
+                        TranslationMode.BOTH -> {
+                            // Original EPUB
+                            val originalChapters = chapterContents.mapNotNull { ch ->
+                                ch.originalContent?.let {
+                                    EpubWriter.Chapter(title = ch.name, content = it, order = ch.order)
+                                }
+                            }
+                            if (originalChapters.isNotEmpty()) {
+                                writeEpub(buildFilename("Original"), metadata, originalChapters, coverImage)
+                            }
+
+                            // Translated EPUB
+                            val translatedChapters = chapterContents.mapNotNull { ch ->
+                                ch.translatedContent?.let {
+                                    EpubWriter.Chapter(title = ch.name, content = it, order = ch.order)
+                                }
+                            }
+                            if (translatedChapters.isNotEmpty()) {
+                                val translatedMetadata = metadata.copy(
+                                    title = "${manga.title} [Translated]",
+                                )
+                                writeEpub(buildFilename("Translated"), translatedMetadata, translatedChapters, coverImage)
+                            }
+                        }
+                    }
+
+                    logcat(LogPriority.INFO) { "Exported ${manga.title}: ${chapterContents.size} chapters" }
                     successCount++
                 } catch (e: Exception) {
                     logcat(LogPriority.ERROR, e) { "Failed to export ${manga.title}" }
@@ -423,8 +400,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                 return
             }
 
-            if (totalCount > 1) {
-                // Create ZIP for multiple novels
+            if (tempFiles.size > 1 || totalCount > 1) {
+                // Create ZIP for multiple files (multiple novels OR both-mode producing two files)
                 logcat(LogPriority.INFO) { "Writing ${tempFiles.size} EPUBs to ZIP at $outputUri" }
                 context.contentResolver.openOutputStream(outputUri)?.use { outputStream ->
                     ZipOutputStream(outputStream).use { zipOut ->
@@ -461,6 +438,91 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
             // Cleanup
             tempDir.deleteRecursively()
         }
+    }
+
+    /**
+     * Read original (source) content for a chapter from the download directory or CBZ archive.
+     */
+    private fun readOriginalContent(
+        manga: Manga,
+        chapter: tachiyomi.domain.chapter.model.Chapter,
+        source: eu.kanade.tachiyomi.source.Source,
+    ): String? {
+        try {
+            val chapterDirOrCbz = downloadProvider.findChapterDir(
+                chapter.name,
+                chapter.scanlator,
+                chapter.url,
+                manga.title,
+                source,
+            )
+
+            logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: chapterDir found=${chapterDirOrCbz != null}, exists=${chapterDirOrCbz?.exists()}, name=${chapterDirOrCbz?.name}" }
+
+            if (chapterDirOrCbz != null) {
+                val isCbz = chapterDirOrCbz.name?.endsWith(".cbz") == true
+
+                if (isCbz) {
+                    logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: reading from CBZ archive" }
+                    val content = readContentFromCbz(chapterDirOrCbz.uri)
+                    if (content != null) return content
+                } else {
+                    val allFiles = chapterDirOrCbz.listFiles() ?: emptyArray()
+                    val htmlFiles = allFiles.filter {
+                        it.isFile && it.name?.endsWith(".html") == true
+                    }.sortedBy { it.name }
+
+                    val txtFiles = allFiles.filter {
+                        it.isFile && it.name?.endsWith(".txt") == true
+                    }.sortedBy { it.name }
+
+                    val filesToRead = htmlFiles.ifEmpty { txtFiles }
+
+                    if (filesToRead.isNotEmpty()) {
+                        val sb = StringBuilder()
+                        filesToRead.forEachIndexed { i, file ->
+                            val fileContent = context.contentResolver.openInputStream(file.uri)?.use {
+                                it.bufferedReader().readText()
+                            } ?: ""
+                            sb.append(fileContent)
+                            if (i < filesToRead.size - 1) {
+                                sb.append("\n\n")
+                            }
+                        }
+                        val content = sb.toString()
+                        logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: read content length=${content.length}" }
+                        if (content.isNotBlank()) return content
+                    }
+                }
+            }
+
+            // If no content found, try CBZ archive in manga directory
+            val mangaDir = downloadProvider.findMangaDir(manga.title, source)
+            if (mangaDir != null) {
+                val cbzFiles = mangaDir.listFiles()?.filter {
+                    it.isFile && it.name?.endsWith(".cbz") == true
+                } ?: emptyList()
+
+                val chapterDirNames = downloadProvider.getValidChapterDirNames(
+                    chapter.name,
+                    chapter.scanlator,
+                    chapter.url,
+                )
+
+                val matchingCbz = cbzFiles.find { cbzFile ->
+                    val cbzBaseName = cbzFile.name?.removeSuffix(".cbz") ?: ""
+                    chapterDirNames.any { it == cbzBaseName }
+                }
+
+                if (matchingCbz != null) {
+                    logcat(LogPriority.DEBUG) { "${manga.title} ch ${chapter.name}: found CBZ archive ${matchingCbz.name}" }
+                    return readContentFromCbz(matchingCbz.uri)
+                }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read downloaded chapter: ${chapter.name}" }
+        }
+        return null
     }
 
     private fun updateProgress(current: Int, total: Int, title: String) {
@@ -589,7 +651,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         private const val KEY_MANGA_IDS = "manga_ids"
         private const val KEY_OUTPUT_URI = "output_uri"
         private const val KEY_DOWNLOADED_ONLY = "downloaded_only"
-        private const val KEY_PREFER_TRANSLATED = "prefer_translated"
+        private const val KEY_TRANSLATION_MODE = "translation_mode"
         private const val KEY_INCLUDE_CHAPTER_COUNT = "include_chapter_count"
         private const val KEY_INCLUDE_CHAPTER_RANGE = "include_chapter_range"
         private const val KEY_INCLUDE_STATUS = "include_status"
@@ -599,7 +661,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
             mangaIds: List<Long>,
             outputUri: Uri,
             downloadedOnly: Boolean = false,
-            preferTranslated: Boolean = false,
+            translationMode: TranslationMode = TranslationMode.ORIGINAL,
             includeChapterCount: Boolean = false,
             includeChapterRange: Boolean = false,
             includeStatus: Boolean = false,
@@ -608,7 +670,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                 KEY_MANGA_IDS to mangaIds.toLongArray(),
                 KEY_OUTPUT_URI to outputUri.toString(),
                 KEY_DOWNLOADED_ONLY to downloadedOnly,
-                KEY_PREFER_TRANSLATED to preferTranslated,
+                KEY_TRANSLATION_MODE to translationMode.key,
                 KEY_INCLUDE_CHAPTER_COUNT to includeChapterCount,
                 KEY_INCLUDE_CHAPTER_RANGE to includeChapterRange,
                 KEY_INCLUDE_STATUS to includeStatus,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -8,6 +8,8 @@ import eu.kanade.tachiyomi.data.translation.engine.LibreTranslateEngine
 import eu.kanade.tachiyomi.source.fetchNovelPageText
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.Page
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,6 +61,9 @@ class TranslationService(
 
     private val queue = ConcurrentLinkedQueue<TranslationTask>()
 
+    private val _queueState = MutableStateFlow<List<TranslationTask>>(emptyList())
+    val queueState = _queueState.asStateFlow()
+
     private var translationJob: Job? = null
 
     private val _progressState = MutableStateFlow(
@@ -78,23 +83,27 @@ class TranslationService(
 
     /**
      * Add a chapter to the translation queue.
+     * @param forceRetranslate if true, skip the "already translated" check.
      */
     fun enqueue(
         manga: Manga,
         chapter: Chapter,
         priority: Int = 0,
+        forceRetranslate: Boolean = false,
     ) {
         if (!translationPreferences.translationEnabled().get()) return
 
         val task = TranslationTask(
             chapterId = chapter.id,
             mangaId = manga.id,
+            chapterName = chapter.name,
             sourceLanguage = translationPreferences.sourceLanguage().get(),
             targetLanguage = translationPreferences.targetLanguage().get(),
             engineId = 0, // Will be determined at translation time
             priority = priority,
             status = TranslationStatus.QUEUED,
             retryCount = 0,
+            forceRetranslate = forceRetranslate,
         )
 
         // Add to queue if not already present
@@ -108,16 +117,18 @@ class TranslationService(
 
     /**
      * Add multiple chapters to the translation queue.
+     * @param forceRetranslate if true, retranslate even if already translated.
      */
     fun enqueueAll(
         manga: Manga,
         chapters: List<Chapter>,
         priority: Int = 0,
+        forceRetranslate: Boolean = false,
     ) {
         if (!translationPreferences.translationEnabled().get()) return
 
         chapters.forEach { chapter ->
-            enqueue(manga, chapter, priority)
+            enqueue(manga, chapter, priority, forceRetranslate)
         }
     }
 
@@ -156,10 +167,17 @@ class TranslationService(
                 val task = queue.poll() ?: break
 
                 try {
+                    // Resolve chapter name for progress display
+                    val chapterNameForProgress = try {
+                        getChapter.await(task.chapterId)?.name ?: "Chapter ${task.chapterId}"
+                    } catch (_: Exception) {
+                        "Chapter ${task.chapterId}"
+                    }
+
                     _progressState.update { current ->
                         current.copy(
                             isRunning = true,
-                            currentChapterName = "Chapter ${task.chapterId}",
+                            currentChapterName = chapterNameForProgress,
                             currentChapterProgress = 0f,
                         )
                     }
@@ -239,10 +257,21 @@ class TranslationService(
             it.copy(
                 isRunning = false,
                 isPaused = false,
+                isCancelling = false,
                 currentChapterName = null,
                 currentChapterProgress = 0f,
+                currentChunkIndex = 0,
+                totalChunks = 0,
             )
         }
+    }
+
+    /**
+     * Request cancellation of the current translation.
+     * The current chunk will finish, then partial progress will be saved.
+     */
+    fun cancel() {
+        _progressState.update { it.copy(isCancelling = true) }
     }
 
     /**
@@ -257,6 +286,8 @@ class TranslationService(
 
     /**
      * Translate a single chapter.
+     * Supports partial translation: if some chunks fail, the partial result is saved
+     * with a .tmp extension and can be resumed on the next attempt.
      */
     private suspend fun translateChapter(task: TranslationTask) = withContext(Dispatchers.IO) {
         val engine = translationEngineManager.getEngine()
@@ -272,11 +303,23 @@ class TranslationService(
 
         logcat(LogPriority.DEBUG) { "Starting translation for chapter: ${chapter.name}" }
 
-        // Check if already translated
-        val existingTranslation = translatedChapterRepository.getTranslatedChapter(task.chapterId, task.targetLanguage)
-        if (existingTranslation != null) {
-            logcat(LogPriority.DEBUG) { "Chapter ${chapter.name} already translated, skipping" }
-            return@withContext
+        // Check if already translated (skip unless forceRetranslate)
+        if (!task.forceRetranslate) {
+            val existingTranslation = translatedChapterRepository.getTranslatedChapter(task.chapterId, task.targetLanguage)
+            if (existingTranslation != null) {
+                logcat(LogPriority.DEBUG) { "Chapter ${chapter.name} already translated, skipping" }
+                return@withContext
+            }
+        }
+
+        if (translationPreferences.smartAutoTranslate().get()) {
+            val sourceLang = source.lang
+            if (sourceLang.isNotBlank() && sourceLang != "all" && sourceLang != "other") {
+                if (sourceLang == task.targetLanguage) {
+                    logcat(LogPriority.DEBUG) { "Source language ($sourceLang) matches target language, skipping translation" }
+                    return@withContext
+                }
+            }
         }
 
         // Try to get content from downloaded chapter first, fall back to fetching from source
@@ -287,71 +330,238 @@ class TranslationService(
             return@withContext
         }
 
+        if (task.sourceLanguage == "auto" && translationPreferences.smartAutoTranslate().get()) {
+            val detected = detectLanguage(allContent, task.mangaId)
+            if (detected != null && detected == task.targetLanguage) {
+                logcat(LogPriority.DEBUG) { "Detected language ($detected) matches target language, skipping translation" }
+                return@withContext
+            }
+        }
+
+        // Extract and preserve image tags (including base64 embedded images) before text extraction
+        val (contentWithoutImages, _) = extractImages(allContent)
+
         // Extract text from HTML
-        val plainText = extractTextFromHtml(allContent)
+        val plainText = extractTextFromHtml(contentWithoutImages)
         val paragraphs = plainText.split("\n\n").filter { it.isNotBlank() }
 
         logcat(LogPriority.DEBUG) { "Translating ${paragraphs.size} paragraphs for chapter ${chapter.name}" }
 
-        // Translate the content
-        val result = engine.translate(paragraphs, task.sourceLanguage, task.targetLanguage)
+        // Group paragraphs into chunks to improve translation quality
+        val chunkSize = translationPreferences.translationChunkSize().get()
+        val chunks = buildChunks(paragraphs, chunkSize)
 
-        when (result) {
-            is TranslationResult.Success -> {
-                val translatedTexts = result.translatedTexts
-                if (translatedTexts.isEmpty()) throw IllegalStateException("No translation returned")
+        logcat(LogPriority.DEBUG) { "Grouped into ${chunks.size} chunks (size=$chunkSize)" }
 
-                // Wrap in HTML
-                val translatedHtml = translatedTexts.joinToString("") { paragraph ->
-                    "<p>${paragraph.trim().replace("\n", "<br/>")}</p>"
+        // Update progress with chunk info
+        _progressState.update { current ->
+            current.copy(totalChunks = chunks.size, currentChunkIndex = 0)
+        }
+
+        // Check for existing partial translation to resume from
+        val existingTmpParagraphs = run {
+            val tmp = translatedChapterRepository.getTmpTranslation(task.chapterId, task.targetLanguage)
+            if (tmp != null) {
+                val tmpText = extractTextFromHtml(tmp.translatedContent)
+                tmpText.split("\n\n").filter { it.isNotBlank() }
+            } else {
+                emptyList()
+            }
+        }
+
+        // Determine which chunks were already translated (for resume)
+        // We count how many source paragraphs the existing tmp translation covers
+        var resumeFromChunk = 0
+        if (existingTmpParagraphs.isNotEmpty() && !task.forceRetranslate) {
+            var coveredParagraphs = 0
+            for ((i, chunk) in chunks.withIndex()) {
+                val chunkParagraphCount = chunk.split("\n\n").filter { it.isNotBlank() }.size
+                coveredParagraphs += chunkParagraphCount
+                if (coveredParagraphs <= existingTmpParagraphs.size) {
+                    resumeFromChunk = i + 1
+                } else {
+                    break
                 }
+            }
+            if (resumeFromChunk > 0) {
+                logcat(LogPriority.INFO) { "Resuming from chunk $resumeFromChunk/${chunks.size} (${existingTmpParagraphs.size} paragraphs already translated)" }
+            }
+        }
 
-                // Save to database
-                val translatedChapter = TranslatedChapter(
-                    chapterId = task.chapterId,
-                    mangaId = task.mangaId,
-                    targetLanguage = task.targetLanguage,
-                    engineId = engine.id.toString(),
-                    translatedContent = translatedHtml,
-                    dateTranslated = System.currentTimeMillis(),
-                    isCached = true,
-                )
-                translatedChapterRepository.upsertTranslation(translatedChapter)
+        // Translate chapter title
+        var translatedTitle: String? = null
+        try {
+            val titleResult = engine.translate(listOf(chapter.name), task.sourceLanguage, task.targetLanguage)
+            if (titleResult is TranslationResult.Success) {
+                translatedTitle = titleResult.translatedTexts.firstOrNull()?.trim()
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to translate chapter title: ${chapter.name}" }
+        }
 
-                // Update chapter name with translated title if available
+        // Translate chunks and split responses back into paragraphs
+        val allTranslated = mutableListOf<String>()
+        // Add previously translated paragraphs
+        if (resumeFromChunk > 0) {
+            allTranslated.addAll(existingTmpParagraphs)
+        }
+
+        var failedChunkIndex = -1
+        for ((chunkIndex, chunk) in chunks.withIndex()) {
+            // Skip already-translated chunks
+            if (chunkIndex < resumeFromChunk) {
+                logcat(LogPriority.DEBUG) { "Skipping chunk ${chunkIndex + 1}/${chunks.size} (already translated)" }
+                _progressState.update { current ->
+                    current.copy(
+                        currentChapterProgress = 0.5f + 0.5f * (chunkIndex + 1f) / chunks.size,
+                        currentChunkIndex = chunkIndex + 1,
+                    )
+                }
+                continue
+            }
+
+            // Check for cancellation
+            if (_progressState.value.isCancelling) {
+                savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                throw CancellationException("Translation cancelled by user")
+            }
+
+            logcat(LogPriority.DEBUG) { "Sending chunk ${chunkIndex + 1}/${chunks.size} for translation (${chunk.length} chars)" }
+
+            var chunkSuccess = false
+            for (attempt in 1..2) {
                 try {
-                    val nameResult = engine.translateSingle(chapter.name, task.sourceLanguage, task.targetLanguage)
-                    if (nameResult is TranslationResult.Success) {
-                        val translatedName = nameResult.translatedTexts.firstOrNull()
-                        if (!translatedName.isNullOrBlank() && translatedName != chapter.name) {
-                            val newName = "${chapter.name} [$translatedName]"
-                            updateChapter.await(
-                                tachiyomi.domain.chapter.model.ChapterUpdate(
-                                    id = chapter.id,
-                                    name = newName,
-                                ),
-                            )
+                    val result = engine.translate(listOf(chunk), task.sourceLanguage, task.targetLanguage)
+                    when (result) {
+                        is TranslationResult.Success -> {
+                            val translated = result.translatedTexts.firstOrNull() ?: ""
+                            val translatedParagraphs = translated.split("\n\n").filter { it.isNotBlank() }
+                            allTranslated.addAll(translatedParagraphs.ifEmpty { listOf(translated) })
+                            chunkSuccess = true
+                        }
+                        is TranslationResult.Error -> {
+                            logcat(LogPriority.ERROR) { "Translation error for chunk ${chunkIndex + 1}/${chunks.size} (attempt $attempt): ${result.message}" }
+                            if (attempt < 2) {
+                                delay(2000L)
+                                continue
+                            }
                         }
                     }
+                    break
+                } catch (e: CancellationException) {
+                    savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                    throw e
                 } catch (e: Exception) {
-                    logcat(LogPriority.WARN, e) { "Failed to translate chapter name" }
-                }
-
-                logcat(LogPriority.DEBUG) { "Successfully translated and saved chapter ${chapter.name}" }
-
-                // Update progress to complete
-                _progressState.update { current ->
-                    current.copy(currentChapterProgress = 1f)
+                    logcat(LogPriority.ERROR, e) { "Translation exception for chunk ${chunkIndex + 1}/${chunks.size} (attempt $attempt)" }
+                    if (attempt < 2) {
+                        delay(2000L)
+                        continue
+                    }
+                    break
                 }
             }
-            is TranslationResult.Error -> {
-                throw Exception("Translation failed: ${result.message}")
+
+            if (!chunkSuccess) {
+                failedChunkIndex = chunkIndex
+                logcat(LogPriority.ERROR) { "Chunk ${chunkIndex + 1}/${chunks.size} failed after retries, stopping" }
+                break
             }
+
+            // Update sub-progress
+            _progressState.update { current ->
+                current.copy(
+                    currentChapterProgress = 0.5f + 0.5f * (chunkIndex + 1f) / chunks.size,
+                    currentChunkIndex = chunkIndex + 1,
+                )
+            }
+            // Rate limiting between chunks
+            val delayMs = translationPreferences.rateLimitDelayMs().get()
+            if (delayMs > 0 && chunkIndex < chunks.size - 1) {
+                delay(delayMs.toLong())
+            }
+        }
+
+        // Check if all chunks were translated successfully
+        if (failedChunkIndex >= 0) {
+            // Save partial translation as .tmp for resume
+            if (allTranslated.isNotEmpty()) {
+                savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                logcat(LogPriority.WARN) { "Saved partial translation (${allTranslated.size} paragraphs) for chapter ${chapter.name}" }
+            }
+            throw Exception(
+                "Translation incomplete: failed at chunk ${failedChunkIndex + 1}/${chunks.size}. " +
+                    "${allTranslated.size} paragraphs translated, will resume on next attempt.",
+            )
+        }
+
+        if (allTranslated.isEmpty()) throw IllegalStateException("No translation returned")
+
+        // Build the final translated HTML with optional title at start
+        val translatedHtml = buildString {
+            if (!translatedTitle.isNullOrBlank()) {
+                append("<h1>${translatedTitle.trim()}</h1>")
+            }
+            allTranslated.forEach { paragraph ->
+                append("<p>${paragraph.trim().replace("\n", "<br/>")}</p>")
+            }
+        }
+
+        // Save the complete translation
+        val translatedChapter = TranslatedChapter(
+            chapterId = task.chapterId,
+            mangaId = task.mangaId,
+            targetLanguage = task.targetLanguage,
+            engineId = engine.id.toString(),
+            translatedContent = translatedHtml,
+            dateTranslated = System.currentTimeMillis(),
+        )
+        translatedChapterRepository.upsertTranslation(translatedChapter)
+
+        logcat(LogPriority.DEBUG) { "Successfully translated and saved chapter ${chapter.name}" }
+
+        _progressState.update { current ->
+            current.copy(currentChapterProgress = 1f)
+        }
+    }
+
+    /**
+     * Save a partial translation as a .tmp file for later resume.
+     */
+    private suspend fun savePartialTranslation(
+        task: TranslationTask,
+        engineId: String,
+        translatedParagraphs: List<String>,
+        translatedTitle: String?,
+    ) {
+        if (translatedParagraphs.isEmpty()) return
+
+        val html = buildString {
+            if (!translatedTitle.isNullOrBlank()) {
+                append("<h1>${translatedTitle.trim()}</h1>")
+            }
+            translatedParagraphs.forEach { paragraph ->
+                append("<p>${paragraph.trim().replace("\n", "<br/>")}</p>")
+            }
+        }
+
+        val partial = TranslatedChapter(
+            chapterId = task.chapterId,
+            mangaId = task.mangaId,
+            targetLanguage = task.targetLanguage,
+            engineId = engineId,
+            translatedContent = html,
+            dateTranslated = System.currentTimeMillis(),
+        )
+        try {
+            translatedChapterRepository.upsertTmpTranslation(partial)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to save partial translation" }
         }
     }
 
     /**
      * Get chapter content either from downloaded files or directly from source.
+     * Checks both directory-based downloads and CBZ archives.
      */
     private suspend fun getChapterContent(
         chapter: Chapter,
@@ -359,7 +569,7 @@ class TranslationService(
         source: eu.kanade.tachiyomi.source.Source,
     ): String {
         // First try to get content from downloaded chapter
-        val chapterDir = downloadProvider.findChapterDir(
+        val chapterDirOrFile = downloadProvider.findChapterDir(
             chapter.name,
             chapter.scanlator,
             chapter.url,
@@ -367,30 +577,80 @@ class TranslationService(
             source,
         )
 
-        if (chapterDir != null) {
-            val htmlFiles = chapterDir.listFiles()?.filter {
-                it.isFile && it.name?.endsWith(".html") == true
-            }?.sortedBy { it.name } ?: emptyList()
+        if (chapterDirOrFile != null) {
+            val isCbz = chapterDirOrFile.name?.endsWith(".cbz") == true
 
-            if (htmlFiles.isNotEmpty()) {
-                logcat(LogPriority.DEBUG) { "Reading content from downloaded chapter" }
-                val content = StringBuilder()
-                htmlFiles.forEachIndexed { index, file ->
-                    val fileContent = context.contentResolver.openInputStream(file.uri)?.use {
-                        it.bufferedReader().readText()
-                    } ?: ""
-                    content.append(fileContent)
-                    if (index < htmlFiles.size - 1) {
-                        content.append("\n\n")
+            if (isCbz) {
+                logcat(LogPriority.DEBUG) { "Reading content from CBZ archive for chapter: ${chapter.name}" }
+                try {
+                    val inputStream = context.contentResolver.openInputStream(chapterDirOrFile.uri)
+                    if (inputStream != null) {
+                        val entries = mutableListOf<Pair<String, String>>()
+                        java.util.zip.ZipInputStream(inputStream).use { zis ->
+                            var entry = zis.nextEntry
+                            while (entry != null) {
+                                if (!entry.isDirectory && (entry.name.endsWith(".html") || entry.name.endsWith(".txt"))) {
+                                    val bytes = zis.readBytes()
+                                    val text = bytes.toString(Charsets.UTF_8)
+                                    entries.add(entry.name to text)
+                                }
+                                zis.closeEntry()
+                                entry = zis.nextEntry
+                            }
+                        }
+                        entries.sortBy { it.first }
+                        if (entries.isNotEmpty()) {
+                            val content = StringBuilder()
+                            entries.forEachIndexed { index, (_, text) ->
+                                content.append(text)
+                                if (index < entries.size - 1) content.append("\n\n")
+                            }
+                            return content.toString()
+                        }
                     }
-
-                    // Update progress
-                    _progressState.update { current ->
-                        current.copy(currentChapterProgress = (index + 1f) / (htmlFiles.size * 2))
-                    }
+                } catch (e: Exception) {
+                    logcat(LogPriority.WARN, e) { "Failed to read CBZ for chapter: ${chapter.name}" }
                 }
-                return content.toString()
+            } else {
+                // Read from directory
+                val htmlFiles = chapterDirOrFile.listFiles()?.filter {
+                    it.isFile && (it.name?.endsWith(".html") == true || it.name?.endsWith(".txt") == true)
+                }?.sortedBy { it.name } ?: emptyList()
+
+                if (htmlFiles.isNotEmpty()) {
+                    logcat(LogPriority.DEBUG) { "Reading content from downloaded chapter directory" }
+                    val content = StringBuilder()
+                    htmlFiles.forEachIndexed { index, file ->
+                        val fileContent = context.contentResolver.openInputStream(file.uri)?.use {
+                            it.bufferedReader().readText()
+                        } ?: ""
+                        content.append(fileContent)
+                        if (index < htmlFiles.size - 1) {
+                            content.append("\n\n")
+                        }
+
+                        // Update progress
+                        _progressState.update { current ->
+                            current.copy(currentChapterProgress = (index + 1f) / (htmlFiles.size * 2))
+                        }
+                    }
+                    return content.toString()
+                }
             }
+        }
+
+        // Also try the download cache as a secondary check
+        val isDownloaded = downloadCache.isChapterDownloaded(
+            chapter.name,
+            chapter.scanlator,
+            chapter.url,
+            manga.title,
+            manga.source,
+            skipCache = false,
+        )
+
+        if (isDownloaded && chapterDirOrFile == null) {
+            logcat(LogPriority.WARN) { "Download cache says chapter is downloaded but findChapterDir returned null for: ${chapter.name}" }
         }
 
         // Fall back to fetching from source
@@ -428,6 +688,7 @@ class TranslationService(
                 totalChapters = queue.size + current.completedChapters,
             )
         }
+        _queueState.value = queue.toList()
     }
 
     /**
@@ -456,9 +717,9 @@ class TranslationService(
         sourceLanguage: String? = null,
         targetLanguage: String? = null,
     ): String {
-        // if (!translationPreferences.translationEnabled().get()) {
-        //     return content
-        // }
+        if (!translationPreferences.translationEnabled().get()) {
+            return content
+        }
 
         val srcLang = sourceLanguage ?: translationPreferences.sourceLanguage().get()
         val tgtLang = targetLanguage ?: translationPreferences.targetLanguage().get()
@@ -477,15 +738,23 @@ class TranslationService(
             }
         }
 
+        // Extract and preserve image tags before translation
+        val (contentWithoutImages, preservedImages) = extractImages(content)
+
         // Extract plain text from HTML for translation (more efficient and accurate)
-        val plainText = extractTextFromHtml(content)
+        val plainText = extractTextFromHtml(contentWithoutImages)
 
         // Translate the plain text
         return when (val result = translateText(plainText, srcLang, tgtLang)) {
             is TranslationResult.Success -> {
                 val translatedText = result.translatedTexts.firstOrNull() ?: return content
                 // Wrap translated text in proper HTML paragraphs
-                val translatedHtml = wrapTextInHtml(translatedText)
+                var translatedHtml = wrapTextInHtml(translatedText)
+
+                // Reinsert preserved image tags
+                if (preservedImages.isNotEmpty()) {
+                    translatedHtml = reinsertImages(translatedHtml, preservedImages)
+                }
 
                 // Save translation to database
                 if (chapterId != null && mangaId != null) {
@@ -497,7 +766,6 @@ class TranslationService(
                         engineId = engine?.id?.toString() ?: "unknown",
                         translatedContent = translatedHtml,
                         dateTranslated = System.currentTimeMillis(),
-                        isCached = true,
                     )
                     try {
                         translatedChapterRepository.upsertTranslation(translatedChapter)
@@ -544,8 +812,8 @@ class TranslationService(
     /**
      * Get all available translation languages for a manga.
      */
-    suspend fun getTranslatedLanguages(mangaId: Long): List<String> {
-        return translatedChapterRepository.getTranslatedLanguagesForManga(mangaId)
+    suspend fun getTranslatedLanguages(chapterIds: Collection<Long>): List<String> {
+        return translatedChapterRepository.getTranslatedLanguagesForChapters(chapterIds)
     }
 
     /**
@@ -569,15 +837,75 @@ class TranslationService(
         translationPreferences.targetLanguage().set(language)
     }
 
-    suspend fun detectLanguage(text: String): String? {
+    /**
+     * Detect language of text content. Uses LibreTranslate's detection endpoint if available,
+     * otherwise falls back to using the manga source's language setting.
+     */
+    suspend fun detectLanguage(text: String, mangaId: Long? = null): String? {
         val engine = translationEngineManager.getSelectedEngine()
 
         if (engine is LibreTranslateEngine) {
-            // Use a sample of text for detection to save bandwidth/time
             val sample = text.take(500)
             return engine.detectLanguage(sample)
         }
+
+        // For non-Libre engines, use the source's language as a heuristic
+        if (mangaId != null) {
+            val manga = getManga.await(mangaId)
+            if (manga != null) {
+                val source = sourceManager.get(manga.source)
+                if (source != null) {
+                    // Source lang is typically a 2-letter ISO code like "en", "ja", "ko"
+                    val sourceLang = source.lang
+                    if (sourceLang.isNotBlank() && sourceLang != "all" && sourceLang != "other") {
+                        return sourceLang
+                    }
+                }
+            }
+        }
+
+        // If source language preference is set (not "auto"), use that
+        val configuredLang = translationPreferences.sourceLanguage().get()
+        if (configuredLang.isNotBlank() && configuredLang != "auto") {
+            return configuredLang
+        }
+
         return null
+    }
+
+    /**
+     * CSS selector for HTML elements that should be preserved through translation.
+     * These are replaced with placeholders before translation and reinserted after.
+     */
+    private val imageElementSelector = "img, figure, picture, video, source, svg"
+
+    /**
+     * Extract image/media tags from HTML using Jsoup, replacing them with unique placeholders.
+     * Returns the modified HTML and a map of placeholder -> original tag.
+     */
+    private fun extractImages(html: String): Pair<String, Map<String, String>> {
+        val doc = Jsoup.parse(html)
+        doc.outputSettings().prettyPrint(false)
+        val images = mutableMapOf<String, String>()
+        var index = 0
+        doc.select(imageElementSelector).forEach { element: Element ->
+            val placeholder = "[IMG_PLACEHOLDER_$index]"
+            images[placeholder] = element.outerHtml()
+            element.replaceWith(org.jsoup.nodes.TextNode("\n$placeholder\n"))
+            index++
+        }
+        return doc.body().html() to images
+    }
+
+    /**
+     * Reinsert preserved image tags into translated content.
+     */
+    private fun reinsertImages(translatedHtml: String, images: Map<String, String>): String {
+        var result = translatedHtml
+        for ((placeholder, originalTag) in images) {
+            result = result.replace(placeholder, originalTag)
+        }
+        return result
     }
 
     /**
@@ -586,6 +914,8 @@ class TranslationService(
      */
     private fun extractTextFromHtml(html: String): String {
         return html
+            // Strip base64 data URIs (embedded images) before text extraction
+            .replace(Regex("data:[a-zA-Z0-9/+.-]+;base64,[A-Za-z0-9+/=\\s]+"), "")
             // Convert paragraph and line breaks to newlines
             .replace(Regex("</p>\\s*<p[^>]*>", RegexOption.IGNORE_CASE), "\n\n")
             .replace(Regex("<br\\s*/?>", RegexOption.IGNORE_CASE), "\n")
@@ -615,6 +945,18 @@ class TranslationService(
             .joinToString("") { paragraph ->
                 "<p>${paragraph.trim().replace("\n", "<br/>")}</p>"
             }
+    }
+
+    /**
+     * Group paragraphs into translation chunks.
+     * Each chunk is a single string with paragraphs separated by double newlines.
+     * This keeps context together so LLMs produce better translations and don't skip content.
+     */
+    private fun buildChunks(paragraphs: List<String>, chunkSize: Int): List<String> {
+        if (paragraphs.isEmpty()) return emptyList()
+        return paragraphs.chunked(chunkSize.coerceAtLeast(1)).map { group ->
+            group.joinToString("\n\n")
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -76,7 +76,6 @@ import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.sort
 import tachiyomi.domain.library.service.LibraryPreferences
-import eu.kanade.tachiyomi.source.custom.CustomNovelSource
 import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
@@ -360,11 +359,6 @@ class LibraryScreenModel(
             applyFilter(preferences.filterNovel) { isNovel }
         }
 
-        val filterFnCustomExtension: (LibraryItem) -> Boolean = { item ->
-            val isCustom = sourceManager.get(item.libraryManga.manga.source) is CustomNovelSource
-            applyFilter(preferences.filterCustomExtension) { isCustom }
-        }
-
         val tagIncluded = preferences.includedTags
         val tagExcluded = preferences.excludedTags
         val tagCaseSensitive = preferences.tagCaseSensitive
@@ -431,7 +425,6 @@ class LibraryScreenModel(
                 filterFnTracking(it) &&
                 filterFnExtensions(it) &&
                 filterFnNovel(it) &&
-                filterFnCustomExtension(it) &&
                 filterFnTags(it) &&
                 filterFnChapterCount(it)
         }
@@ -569,7 +562,6 @@ class LibraryScreenModel(
                 libraryPreferences.tagCaseSensitive().changes(),
                 libraryPreferences.filterChapterCount().changes(),
                 libraryPreferences.filterChapterCountThreshold().changes(),
-                libraryPreferences.filterCustomExtension().changes(),
             ) { arr -> arr },
         ) { first, second, third ->
             ItemPreferences(
@@ -595,7 +587,6 @@ class LibraryScreenModel(
                 tagCaseSensitive = third[5] as Boolean,
                 filterChapterCount = third[6] as TriState,
                 filterChapterCountThreshold = third[7] as Int,
-                filterCustomExtension = third[8] as TriState,
             )
         }
     }
@@ -1760,7 +1751,6 @@ class LibraryScreenModel(
         val tagCaseSensitive: Boolean,
         val filterChapterCount: TriState = TriState.DISABLED,
         val filterChapterCountThreshold: Int = 10,
-        val filterCustomExtension: TriState = TriState.DISABLED,
     )
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -26,6 +26,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.epub.EpubExportJob
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.translation.TranslationJob
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.SManga
@@ -52,6 +53,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import logcat.LogPriority
 import mihon.core.common.utils.mutate
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.core.common.util.lang.compareToWithCollator
@@ -74,6 +76,7 @@ import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.sort
 import tachiyomi.domain.library.service.LibraryPreferences
+import eu.kanade.tachiyomi.source.custom.CustomNovelSource
 import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
@@ -83,6 +86,7 @@ import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.track.interactor.GetTracksPerManga
 import tachiyomi.domain.track.model.Track
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
+import tachiyomi.i18n.MR
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -356,6 +360,11 @@ class LibraryScreenModel(
             applyFilter(preferences.filterNovel) { isNovel }
         }
 
+        val filterFnCustomExtension: (LibraryItem) -> Boolean = { item ->
+            val isCustom = sourceManager.get(item.libraryManga.manga.source) is CustomNovelSource
+            applyFilter(preferences.filterCustomExtension) { isCustom }
+        }
+
         val tagIncluded = preferences.includedTags
         val tagExcluded = preferences.excludedTags
         val tagCaseSensitive = preferences.tagCaseSensitive
@@ -406,6 +415,12 @@ class LibraryScreenModel(
             true
         }
 
+        val filterFnChapterCount: (LibraryItem) -> Boolean = { item ->
+            applyFilter(preferences.filterChapterCount) {
+                item.libraryManga.totalChapters >= preferences.filterChapterCountThreshold
+            }
+        }
+
         return fastFilter {
             filterFnDownloaded(it) &&
                 filterFnUnread(it) &&
@@ -416,7 +431,9 @@ class LibraryScreenModel(
                 filterFnTracking(it) &&
                 filterFnExtensions(it) &&
                 filterFnNovel(it) &&
-                filterFnTags(it)
+                filterFnCustomExtension(it) &&
+                filterFnTags(it) &&
+                filterFnChapterCount(it)
         }
     }
 
@@ -550,6 +567,9 @@ class LibraryScreenModel(
                 libraryPreferences.tagIncludeMode().changes(),
                 libraryPreferences.tagExcludeMode().changes(),
                 libraryPreferences.tagCaseSensitive().changes(),
+                libraryPreferences.filterChapterCount().changes(),
+                libraryPreferences.filterChapterCountThreshold().changes(),
+                libraryPreferences.filterCustomExtension().changes(),
             ) { arr -> arr },
         ) { first, second, third ->
             ItemPreferences(
@@ -573,6 +593,9 @@ class LibraryScreenModel(
                 tagIncludeModeAnd = third[3] as Boolean,
                 tagExcludeModeAnd = third[4] as Boolean,
                 tagCaseSensitive = third[5] as Boolean,
+                filterChapterCount = third[6] as TriState,
+                filterChapterCountThreshold = third[7] as Int,
+                filterCustomExtension = third[8] as TriState,
             )
         }
     }
@@ -774,6 +797,8 @@ class LibraryScreenModel(
                 // Queue all chapters for translation (TranslationService will skip already translated ones)
                 translationService.enqueueAll(manga, chapters)
             }
+            // Start background worker with notification
+            TranslationJob.start(Injekt.get<android.app.Application>())
         }
     }
 
@@ -824,6 +849,7 @@ class LibraryScreenModel(
         deleteFromLibrary: Boolean,
         deleteChapters: Boolean,
         clearChaptersFromDb: Boolean = false,
+        deleteTranslations: Boolean = false,
     ) {
         screenModelScope.launchNonCancellable {
             if (deleteFromLibrary) {
@@ -851,9 +877,16 @@ class LibraryScreenModel(
                 removeChapters.awaitByMangaIds(mangaIds)
             }
 
+            if (deleteTranslations) {
+                mangas.forEach { manga ->
+                    val chapters = getChaptersByMangaId.await(manga.id)
+                    translatedChapterRepository.deleteAllForChapters(chapters.map { it.id })
+                }
+            }
+
             // Refresh library UI after modifications
             if (deleteFromLibrary) {
-            } else if (deleteChapters || clearChaptersFromDb) {
+            } else if (deleteChapters || clearChaptersFromDb || deleteTranslations) {
                 getLibraryManga.notifyChanged()
             }
         }
@@ -1087,7 +1120,14 @@ class LibraryScreenModel(
         }
         val currentTime = System.currentTimeMillis()
 
-        screenModelScope.launchIO {
+        // Use launchNonCancellable so the job survives navigation away
+        val context = Injekt.get<android.app.Application>()
+        screenModelScope.launchNonCancellable {
+            snackbarHostState.showSnackbar(
+                message = context.stringResource(MR.strings.batch_updating_entries, mangaList.size),
+                duration = SnackbarDuration.Short,
+            )
+
             val results = mangaList.map { manga ->
                 async {
                     try {
@@ -1125,7 +1165,18 @@ class LibraryScreenModel(
             }
             val outcomes = results.awaitAll()
             val successCount = outcomes.count { it }
+            val failCount = mangaList.size - successCount
             logcat(LogPriority.INFO) { "Batch update complete: $successCount/${mangaList.size} succeeded" }
+
+            val message = if (failCount > 0) {
+                context.stringResource(MR.strings.batch_update_complete_with_failures, successCount, mangaList.size, failCount)
+            } else {
+                context.stringResource(MR.strings.batch_update_complete, successCount)
+            }
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short,
+            )
         }
     }
 
@@ -1240,7 +1291,7 @@ class LibraryScreenModel(
             mangaIds = mangaList.map { it.id },
             outputUri = uri,
             downloadedOnly = options.downloadedOnly,
-            preferTranslated = options.preferTranslated,
+            translationMode = options.translationMode,
             includeChapterCount = options.includeChapterCount,
             includeChapterRange = options.includeChapterRange,
             includeStatus = options.includeStatus,
@@ -1306,9 +1357,9 @@ class LibraryScreenModel(
                         var firstChapterNum = Double.MAX_VALUE
                         var lastChapterNum = Double.MIN_VALUE
 
-                        // Get translated chapter IDs for this manga if preferTranslated is enabled
-                        val translatedChapterIds = if (options.preferTranslated) {
-                            translatedChapterRepository.getTranslatedChapterIds(manga.id)
+                        // Get translated chapter IDs for this manga if translation mode needs them
+                        val translatedChapterIds = if (options.translationMode != tachiyomi.domain.translation.model.TranslationMode.ORIGINAL) {
+                            translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
                         } else {
                             emptySet()
                         }
@@ -1333,9 +1384,9 @@ class LibraryScreenModel(
                                 continue
                             }
 
-                            // Try to get translated content first if preferTranslated is enabled
+                            // Try to get translated content first if translation mode needs it
                             var content: String? = null
-                            if (options.preferTranslated && hasTranslation) {
+                            if (options.translationMode != tachiyomi.domain.translation.model.TranslationMode.ORIGINAL && hasTranslation) {
                                 try {
                                     val translations = translatedChapterRepository.getAllTranslationsForChapter(chapter.id)
                                     content = translations.firstOrNull()?.translatedContent
@@ -1707,6 +1758,9 @@ class LibraryScreenModel(
         val tagIncludeModeAnd: Boolean,
         val tagExcludeModeAnd: Boolean,
         val tagCaseSensitive: Boolean,
+        val filterChapterCount: TriState = TriState.DISABLED,
+        val filterChapterCountThreshold: Int = 10,
+        val filterCustomExtension: TriState = TriState.DISABLED,
     )
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.cache.LibrarySettingsCache
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.source.custom.CustomNovelSource
 import eu.kanade.tachiyomi.jsplugin.source.JsSource
 import eu.kanade.tachiyomi.source.isNovelSource
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +40,7 @@ data class ExtensionInfo(
     val sourceName: String,
     val isStub: Boolean = false,
     val isNovel: Boolean = false,
+    val isCustom: Boolean = false,
 )
 
 class LibrarySettingsScreenModel(
@@ -227,15 +229,20 @@ class LibrarySettingsScreenModel(
                     val source = sourceManager.getOrStub(sourceId)
                     val isNovel = source.isNovelSource()
                     val isStub = source is StubSource
+                    val isCustom = source is CustomNovelSource
                     val shouldInclude = when (type) {
                         LibraryScreenModel.LibraryType.All -> true
                         LibraryScreenModel.LibraryType.Manga -> !isNovel
                         LibraryScreenModel.LibraryType.Novel -> isNovel
                     }
                     if (shouldInclude) {
-                        // Add (JS) suffix for JS plugin sources
-                        val displayName = if (source is JsSource) "${source.name} (JS)" else source.name
-                        ExtensionInfo(sourceId, displayName, isStub, isNovel)
+                        // Add suffix for special source types
+                        val displayName = when {
+                            source is JsSource -> "${source.name} (JS)"
+                            isCustom -> "${source.name} (Custom)"
+                            else -> source.name
+                        }
+                        ExtensionInfo(sourceId, displayName, isStub, isNovel, isCustom)
                     } else {
                         null
                     }
@@ -303,7 +310,7 @@ class LibrarySettingsScreenModel(
                     if (shouldInclude) {
                         if (genres.isNullOrEmpty()) {
                             noTagsCount++
-                        } else {
+                    } else {
                             genres.forEach { tag ->
                                 val normalizedTag = tag.trim()
                                 if (normalizedTag.isNotBlank()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -290,8 +290,8 @@ data object LibraryTab : Tab {
                 DeleteLibraryMangaDialog(
                     containsLocalManga = dialog.manga.any(Manga::isLocal),
                     onDismissRequest = onDismissRequest,
-                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb ->
-                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb)
+                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations ->
+                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations)
                         screenModel.clearSelection()
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
@@ -312,8 +312,8 @@ data object NovelsTab : Tab {
                 DeleteLibraryMangaDialog(
                     containsLocalManga = dialog.manga.any(Manga::isLocal),
                     onDismissRequest = onDismissRequest,
-                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb ->
-                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb)
+                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations ->
+                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations)
                         screenModel.clearSelection()
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -197,6 +197,13 @@ class MangaScreen(
             onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,
             onMultiDeleteClicked = screenModel::showDeleteChapterDialog,
             onMultiRemoveFromDbClicked = screenModel::showRemoveChaptersFromDbDialog,
+            onMultiDeleteTranslationClicked = screenModel::deleteTranslations,
+            onTranslateSelectedClicked = { chapters ->
+                screenModel.translateSelectedChapters(chapters, forceRetranslate = false)
+            },
+            onRetranslateSelectedClicked = { chapters ->
+                screenModel.translateSelectedChapters(chapters, forceRetranslate = true)
+            },
             onChapterSwipe = screenModel::chapterSwipe,
             onChapterSelected = screenModel::toggleSelection,
             onAllChapterSelected = screenModel::toggleAllSelection,
@@ -273,6 +280,7 @@ class MangaScreen(
                     // Initiated from the context of [dialog.target] so we show [dialog.current].
                     onClickTitle = { navigator.push(MangaScreen(dialog.current.id)) },
                     onDismissRequest = onDismissRequest,
+                    showQuickOption = true,
                 )
             }
             MangaScreenModel.Dialog.SettingsSheet -> ChapterSettingsDialog(
@@ -377,13 +385,7 @@ class MangaScreen(
                     manga = dialog.manga,
                     onDismissRequest = onDismissRequest,
                     onConfirm = { details ->
-                        screenModel.saveTranslatedDetails(
-                            details.translatedTitle,
-                            details.translatedDescription,
-                            details.translatedGenres,
-                            details.addToAltTitles,
-                            details.saveTagsToNotes,
-                        )
+                        screenModel.applyTranslatedDetails(details)
                     },
                 )
             }
@@ -392,8 +394,8 @@ class MangaScreen(
                     manga = dialog.manga,
                     chapters = dialog.chapters,
                     onDismissRequest = onDismissRequest,
-                    onExport = { uri ->
-                        screenModel.exportAsEpub(dialog.manga, dialog.chapters, uri)
+                    onExport = { uri, options ->
+                        screenModel.exportAsEpub(dialog.manga, dialog.chapters, uri, options)
                     },
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -35,8 +35,10 @@ import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.data.epub.EpubExportJob
 import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.translation.TranslationJob
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.Source
@@ -193,10 +195,12 @@ class MangaScreenModel(
                 getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
                 downloadCache.changes,
                 downloadManager.queueState,
-            ) { mangaAndChapters, _, _ -> mangaAndChapters }
+                // Re-evaluate when translation progress changes (e.g. a chapter finishes translating)
+                translationService.progressState,
+            ) { mangaAndChapters, _, _, _ -> mangaAndChapters }
                 .flowWithLifecycle(lifecycle)
                 .collectLatest { (manga, chapters) ->
-                    val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(manga.id)
+                    val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
                     updateSuccessState {
                         it.copy(
                             manga = manga,
@@ -237,15 +241,16 @@ class MangaScreenModel(
             val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
 
             val manga = mangaDeferred.await()
-            val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(manga.id)
-            val chapters = chaptersDeferred.await().toChapterListItems(manga, translatedChapterIds)
+            val chapters = chaptersDeferred.await()
+            val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
+            val chapterListItems = chapters.toChapterListItems(manga, translatedChapterIds)
 
             if (!manga.favorite) {
                 setMangaDefaultChapterFlags.await(manga)
             }
 
             val needRefreshInfo = !manga.initialized
-            val needRefreshChapter = chapters.isEmpty()
+            val needRefreshChapter = chapterListItems.isEmpty()
 
             // Show what we have earlier
             val source = Injekt.get<SourceManager>().getOrStub(manga.source)
@@ -254,7 +259,7 @@ class MangaScreenModel(
                     manga = manga,
                     source = source,
                     isFromSource = isFromSource,
-                    chapters = chapters,
+                    chapters = chapterListItems,
                     availableScanlators = availableScanlatorsDeferred.await(),
                     excludedScanlators = excludedScanlatorsDeferred.await(),
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
@@ -558,64 +563,6 @@ class MangaScreenModel(
             updateManga.await(update)
             getLibraryManga.applyMangaDetailUpdate(mangaId) { it.copy(genre = tags) }
         }
-    }
-
-    /**
-     * Save translated manga details (title to alt titles, description to notes, genres).
-     */
-    fun saveTranslatedDetails(
-        translatedTitle: String?,
-        translatedDescription: String?,
-        translatedGenres: List<String>?,
-        addToAltTitles: Boolean,
-        saveTagsToNotes: Boolean,
-    ) {
-        val manga = successState?.manga ?: return
-
-        screenModelScope.launchIO {
-            // Add translated title to alternative titles if requested
-            if (addToAltTitles && translatedTitle != null && translatedTitle != manga.title) {
-                val currentAltTitles = manga.alternativeTitles.toMutableList()
-                if (!currentAltTitles.contains(translatedTitle)) {
-                    currentAltTitles.add(0, translatedTitle) // Add at the beginning
-                    updateManga.awaitUpdateAlternativeTitles(mangaId, currentAltTitles)
-                }
-            }
-
-            // Prepare new notes
-            var newNotes = manga.notes
-
-            // Save translated description to notes
-            if (translatedDescription != null) {
-                if (newNotes.isBlank()) {
-                    newNotes = "Translated Description:\n$translatedDescription"
-                } else if (!newNotes.contains("Translated Description:")) {
-                    newNotes = "$newNotes\n\nTranslated Description:\n$translatedDescription"
-                }
-            }
-
-            // Save translated tags to notes
-            if (saveTagsToNotes && translatedGenres != null && translatedGenres.isNotEmpty()) {
-                val tagsString = "Translated Tags: ${translatedGenres.joinToString(", ")}"
-                if (newNotes.isBlank()) {
-                    newNotes = tagsString
-                } else if (!newNotes.contains("Translated Tags:")) {
-                    newNotes = "$newNotes\n\n$tagsString"
-                }
-            }
-
-            if (newNotes != manga.notes) {
-                updateManga.awaitUpdateNotes(mangaId, newNotes)
-            }
-
-            // Save translated genres if provided (as genres)
-            if (translatedGenres != null && translatedGenres.isNotEmpty()) {
-                updateManga.awaitUpdateGenre(mangaId, translatedGenres)
-                getLibraryManga.applyMangaDetailUpdate(mangaId) { it.copy(genre = translatedGenres) }
-            }
-        }
-
-        dismissDialog()
     }
 
     // Manga info - end
@@ -1296,6 +1243,25 @@ class MangaScreenModel(
         }
     }
 
+    fun deleteTranslations(chapters: List<Chapter>) {
+        screenModelScope.launchNonCancellable {
+            val chapterIds = chapters.map { it.id }.toSet()
+            translatedChapterRepository.deleteAllForChapters(chapterIds)
+            // Update the UI to reflect that these chapters no longer have translations
+            updateSuccessState { state ->
+                state.copy(
+                    chapters = state.chapters.map { item ->
+                        if (item.chapter.id in chapterIds) {
+                            item.copy(hasTranslation = false)
+                        } else {
+                            item
+                        }
+                    },
+                )
+            }
+        }
+    }
+
     fun showSettingsDialog() {
         updateSuccessState { it.copy(dialog = Dialog.SettingsSheet) }
     }
@@ -1407,8 +1373,12 @@ class MangaScreenModel(
 
     fun showExportEpubDialog() {
         val manga = successState?.manga ?: return
-        val chapters = successState?.chapters?.map { it.chapter } ?: return
-        updateSuccessState { it.copy(dialog = Dialog.ExportEpub(manga, chapters)) }
+        val chapterItems = successState?.chapters ?: return
+        // Only include chapters that are downloaded or have a translation
+        val exportableChapters = chapterItems.filter {
+            it.downloadState == Download.State.DOWNLOADED || it.hasTranslation
+        }.map { it.chapter }
+        updateSuccessState { it.copy(dialog = Dialog.ExportEpub(manga, exportableChapters)) }
     }
 
     /**
@@ -1423,50 +1393,72 @@ class MangaScreenModel(
         val manga = successState?.manga ?: return
         screenModelScope.launchIO {
             // Handle genres - merge or replace based on user preference
-            val finalGenres = if (details.translatedGenres != null && details.mergeGenres) {
-                // Merge: combine existing genres with translated ones, removing duplicates
-                val existingGenres = manga.genre ?: emptyList()
-                val combinedGenres = (existingGenres + details.translatedGenres).distinct()
-                combinedGenres
-            } else {
-                details.translatedGenres
+            val finalGenres = when {
+                details.translatedGenres == null -> null
+                details.mergeGenres -> {
+                    val existingGenres = manga.genre ?: emptyList()
+                    (existingGenres + details.translatedGenres).distinct()
+                }
+                else -> details.translatedGenres
             }
 
-            val update = tachiyomi.domain.manga.model.MangaUpdate(
-                id = manga.id,
-                title = details.translatedTitle,
-                description = details.translatedDescription,
-                genre = finalGenres,
-            )
-
-            // Update manga
-            updateManga.await(update)
-
-            // Add to alternative titles if requested
             if (details.addToAltTitles && !details.translatedTitle.isNullOrBlank() &&
                 details.translatedTitle != manga.title
             ) {
+                val currentAltTitles = manga.alternativeTitles.toMutableList()
+                if (!currentAltTitles.contains(details.translatedTitle)) {
+                    currentAltTitles.add(0, details.translatedTitle)
+                    updateManga.awaitUpdateAlternativeTitles(mangaId, currentAltTitles)
+                }
             }
 
-            // Save tags to notes if requested
-            if (details.saveTagsToNotes && !details.translatedGenres.isNullOrEmpty()) {
-                // Append translated tags to notes
-                val currentNotes = manga.notes ?: ""
-                val tagsString = details.translatedGenres.joinToString(", ")
-                val newNotes = if (currentNotes.isBlank()) {
-                    "Translated Tags: $tagsString"
+            if (details.translatedDescription != null) {
+                updateManga.awaitUpdateDescription(mangaId, details.translatedDescription)
+            }
+
+            var newNotes = manga.notes
+            if (details.translatedDescription != null) {
+                val descBlock = "Translated Description:\n${details.translatedDescription}"
+                val descRegex = Regex("""Translated Description:\n[\s\S]*?(?=\n\nTranslated Tags:|$)""")
+                newNotes = if (newNotes.isBlank()) {
+                    descBlock
+                } else if (descRegex.containsMatchIn(newNotes)) {
+                    descRegex.replace(newNotes, descBlock)
                 } else {
-                    "$currentNotes\n\nTranslated Tags: $tagsString"
+                    "$newNotes\n\n$descBlock"
                 }
-                updateMangaNotes(manga.id, newNotes)
+            }
+
+            if (details.saveTagsToNotes && !details.translatedGenres.isNullOrEmpty()) {
+                val tagsString = "Translated Tags: ${details.translatedGenres.joinToString(", ")}"
+                val tagsRegex = Regex("""Translated Tags:.*""")
+                newNotes = if (newNotes.isBlank()) {
+                    tagsString
+                } else if (tagsRegex.containsMatchIn(newNotes)) {
+                    tagsRegex.replace(newNotes, tagsString)
+                } else {
+                    "$newNotes\n\n$tagsString"
+                }
+            }
+
+            if (newNotes != manga.notes) {
+                updateManga.awaitUpdateNotes(mangaId, newNotes)
+            }
+
+            if (finalGenres != null && finalGenres.isNotEmpty()) {
+                updateManga.awaitUpdateGenre(mangaId, finalGenres)
+                getLibraryManga.applyMangaDetailUpdate(mangaId) { it.copy(genre = finalGenres) }
             }
         }
+
+        dismissDialog()
     }
 
     /**
      * Queue all downloaded chapters for translation.
+     * @param forceRetranslate if true, retranslate even already-translated chapters.
      */
-    fun translateDownloadedChapters() {
+    fun translateDownloadedChapters(forceRetranslate: Boolean = false) {
         val state = successState ?: return
         val manga = state.manga
 
@@ -1485,156 +1477,97 @@ class MangaScreenModel(
                 return@launchIO
             }
 
+            // Filter out already-translated chapters unless forcing
+            val chaptersToTranslate = if (forceRetranslate) {
+                downloadedChapters
+            } else {
+                val translatedIds = translatedChapterRepository.getTranslatedChapterIds(downloadedChapters.map { it.id })
+                downloadedChapters.filter { it.id !in translatedIds }
+            }
+
+            if (chaptersToTranslate.isEmpty()) {
+                withUIContext {
+                    snackbarHostState.showSnackbar(context.stringResource(MR.strings.translation_all_downloaded_already_translated))
+                }
+                return@launchIO
+            }
+
             // Queue chapters for translation
-            translationService.enqueueAll(manga, downloadedChapters, TranslationService.PRIORITY_NORMAL)
+            translationService.enqueueAll(manga, chaptersToTranslate, TranslationService.PRIORITY_NORMAL, forceRetranslate)
+
+            // Start background worker with notification
+            TranslationJob.start(context)
 
             withUIContext {
                 snackbarHostState.showSnackbar(
-                    context.stringResource(TDMR.strings.translation_queued, downloadedChapters.size),
+                    context.stringResource(TDMR.strings.translation_queued, chaptersToTranslate.size),
                 )
             }
         }
     }
 
     /**
-     * Export novel as EPUB file.
+     * Queue selected chapters for translation.
      */
-    fun exportAsEpub(manga: Manga, chapters: List<Chapter>, uri: android.net.Uri) {
+    fun translateSelectedChapters(chapters: List<Chapter>, forceRetranslate: Boolean = false) {
+        val state = successState ?: return
+        val manga = state.manga
+
         screenModelScope.launchIO {
-            try {
-                val sourceManager = Injekt.get<SourceManager>()
-                val downloadProvider = Injekt.get<DownloadProvider>()
-                val source = sourceManager.get(manga.source) ?: throw Exception("Source not found")
-                val sortedChapters = chapters.sortedBy { it.chapterNumber }
+            val chaptersToTranslate = if (forceRetranslate) {
+                chapters
+            } else {
+                val translatedIds = translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
+                chapters.filter { it.id !in translatedIds }
+            }
 
-                if (!source.isNovelSource()) {
-                    withUIContext {
-                        snackbarHostState.showSnackbar("EPUB export is only available for novels")
-                    }
-                    return@launchIO
+            if (chaptersToTranslate.isEmpty()) {
+                withUIContext {
+                    snackbarHostState.showSnackbar(context.stringResource(MR.strings.translation_selected_already_translated))
                 }
+                return@launchIO
+            }
 
-                val epubChapters = mutableListOf<mihon.core.archive.EpubWriter.Chapter>()
+            translationService.enqueueAll(manga, chaptersToTranslate, TranslationService.PRIORITY_NORMAL, forceRetranslate)
+            TranslationJob.start(context)
 
-                for ((index, chapter) in sortedChapters.withIndex()) {
-                    // Check if chapter is downloaded
-                    val isDownloaded = downloadManager.isChapterDownloaded(
-                        chapter.name,
-                        chapter.scanlator,
-                        chapter.url,
-                        manga.title,
-                        manga.source,
-                    )
-
-                    if (!isDownloaded) {
-                        continue
-                    }
-
-                    withUIContext {
-                        snackbarHostState.showSnackbar(
-                            context.stringResource(TDMR.strings.export_epub_progress, index + 1, sortedChapters.size),
-                            duration = SnackbarDuration.Short,
-                        )
-                    }
-
-                    // Fetch chapter content from disk
-                    val content = try {
-                        val chapterDir = downloadProvider.findChapterDir(
-                            chapter.name,
-                            chapter.scanlator,
-                            chapter.url,
-                            manga.title,
-                            source,
-                        )
-
-                        if (chapterDir != null) {
-                            val htmlFiles = chapterDir.listFiles()?.filter {
-                                it.isFile && it.name?.endsWith(".html") == true
-                            }?.sortedBy { it.name } ?: emptyList()
-
-                            if (htmlFiles.isNotEmpty()) {
-                                val sb = StringBuilder()
-                                htmlFiles.forEachIndexed { i, file ->
-                                    val fileContent = context.contentResolver.openInputStream(file.uri)?.use {
-                                        it.bufferedReader().readText()
-                                    } ?: ""
-                                    sb.append(fileContent)
-                                    if (i < htmlFiles.size - 1) {
-                                        sb.append("\n\n")
-                                    }
-                                }
-                                sb.toString()
-                            } else {
-                                "<p>Chapter content not found</p>"
-                            }
-                        } else {
-                            "<p>Chapter directory not found</p>"
-                        }
-                    } catch (e: Exception) {
-                        logcat(LogPriority.ERROR, e) { "Failed to get content for chapter: ${chapter.name}" }
-                        "<p>Failed to load chapter content</p>"
-                    }
-
-                    epubChapters.add(
-                        mihon.core.archive.EpubWriter.Chapter(
-                            title = chapter.name,
-                            content = content,
-                            order = index,
-                        ),
-                    )
-                }
-
-                if (epubChapters.isEmpty()) {
-                    withUIContext {
-                        snackbarHostState.showSnackbar("No downloaded chapters found to export")
-                    }
-                    return@launchIO
-                }
-
-                // Get cover image
-                val coverImage = try {
-                    manga.thumbnailUrl?.let { url ->
-                        val client = Injekt.get<eu.kanade.tachiyomi.network.NetworkHelper>().client
-                        val request = okhttp3.Request.Builder().url(url).build()
-                        client.newCall(request).execute().use { it.body.bytes() }
-                    }
-                } catch (e: Exception) {
-                    logcat(LogPriority.WARN, e) { "Failed to fetch cover image" }
-                    null
-                }
-
-                // Create EPUB metadata
-                val metadata = mihon.core.archive.EpubWriter.Metadata(
-                    title = manga.title,
-                    author = manga.author,
-                    description = manga.description,
-                    language = "en",
-                    genres = manga.genre ?: emptyList(),
-                    publisher = source.name,
+            withUIContext {
+                snackbarHostState.showSnackbar(
+                    context.stringResource(TDMR.strings.translation_queued, chaptersToTranslate.size),
                 )
+            }
+        }
+    }
 
-                // Write EPUB
-                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                    mihon.core.archive.EpubWriter().write(
-                        outputStream = outputStream,
-                        metadata = metadata,
-                        chapters = epubChapters,
-                        coverImage = coverImage,
-                    )
-                }
+    /**
+     * Export novel as EPUB file via the background EpubExportJob.
+     */
+    fun exportAsEpub(
+        manga: Manga,
+        chapters: List<Chapter>,
+        uri: android.net.Uri,
+        options: eu.kanade.presentation.library.components.EpubExportOptions =
+            eu.kanade.presentation.library.components.EpubExportOptions(),
+    ) {
+        val context = Injekt.get<android.app.Application>()
 
-                withUIContext {
-                    snackbarHostState.showSnackbar(
-                        context.stringResource(TDMR.strings.export_epub_success),
-                    )
-                }
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR, e) { "Failed to export EPUB" }
-                withUIContext {
-                    snackbarHostState.showSnackbar(
-                        context.stringResource(TDMR.strings.export_epub_error, e.message ?: "Unknown error"),
-                    )
-                }
+        EpubExportJob.start(
+            context = context,
+            mangaIds = listOf(manga.id),
+            outputUri = uri,
+            downloadedOnly = options.downloadedOnly,
+            translationMode = options.translationMode,
+            includeChapterCount = options.includeChapterCount,
+            includeChapterRange = options.includeChapterRange,
+            includeStatus = options.includeStatus,
+        )
+
+        screenModelScope.launchIO {
+            withUIContext {
+                snackbarHostState.showSnackbar(
+                    "EPUB export started",
+                    duration = SnackbarDuration.Short,
+                )
             }
         }
     }

--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.util.fastForEach
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
@@ -32,6 +33,7 @@ import mihon.feature.common.utils.getLabel
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LabeledCheckbox
 import tachiyomi.presentation.core.components.material.padding
@@ -47,6 +49,7 @@ internal fun Screen.MigrateMangaDialog(
     onClickTitle: () -> Unit,
     onDismissRequest: () -> Unit,
     onComplete: () -> Unit = onDismissRequest,
+    showQuickOption: Boolean = false,
 ) {
     val scope = rememberCoroutineScope()
 
@@ -98,6 +101,18 @@ internal fun Screen.MigrateMangaDialog(
 
                 Spacer(modifier = Modifier.weight(1f))
 
+                if (showQuickOption) {
+                    TextButton(
+                        onClick = {
+                            scope.launchIO {
+                                screenModel.quickMigrate()
+                                withUIContext { onComplete() }
+                            }
+                        },
+                    ) {
+                        Text(text = stringResource(MR.strings.action_quick_migrate))
+                    }
+                }
                 TextButton(
                     onClick = {
                         scope.launchIO {
@@ -128,6 +143,7 @@ private class MigrateDialogScreenModel(
     private val coverCache: CoverCache = Injekt.get(),
     private val downloadManager: DownloadManager = Injekt.get(),
     private val migrateManga: MigrateMangaUseCase = Injekt.get(),
+    private val updateManga: UpdateManga = Injekt.get(),
 ) : StateScreenModel<MigrateDialogScreenModel.State>(State()) {
 
     fun init(current: Manga, target: Manga) {
@@ -172,6 +188,26 @@ private class MigrateDialogScreenModel(
         sourcePreference.migrationFlags().set(state.selectedFlags)
         mutableState.update { it.copy(isMigrating = true) }
         migrateManga(current, target, replace)
+        mutableState.update { it.copy(isMigrating = false, isMigrated = true) }
+    }
+
+    /**
+     * Quick migrate: just update the source ID and URL in the database.
+     * Useful when an extension changed name/URL but content stayed the same.
+     */
+    suspend fun quickMigrate() {
+        val state = state.value
+        val current = state.current ?: return
+        val target = state.target ?: return
+        mutableState.update { it.copy(isMigrating = true) }
+        updateManga.await(
+            MangaUpdate(
+                id = current.id,
+                source = target.source,
+                url = target.url,
+                thumbnailUrl = target.thumbnailUrl,
+            ),
+        )
         mutableState.update { it.copy(isMigrating = false, isMigrated = true) }
     }
 

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
@@ -10,8 +10,14 @@ import java.util.zip.ZipOutputStream
 /**
  * EPUB writer for creating EPUB 3.0 files.
  * Creates a valid EPUB with proper structure: mimetype, META-INF/container.xml, content.opf, nav.xhtml, and chapter HTML files.
+ *
+ * @param deflateLevel Deflate compression level (0-9). 0 = no compression (stored), 9 = max compression.
+ *                     Default is [java.util.zip.Deflater.DEFAULT_COMPRESSION] (-1).
+ *                     The `mimetype` entry is ALWAYS stored uncompressed per the EPUB spec, regardless of this setting.
  */
-class EpubWriter {
+class EpubWriter(
+    private val deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
+) {
 
     data class Chapter(
         val title: String,
@@ -46,6 +52,8 @@ class EpubWriter {
         val bookId = UUID.randomUUID().toString()
 
         ZipOutputStream(outputStream).use { zip ->
+            // Set the compression level for all entries except mimetype
+            zip.setLevel(deflateLevel)
             // mimetype must be first entry and stored uncompressed
             writeMimetype(zip)
 
@@ -203,7 +211,10 @@ $spineItems
     }
 
     private fun writeEntry(zip: ZipOutputStream, path: String, content: ByteArray) {
-        zip.putNextEntry(ZipEntry(path))
+        val entry = ZipEntry(path).apply {
+            method = ZipEntry.DEFLATED
+        }
+        zip.putNextEntry(entry)
         zip.write(content)
         zip.closeEntry()
     }
@@ -226,9 +237,10 @@ $spineItems
             metadata: Metadata,
             chapters: List<Chapter>,
             coverImage: ByteArray? = null,
+            deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
         ) {
             file.outputStream().use { outputStream ->
-                EpubWriter().write(outputStream, metadata, chapters, coverImage)
+                EpubWriter(deflateLevel).write(outputStream, metadata, chapters, coverImage)
             }
         }
     }

--- a/core/archive/src/main/kotlin/mihon/core/archive/ZipWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/ZipWriter.kt
@@ -10,7 +10,7 @@ import me.zhanghai.android.libarchive.ArchiveException
 import java.io.Closeable
 import java.nio.ByteBuffer
 
-class ZipWriter(val context: Context, file: UniFile) : Closeable {
+class ZipWriter(val context: Context, file: UniFile, compressionLevel: Int = 0) : Closeable {
     private val pfd = file.openFileDescriptor(context, "wt")
     private val archive = Archive.writeNew()
     private val entry = ArchiveEntry.new2(archive)
@@ -20,7 +20,12 @@ class ZipWriter(val context: Context, file: UniFile) : Closeable {
         try {
             Archive.setCharset(archive, Charsets.UTF_8.name().toByteArray())
             Archive.writeSetFormatZip(archive)
-            Archive.writeZipSetCompressionStore(archive)
+            if (compressionLevel > 0) {
+                Archive.writeZipSetCompressionDeflate(archive)
+                Archive.writeSetOptions(archive, "zip:compression-level=$compressionLevel".toByteArray())
+            } else {
+                Archive.writeZipSetCompressionStore(archive)
+            }
             Archive.writeOpenFd(archive, pfd.fd)
         } catch (e: ArchiveException) {
             close()

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -34,5 +34,7 @@ dependencies {
     implementation(projects.domain)
     implementation(projects.core.common)
 
+    implementation(libs.unifile)
+
     api(libs.bundles.sqldelight)
 }

--- a/data/src/main/java/tachiyomi/data/AndroidDatabaseHandler.kt
+++ b/data/src/main/java/tachiyomi/data/AndroidDatabaseHandler.kt
@@ -212,7 +212,6 @@ class AndroidDatabaseHandler(
                 "mangas_categories",
                 "manga_sync",
                 "excluded_scanlators",
-                "translated_chapters",
             ).forEach { table ->
                 try {
                     driver.executeQuery(null, "SELECT count(*) FROM $table", { cursor ->

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -1,198 +1,410 @@
 package tachiyomi.data.translation
 
 import android.content.Context
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import tachiyomi.data.DatabaseHandler
+import com.hippo.unifile.UniFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import tachiyomi.core.common.storage.nameWithoutExtension
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.storage.service.StorageManager
 import tachiyomi.domain.translation.model.TranslatedChapter
-import tachiyomi.domain.translation.model.TranslationInfo
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import java.io.File
 
+/**
+ * Filesystem-only implementation of [TranslatedChapterRepository].
+ *
+ * Storage layout (shared storage via SAF / UniFile):
+ *   {baseDir}/translations/{chapterId}_{targetLanguage}.html
+ *
+ * Falls back to app-internal storage if shared storage is unavailable:
+ *   filesDir/translations/{chapterId}_{targetLanguage}.html
+ *
+ * Engine and date metadata are embedded as an HTML comment on the first line:
+ *   <!-- tsundoku-meta:engineId:dateTranslated -->
+ *
+ * NOTE: This implementation uses [UniFile] throughout (same as the download system)
+ * to avoid converting SAF URIs to file paths, which causes crashes on some devices/ROMs
+ * when [android.content.Context.getExternalCacheDirs] fails.
+ */
 class TranslatedChapterRepositoryImpl(
     private val context: Context,
-    private val handler: DatabaseHandler,
+    private val storageManager: StorageManager,
 ) : TranslatedChapterRepository {
 
-    private val translationsDir = File(context.filesDir, "translations").also { it.mkdirs() }
+    /** Legacy (app-internal) directory – used for fallback and migration. */
+    private val legacyDir = File(context.filesDir, "translations")
 
-    private fun getTranslationFile(chapterId: Long, targetLanguage: String): File {
-        return File(translationsDir, "${chapterId}_$targetLanguage.html")
-    }
-
-    override suspend fun getTranslatedChapter(chapterId: Long, targetLanguage: String): TranslatedChapter? {
-        val record = handler.awaitOneOrNull {
-            translated_chaptersQueries.getTranslatedChapter(chapterId, targetLanguage)
-        } ?: return null
-
-        val content = if (record.translated_content.isEmpty()) {
-            val file = getTranslationFile(chapterId, targetLanguage)
-            if (file.exists()) file.readText() else ""
-        } else {
-            record.translated_content
+    /**
+     * Resolve the translations directory via SAF, falling back to app-internal.
+     * Returns a [UniFile] that can be used for all I/O operations without needing
+     * to convert to a filesystem path.
+     */
+    private val translationsDir: UniFile
+        get() {
+            val shared = storageManager.getTranslationsDirectory()
+            if (shared != null && shared.exists()) return shared
+            // Fallback to app-internal wrapped as UniFile
+            legacyDir.mkdirs()
+            return UniFile.fromFile(legacyDir)!!
         }
 
-        return record.toTranslatedChapter().copy(translatedContent = content)
+    init {
+        // Migrate existing translations from legacy location to shared storage on first access
+        migrateFromLegacyDir()
     }
 
-    override suspend fun getAllTranslationsForChapter(chapterId: Long): List<TranslatedChapter> {
-        return handler.awaitList {
-            translated_chaptersQueries.getAllTranslationsForChapter(chapterId)
-        }.map { record ->
-            val content = if (record.translated_content.isEmpty()) {
-                val file = getTranslationFile(chapterId, record.target_language)
-                if (file.exists()) file.readText() else ""
-            } else {
-                record.translated_content
+    /**
+     * Move translation files from old app-internal dir to the shared storage dir.
+     * Safe to call multiple times – it only moves files that still exist in the legacy dir.
+     */
+    private fun migrateFromLegacyDir() {
+        try {
+            if (!legacyDir.exists()) return
+            val files = legacyDir.listFiles { f -> f.name.endsWith(".html") } ?: return
+            if (files.isEmpty()) return
+
+            val targetDir = storageManager.getTranslationsDirectory() ?: return
+            // Don't migrate if target is effectively the same as legacy (both are app-internal)
+            val targetPath = try { targetDir.filePath } catch (_: Exception) { null }
+            if (targetPath != null && targetPath == legacyDir.absolutePath) return
+
+            var migrated = 0
+            for (file in files) {
+                val name = file.name
+                // Check if already exists in target
+                if (targetDir.findFile(name) != null) {
+                    file.delete()
+                    migrated++
+                    continue
+                }
+                // Copy file content via SAF
+                val dest = targetDir.createFile(name) ?: continue
+                try {
+                    file.inputStream().use { input ->
+                        dest.openOutputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                    file.delete()
+                    migrated++
+                } catch (e: Exception) {
+                    dest.delete()
+                    logcat(LogPriority.WARN, e) { "Failed to migrate translation file: $name" }
+                }
             }
-            record.toTranslatedChapter().copy(translatedContent = content)
+
+            // Clean up empty legacy dir
+            if (legacyDir.listFiles()?.isEmpty() == true) {
+                legacyDir.delete()
+            }
+
+            if (migrated > 0) {
+                logcat(LogPriority.INFO) { "Migrated $migrated translation files to shared storage" }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to migrate translation files" }
         }
     }
 
-    override suspend fun getTranslatedLanguagesForManga(mangaId: Long): List<String> {
-        return handler.awaitList {
-            translated_chaptersQueries.getTranslatedLanguagesForManga(mangaId)
+    private fun getTranslationFileName(chapterId: Long, targetLanguage: String): String {
+        return "${chapterId}_$targetLanguage.html"
+    }
+
+    private fun getTmpTranslationFileName(chapterId: Long, targetLanguage: String): String {
+        return "${chapterId}_$targetLanguage.html.tmp"
+    }
+
+    private fun findTranslationFile(chapterId: Long, targetLanguage: String): UniFile? {
+        val name = getTranslationFileName(chapterId, targetLanguage)
+        return translationsDir.findFile(name)
+    }
+
+    // ── Metadata helpers ──────────────────────────────────────────────
+
+    private val META_PREFIX = "<!-- tsundoku-meta:"
+    private val META_SUFFIX = " -->"
+    private val META_REGEX = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+) -->\\n?")
+
+    private fun buildMetaComment(engineId: String, dateTranslated: Long): String {
+        return "$META_PREFIX$engineId:$dateTranslated$META_SUFFIX\n"
+    }
+
+    private data class FileMeta(val engineId: String, val dateTranslated: Long, val content: String)
+
+    /** Read a translation file, parsing the optional metadata comment from the first line. */
+    private fun parseUniFile(file: UniFile): FileMeta? {
+        if (!file.exists()) return null
+        val raw = try {
+            file.openInputStream().bufferedReader().use { it.readText() }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read translation file: ${file.name}" }
+            return null
+        }
+        val match = META_REGEX.find(raw)
+        return if (match != null) {
+            FileMeta(
+                engineId = match.groupValues[1],
+                dateTranslated = match.groupValues[2].toLong(),
+                content = raw.removeRange(match.range).trimStart('\n'),
+            )
+        } else {
+            FileMeta(engineId = "unknown", dateTranslated = 0L, content = raw)
         }
     }
 
-    override suspend fun hasTranslation(chapterId: Long, targetLanguage: String): Boolean {
-        return handler.awaitOne {
-            translated_chaptersQueries.hasTranslation(chapterId, targetLanguage)
-        }
-    }
+    // ── Read operations ───────────────────────────────────────────────
 
-    override fun getChaptersWithTranslationsAsFlow(mangaId: Long): Flow<List<TranslationInfo>> {
-        return handler.subscribeToList {
-            translated_chaptersQueries.getChaptersWithTranslations(mangaId)
-        }.map { list ->
-            list.map { row ->
-                TranslationInfo(
-                    chapterId = row.chapter_id,
-                    targetLanguage = row.target_language,
-                    engineId = row.engine_id,
-                    dateTranslated = row.date_translated,
+    override suspend fun getTranslatedChapter(chapterId: Long, targetLanguage: String): TranslatedChapter? =
+        withContext(Dispatchers.IO) {
+            val file = findTranslationFile(chapterId, targetLanguage) ?: return@withContext null
+            val meta = parseUniFile(file) ?: return@withContext null
+            TranslatedChapter(
+                chapterId = chapterId,
+                mangaId = 0,
+                targetLanguage = targetLanguage,
+                engineId = meta.engineId,
+                translatedContent = meta.content,
+                dateTranslated = meta.dateTranslated,
+            )
+        }
+
+    override suspend fun getAllTranslationsForChapter(chapterId: Long): List<TranslatedChapter> =
+        withContext(Dispatchers.IO) {
+            val prefix = "${chapterId}_"
+            val dir = translationsDir
+            dir.listFiles()
+                ?.filter { it.name?.startsWith(prefix) == true && it.name?.endsWith(".html") == true }
+                ?.mapNotNull { file ->
+                    val nameWithoutExt = file.nameWithoutExtension ?: return@mapNotNull null
+                    val lang = nameWithoutExt.removePrefix(prefix)
+                    val meta = parseUniFile(file) ?: return@mapNotNull null
+                    TranslatedChapter(
+                        chapterId = chapterId,
+                        mangaId = 0,
+                        targetLanguage = lang,
+                        engineId = meta.engineId,
+                        translatedContent = meta.content,
+                        dateTranslated = meta.dateTranslated,
+                    )
+                }
+                .orEmpty()
+        }
+
+    override suspend fun hasTranslation(chapterId: Long, targetLanguage: String): Boolean =
+        withContext(Dispatchers.IO) {
+            findTranslationFile(chapterId, targetLanguage) != null
+        }
+
+    /**
+     * Check if a partial (tmp) translation exists for a chapter.
+     */
+    override suspend fun hasTmpTranslation(chapterId: Long, targetLanguage: String): Boolean =
+        withContext(Dispatchers.IO) {
+            val name = getTmpTranslationFileName(chapterId, targetLanguage)
+            translationsDir.findFile(name) != null
+        }
+
+    override suspend fun getTranslatedChapterIds(chapterIds: Collection<Long>): Set<Long> =
+        withContext(Dispatchers.IO) {
+            if (chapterIds.isEmpty()) return@withContext emptySet()
+            val dir = translationsDir
+            val allFiles = dir.listFiles() ?: return@withContext emptySet()
+            val wantedIds = chapterIds.toHashSet()
+            allFiles.asSequence()
+                .filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
+                .mapNotNull { it.nameWithoutExtension?.substringBefore('_')?.toLongOrNull() }
+                .filter { it in wantedIds }
+                .toSet()
+        }
+
+    override suspend fun getTranslatedLanguagesForChapters(chapterIds: Collection<Long>): List<String> =
+        withContext(Dispatchers.IO) {
+            if (chapterIds.isEmpty()) return@withContext emptyList()
+            val dir = translationsDir
+            val allFiles = dir.listFiles() ?: return@withContext emptyList()
+            val wantedIds = chapterIds.toHashSet()
+            allFiles.asSequence()
+                .filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
+                .filter { it.nameWithoutExtension?.substringBefore('_')?.toLongOrNull() in wantedIds }
+                .mapNotNull { it.nameWithoutExtension?.substringAfter('_') }
+                .distinct()
+                .toList()
+        }
+
+    override suspend fun getAll(): List<TranslatedChapter> = withContext(Dispatchers.IO) {
+        val dir = translationsDir
+        dir.listFiles()
+            ?.filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
+            ?.mapNotNull { file ->
+                val nameWithoutExt = file.nameWithoutExtension ?: return@mapNotNull null
+                val parts = nameWithoutExt.split('_', limit = 2)
+                if (parts.size != 2) return@mapNotNull null
+                val chapterId = parts[0].toLongOrNull() ?: return@mapNotNull null
+                val lang = parts[1]
+                val meta = parseUniFile(file) ?: return@mapNotNull null
+                TranslatedChapter(
+                    chapterId = chapterId,
+                    mangaId = 0,
+                    targetLanguage = lang,
+                    engineId = meta.engineId,
+                    translatedContent = meta.content,
+                    dateTranslated = meta.dateTranslated,
                 )
             }
-        }
+            .orEmpty()
     }
 
-    override suspend fun getChaptersWithTranslations(mangaId: Long): List<TranslationInfo> {
-        return handler.awaitList {
-            translated_chaptersQueries.getChaptersWithTranslations(mangaId)
-        }.map { row ->
-            TranslationInfo(
-                chapterId = row.chapter_id,
-                targetLanguage = row.target_language,
-                engineId = row.engine_id,
-                dateTranslated = row.date_translated,
+    // ── Write operations ──────────────────────────────────────────────
+
+    override suspend fun upsertTranslation(translatedChapter: TranslatedChapter) =
+        withContext(Dispatchers.IO) {
+            val dir = translationsDir
+            val name = getTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
+            val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
+            val content = (meta + translatedChapter.translatedContent).toByteArray()
+
+            // Delete existing file first (createFile may fail if it already exists on some backends)
+            dir.findFile(name)?.delete()
+            val file = dir.createFile(name)
+                ?: throw IllegalStateException("Failed to create translation file: $name")
+            file.openOutputStream().use { it.write(content) }
+
+            // Remove any tmp file for this chapter+language
+            val tmpName = getTmpTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
+            dir.findFile(tmpName)?.delete()
+            Unit
+        }
+
+    /**
+     * Save a partial (in-progress) translation with .tmp extension.
+     * This allows resuming incomplete translations.
+     */
+    override suspend fun upsertTmpTranslation(translatedChapter: TranslatedChapter) =
+        withContext(Dispatchers.IO) {
+            val dir = translationsDir
+            val name = getTmpTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
+            val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
+            val content = (meta + translatedChapter.translatedContent).toByteArray()
+
+            dir.findFile(name)?.delete()
+            val file = dir.createFile(name)
+                ?: throw IllegalStateException("Failed to create tmp translation file: $name")
+            file.openOutputStream().use { it.write(content) }
+        }
+
+    /**
+     * Read a partial (in-progress) translation.
+     */
+    override suspend fun getTmpTranslation(chapterId: Long, targetLanguage: String): TranslatedChapter? =
+        withContext(Dispatchers.IO) {
+            val name = getTmpTranslationFileName(chapterId, targetLanguage)
+            val file = translationsDir.findFile(name) ?: return@withContext null
+            val meta = parseUniFile(file) ?: return@withContext null
+            TranslatedChapter(
+                chapterId = chapterId,
+                mangaId = 0,
+                targetLanguage = targetLanguage,
+                engineId = meta.engineId,
+                translatedContent = meta.content,
+                dateTranslated = meta.dateTranslated,
             )
         }
+
+    /**
+     * Promote a tmp translation to a final one (remove .tmp extension).
+     */
+    suspend fun promoteTmpTranslation(chapterId: Long, targetLanguage: String): Boolean =
+        withContext(Dispatchers.IO) {
+            val tmpName = getTmpTranslationFileName(chapterId, targetLanguage)
+            val tmpFile = translationsDir.findFile(tmpName) ?: return@withContext false
+            val meta = parseUniFile(tmpFile) ?: return@withContext false
+
+            // Write final file
+            val dir = translationsDir
+            val finalName = getTranslationFileName(chapterId, targetLanguage)
+            dir.findFile(finalName)?.delete()
+            val finalFile = dir.createFile(finalName) ?: return@withContext false
+            val metaComment = buildMetaComment(meta.engineId, meta.dateTranslated)
+            finalFile.openOutputStream().use { it.write((metaComment + meta.content).toByteArray()) }
+
+            // Delete tmp
+            tmpFile.delete()
+            true
+        }
+
+    // ── Delete operations ─────────────────────────────────────────────
+
+    override suspend fun deleteTranslation(chapterId: Long, targetLanguage: String) =
+        withContext(Dispatchers.IO) {
+            findTranslationFile(chapterId, targetLanguage)?.delete()
+            // Also delete any tmp file
+            val tmpName = getTmpTranslationFileName(chapterId, targetLanguage)
+            translationsDir.findFile(tmpName)?.delete()
+            Unit
+        }
+
+    override suspend fun deleteAllForChapter(chapterId: Long) = withContext(Dispatchers.IO) {
+        val prefix = "${chapterId}_"
+        val dir = translationsDir
+        dir.listFiles()
+            ?.filter { it.name?.startsWith(prefix) == true }
+            ?.forEach { it.delete() }
+        Unit
     }
 
-    override suspend fun getTranslatedChapterIds(mangaId: Long): Set<Long> {
-        return handler.awaitList {
-            translated_chaptersQueries.getChaptersWithTranslations(mangaId)
-        }.map { it.chapter_id }.toSet()
-    }
-
-    override suspend fun upsertTranslation(translatedChapter: TranslatedChapter) {
-        val file = getTranslationFile(translatedChapter.chapterId, translatedChapter.targetLanguage)
-        file.writeText(translatedChapter.translatedContent)
-
-        handler.await {
-            translated_chaptersQueries.upsert(
-                chapterId = translatedChapter.chapterId,
-                mangaId = translatedChapter.mangaId,
-                targetLanguage = translatedChapter.targetLanguage,
-                engineId = translatedChapter.engineId,
-                translatedContent = "",
-                dateTranslated = translatedChapter.dateTranslated,
-                isCached = translatedChapter.isCached,
-            )
-        }
-    }
-
-    override suspend fun deleteTranslation(chapterId: Long, targetLanguage: String) {
-        getTranslationFile(chapterId, targetLanguage).delete()
-        handler.await {
-            translated_chaptersQueries.deleteTranslation(chapterId, targetLanguage)
-        }
-    }
-
-    override suspend fun deleteAllForChapter(chapterId: Long) {
-        val translations = handler.awaitList {
-            translated_chaptersQueries.getAllTranslationsForChapter(chapterId)
-        }
-        translations.forEach {
-            getTranslationFile(chapterId, it.target_language).delete()
-        }
-
-        handler.await {
-            translated_chaptersQueries.deleteAllForChapter(chapterId)
-        }
-    }
-
-    override suspend fun deleteAllForManga(mangaId: Long) {
-        val translations = handler.awaitList {
-            translated_chaptersQueries.getChaptersWithTranslations(mangaId)
-        }
-        translations.forEach {
-            getTranslationFile(it.chapter_id, it.target_language).delete()
-        }
-
-        handler.await {
-            translated_chaptersQueries.deleteAllForManga(mangaId)
-        }
-    }
-
-    override suspend fun deleteAll() {
-        translationsDir.deleteRecursively()
-        translationsDir.mkdirs()
-        handler.await {
-            translated_chaptersQueries.deleteAll()
-        }
-    }
-
-    override suspend fun getAll(): List<TranslatedChapter> {
-        return handler.awaitList {
-            translated_chaptersQueries.getAll()
-        }.map { record ->
-            val content = if (record.translated_content.isEmpty()) {
-                val file = getTranslationFile(record.chapter_id, record.target_language)
-                if (file.exists()) file.readText() else ""
-            } else {
-                record.translated_content
+    override suspend fun deleteAllForChapters(chapterIds: Collection<Long>) = withContext(Dispatchers.IO) {
+        if (chapterIds.isEmpty()) return@withContext
+        val wantedIds = chapterIds.toHashSet()
+        val dir = translationsDir
+        dir.listFiles()
+            ?.filter {
+                val name = it.name ?: return@filter false
+                name.endsWith(".html") || name.endsWith(".html.tmp")
             }
-            record.toTranslatedChapter().copy(translatedContent = content)
-        }
+            ?.filter {
+                val nameNoExt = it.name?.substringBefore('_') ?: return@filter false
+                nameNoExt.toLongOrNull() in wantedIds
+            }
+            ?.forEach { it.delete() }
+        Unit
     }
 
-    override suspend fun getCacheSize(): Long {
-        return translationsDir.walkTopDown().filter { it.isFile }.map { it.length() }.sum()
+    override suspend fun deleteAll() = withContext(Dispatchers.IO) {
+        val dir = translationsDir
+        dir.listFiles()?.forEach { it.delete() }
+        Unit
     }
 
-    override suspend fun clearOldCache(olderThan: Long) {
-        val toDelete = handler.awaitList {
-            translated_chaptersQueries.getOldCachedTranslations(olderThan)
-        }
-        toDelete.forEach {
-            getTranslationFile(it.chapter_id, it.target_language).delete()
-        }
-        handler.await {
-            translated_chaptersQueries.clearOldCache(olderThan)
-        }
+    // ── Cache management ──────────────────────────────────────────────
+
+    override suspend fun getCacheSize(): Long = withContext(Dispatchers.IO) {
+        val dir = translationsDir
+        dir.listFiles()
+            ?.filter { it.isFile }
+            ?.sumOf { it.length() }
+            ?: 0L
     }
 
-    private fun tachiyomi.data.Translated_chapters.toTranslatedChapter(): TranslatedChapter {
-        return TranslatedChapter(
-            id = _id,
-            chapterId = chapter_id,
-            mangaId = manga_id,
-            targetLanguage = target_language,
-            engineId = engine_id,
-            translatedContent = translated_content,
-            dateTranslated = date_translated,
-            isCached = is_cached,
-        )
+    override suspend fun clearOldCache(olderThan: Long) = withContext(Dispatchers.IO) {
+        val dir = translationsDir
+        dir.listFiles()
+            ?.filter { it.name?.endsWith(".html") == true || it.name?.endsWith(".html.tmp") == true }
+            ?.filter { it.lastModified() < olderThan }
+            ?.forEach { it.delete() }
+        Unit
+    }
+
+    override suspend fun clearTmpFiles(): Long = withContext(Dispatchers.IO) {
+        val dir = translationsDir
+        var freed = 0L
+        dir.listFiles()
+            ?.filter { it.name?.endsWith(".html.tmp") == true }
+            ?.forEach {
+                freed += it.length()
+                it.delete()
+            }
+        freed
     }
 }

--- a/data/src/main/sqldelight/tachiyomi/migrations/22.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/22.sqm
@@ -1,0 +1,5 @@
+-- Remove translated_chapters table: translations now stored entirely on filesystem
+DROP INDEX IF EXISTS translated_chapters_chapter_id_index;
+DROP INDEX IF EXISTS translated_chapters_manga_id_index;
+DROP INDEX IF EXISTS translated_chapters_language_index;
+DROP TABLE IF EXISTS translated_chapters;

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -41,6 +41,11 @@ class DownloadPreferences(
 
     fun parallelPageLimit() = preferenceStore.getInt("download_parallel_page_limit", 5)
 
+    /**
+     * EPUB compression level (0-9). -1 = default, 0 = stored (no compression), 9 = max compression.
+     */
+    fun epubCompressionLevel() = preferenceStore.getInt("epub_compression_level", -1)
+
     companion object {
         private const val REMOVE_EXCLUDE_CATEGORIES_PREF_KEY = "remove_exclude_categories"
         private const val DOWNLOAD_NEW_CATEGORIES_PREF_KEY = "download_new_categories"

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -98,11 +98,6 @@ class LibraryPreferences(
         TriState.DISABLED,
     )
 
-    fun filterCustomExtension() = preferenceStore.getEnum(
-        "pref_filter_library_custom_extension",
-        TriState.DISABLED,
-    )
-
     fun filterIntervalCustom() = preferenceStore.getEnum(
         "pref_filter_library_interval_custom",
         TriState.DISABLED,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -98,6 +98,11 @@ class LibraryPreferences(
         TriState.DISABLED,
     )
 
+    fun filterCustomExtension() = preferenceStore.getEnum(
+        "pref_filter_library_custom_extension",
+        TriState.DISABLED,
+    )
+
     fun filterIntervalCustom() = preferenceStore.getEnum(
         "pref_filter_library_interval_custom",
         TriState.DISABLED,
@@ -140,6 +145,15 @@ class LibraryPreferences(
     fun searchChapterContent() = preferenceStore.getBoolean("pref_search_chapter_content", false)
     fun searchByUrl() = preferenceStore.getBoolean("pref_search_by_url", false)
     fun useRegexSearch() = preferenceStore.getBoolean("pref_use_regex_search", false)
+
+    fun filterChapterCount() = preferenceStore.getEnum(
+        "pref_filter_library_chapter_count",
+        TriState.DISABLED,
+    )
+    fun filterChapterCountThreshold() = preferenceStore.getInt(
+        "pref_filter_library_chapter_count_threshold",
+        10,
+    )
 
     // endregion
 
@@ -263,6 +277,18 @@ class LibraryPreferences(
 
     fun mangaReadProgress100() = preferenceStore.getBoolean("pref_manga_read_progress_100", true)
     fun novelReadProgress100() = preferenceStore.getBoolean("pref_novel_read_progress_100", true)
+
+    /**
+     * Source type priorities for duplicate detection.
+     * Stored as semicolon-delimited "TYPE:PRIORITY" pairs, e.g. "JS:3;KT:1;CUSTOM:0;LOCAL:-2;STUB:-5"
+     */
+    fun sourceTypePriorities() = preferenceStore.getString("source_type_priorities", "")
+
+    /**
+     * Specific source priorities for duplicate detection.
+     * Stored as semicolon-delimited "SOURCE_ID:PRIORITY" pairs, e.g. "123456:3;789012:-2"
+     */
+    fun specificSourcePriorities() = preferenceStore.getString("specific_source_priorities", "")
 
     // endregion
 

--- a/domain/src/main/java/tachiyomi/domain/storage/service/StorageManager.kt
+++ b/domain/src/main/java/tachiyomi/domain/storage/service/StorageManager.kt
@@ -40,6 +40,7 @@ class StorageManager(
                     parent.createDirectory(LOCAL_NOVEL_SOURCE_PATH)
                     parent.createDirectory(LNREADER_PLUGINS_PATH)
                     parent.createDirectory(FONTS_PATH)
+                    parent.createDirectory(TRANSLATIONS_PATH)
                     parent.createDirectory(DOWNLOADS_PATH).also {
                         DiskUtil.createNoMediaFile(it, context)
                     }
@@ -77,6 +78,10 @@ class StorageManager(
     fun getFontsDirectory(): UniFile? {
         return baseDir?.createDirectory(FONTS_PATH)
     }
+
+    fun getTranslationsDirectory(): UniFile? {
+        return baseDir?.createDirectory(TRANSLATIONS_PATH)
+    }
 }
 
 private const val AUTOMATIC_BACKUPS_PATH = "autobackup"
@@ -85,3 +90,4 @@ private const val LOCAL_SOURCE_PATH = "local"
 private const val LOCAL_NOVEL_SOURCE_PATH = "localnovels"
 private const val LNREADER_PLUGINS_PATH = "lnreader_plugins"
 private const val FONTS_PATH = "fonts"
+private const val TRANSLATIONS_PATH = "translations"

--- a/domain/src/main/java/tachiyomi/domain/translation/model/TranslationModels.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/model/TranslationModels.kt
@@ -1,17 +1,15 @@
 package tachiyomi.domain.translation.model
 
 /**
- * Represents a translated chapter stored in the database.
+ * Represents a translated chapter stored on the filesystem.
  */
 data class TranslatedChapter(
-    val id: Long = 0,
     val chapterId: Long,
     val mangaId: Long,
     val targetLanguage: String,
     val engineId: String,
     val translatedContent: String,
     val dateTranslated: Long = System.currentTimeMillis(),
-    val isCached: Boolean = true,
 )
 
 /**
@@ -21,6 +19,7 @@ data class TranslationTask(
     val id: Long = 0,
     val chapterId: Long,
     val mangaId: Long,
+    val chapterName: String = "",
     val sourceLanguage: String,
     val targetLanguage: String,
     val engineId: Long,
@@ -29,6 +28,7 @@ data class TranslationTask(
     val errorMessage: String? = null,
     val retryCount: Int = 0,
     val createdAt: Long = System.currentTimeMillis(),
+    val forceRetranslate: Boolean = false,
 )
 
 /**
@@ -53,6 +53,9 @@ data class TranslationProgress(
     val currentChapterProgress: Float, // 0.0 to 1.0
     val isRunning: Boolean,
     val isPaused: Boolean,
+    val currentChunkIndex: Int = 0,
+    val totalChunks: Int = 0,
+    val isCancelling: Boolean = false,
 ) {
     val overallProgress: Float
         get() = if (totalChapters > 0) {
@@ -79,3 +82,21 @@ data class TranslatedLanguages(
     val mangaId: Long,
     val languages: List<String>,
 )
+
+/**
+ * Controls which content variant is used for EPUB export.
+ */
+enum class TranslationMode(val key: String) {
+    /** Export only the original (source) content. */
+    ORIGINAL("original"),
+    /** Export only translated content; skip chapters without a translation. */
+    TRANSLATED("translated"),
+    /** Export two separate EPUB files — one original, one translated. */
+    BOTH("both"),
+    ;
+
+    companion object {
+        fun fromKey(key: String): TranslationMode =
+            entries.firstOrNull { it.key == key } ?: ORIGINAL
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -1,11 +1,10 @@
 package tachiyomi.domain.translation.repository
 
-import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.translation.model.TranslatedChapter
-import tachiyomi.domain.translation.model.TranslationInfo
 
 /**
  * Repository interface for managing translated chapters.
+ * All storage is filesystem-based (no database table).
  */
 interface TranslatedChapterRepository {
 
@@ -20,29 +19,19 @@ interface TranslatedChapterRepository {
     suspend fun getAllTranslationsForChapter(chapterId: Long): List<TranslatedChapter>
 
     /**
-     * Get all translated languages for a manga.
-     */
-    suspend fun getTranslatedLanguagesForManga(mangaId: Long): List<String>
-
-    /**
      * Check if a chapter has a translation for a specific language.
      */
     suspend fun hasTranslation(chapterId: Long, targetLanguage: String): Boolean
 
     /**
-     * Get chapters with translations for a manga.
+     * Get set of chapter IDs that have any translation, from the given candidate IDs.
      */
-    fun getChaptersWithTranslationsAsFlow(mangaId: Long): Flow<List<TranslationInfo>>
+    suspend fun getTranslatedChapterIds(chapterIds: Collection<Long>): Set<Long>
 
     /**
-     * Get chapters with translations for a manga (suspend).
+     * Get all distinct languages across the given chapter IDs.
      */
-    suspend fun getChaptersWithTranslations(mangaId: Long): List<TranslationInfo>
-
-    /**
-     * Get set of chapter IDs that have any translation for a manga.
-     */
-    suspend fun getTranslatedChapterIds(mangaId: Long): Set<Long>
+    suspend fun getTranslatedLanguagesForChapters(chapterIds: Collection<Long>): List<String>
 
     /**
      * Insert or update a translated chapter.
@@ -54,8 +43,14 @@ interface TranslatedChapterRepository {
      */
     suspend fun deleteTranslation(chapterId: Long, targetLanguage: String)
 
+    /**
+     * Delete all translations.
+     */
     suspend fun deleteAll()
 
+    /**
+     * Get all translations.
+     */
     suspend fun getAll(): List<TranslatedChapter>
 
     /**
@@ -64,9 +59,9 @@ interface TranslatedChapterRepository {
     suspend fun deleteAllForChapter(chapterId: Long)
 
     /**
-     * Delete all translations for a manga.
+     * Delete all translations for chapters belonging to a manga.
      */
-    suspend fun deleteAllForManga(mangaId: Long)
+    suspend fun deleteAllForChapters(chapterIds: Collection<Long>)
 
     /**
      * Get the total cache size in bytes.
@@ -77,4 +72,25 @@ interface TranslatedChapterRepository {
      * Clear old cached translations.
      */
     suspend fun clearOldCache(olderThan: Long)
+
+    /**
+     * Clear temporary (.tmp) translation files.
+     * Returns the number of bytes freed.
+     */
+    suspend fun clearTmpFiles(): Long
+
+    /**
+     * Insert or update a partial (.tmp) translation (for resume support).
+     */
+    suspend fun upsertTmpTranslation(translatedChapter: TranslatedChapter)
+
+    /**
+     * Get a partial (.tmp) translation if one exists.
+     */
+    suspend fun getTmpTranslation(chapterId: Long, targetLanguage: String): TranslatedChapter?
+
+    /**
+     * Check if a partial (.tmp) translation exists.
+     */
+    suspend fun hasTmpTranslation(chapterId: Long, targetLanguage: String): Boolean
 }

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -66,6 +66,15 @@ class TranslationPreferences(
     )
 
     /**
+     * Smart auto-translate: skip translation if detected language matches target.
+     * Consolidated from ReaderPreferences.autoTranslate() (pref_auto_translate).
+     */
+    fun smartAutoTranslate() = preferenceStore.getBoolean(
+        "pref_auto_translate",
+        false,
+    )
+
+    /**
      * Chapter count threshold to show rate limit warning.
      */
     fun rateLimitWarningThreshold() = preferenceStore.getInt(
@@ -289,16 +298,7 @@ class TranslationPreferences(
     )
 
     /**
-     * Translation chunk mode: "paragraphs", "characters", or "words"
-     */
-    fun translationChunkMode() = preferenceStore.getString(
-        "translation_chunk_mode",
-        "paragraphs",
-    )
-
-    /**
-     * Maximum chunk size per translation batch.
-     * Meaning depends on chunkMode: paragraphs count, character count, or word count.
+     * Maximum chunk size per translation batch (in paragraphs).
      */
     fun translationChunkSize() = preferenceStore.getInt(
         "translation_chunk_size",

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -56,6 +56,7 @@
 
     <!-- Notification channels -->
     <string name="channel_mass_import">Mass Import</string>
+    <string name="channel_translation">Translation</string>
     <string name="mass_import_progress_title">Mass Import Progress</string>
     <string name="mass_import_complete_title">Mass Import Complete</string>
 
@@ -72,18 +73,8 @@
     <string name="novel_add_snippet">Add snippet</string>
     <string name="novel_edit_snippet">Edit snippet</string>
     <string name="novel_delete_snippet">Delete snippet</string>
-    <string name="novel_edit_css_snippet">Edit CSS snippet</string>
-    <string name="novel_add_css_snippet">Add CSS snippet</string>
-    <string name="novel_edit_js_snippet">Edit JS snippet</string>
-    <string name="novel_add_js_snippet">Add JS snippet</string>
-    <string name="pref_novel_js_snippets">JS Snippets</string>
 
-    <!-- Novel TTS Settings -->
-    <string name="pref_novel_tts_section">Text to Speech</string>
-    <string name="pref_novel_tts_voice">Voice</string>
-    <string name="pref_novel_tts_speed">Speech speed</string>
-    <string name="pref_novel_tts_pitch">Speech pitch</string>
-    <string name="pref_novel_tts_auto_next">Auto-play next chapter</string>
+    <!-- Novel TTS Settings (see also TTS Settings section below) -->
 
     <!-- Novel Reader Actions (In MR)
     add_to_library: Add to library
@@ -96,6 +87,30 @@
     <string name="action_scroll_to_bottom">Scroll to bottom</string>
     <string name="action_translate">Translate</string>
     <string name="action_translate_downloaded">Translate downloaded chapters</string>
+    <string name="action_retranslate">Retranslate</string>
+    <string name="translation_smart_auto">Smart Auto-Translate</string>
+    <string name="translation_smart_auto_summary">Only translate if language differs from target</string>
+    <string name="translation_select_target_language">Select target language for translation</string>
+    <string name="translation_job_translating">Translating chapters…</string>
+    <string name="translation_job_processing">Processing…</string>
+    <string name="translation_job_complete">Translation Complete</string>
+    <string name="translation_job_complete_count">%d chapters translated</string>
+    <string name="action_delete_translation">Delete translation</string>
+    <string name="translated_chapters">Translated chapters</string>
+    <!-- Translate manga details dialog -->
+    <string name="translate_details_title">Translate Details</string>
+    <string name="translate_details_no_engine">No translation engine configured. Please configure one in Settings &gt; Translation.</string>
+    <string name="translate_details_translating">Translating…</string>
+    <string name="translate_details_original_title">Original Title:</string>
+    <string name="translate_details_translated_title">Translated Title:</string>
+    <string name="translate_details_add_alt_titles">Add translated title to alternative titles</string>
+    <string name="translate_details_save_tags_notes">Save translated tags to notes</string>
+    <string name="translate_details_original_desc">Original Description:</string>
+    <string name="translate_details_translated_desc">Translated Description:</string>
+    <string name="translate_details_original_genres">Original Genres:</string>
+    <string name="translate_details_translated_genres">Translated Genres:</string>
+    <string name="translate_details_save_genres">Save translated genres</string>
+    <string name="translate_details_merge_genres">Add to existing genres (don\'t replace)</string>
     <string name="action_export_epub">Export as EPUB</string>
     <string name="action_export_epub_bulk">Export selected as EPUB</string>
     <string name="export_epub_progress">Exporting %1$d of %2$d chapters…</string>
@@ -110,13 +125,7 @@
     <string name="action_copy_links">Copy links</string>
     <string name="action_mass_import">Mass import</string>
 
-    <!-- Novel Translation Settings (reader panel) -->
-    <string name="pref_novel_translation_settings">Translation</string>
-    <string name="pref_novel_translation_enabled">Enable translation</string>
-    <string name="pref_novel_realtime_translation">Real-time translation</string>
-    <string name="pref_novel_translation_engine_label">Engine</string>
-    <string name="pref_novel_translation_target_label">Target language</string>
-    <string name="pref_novel_translation_hint">Configure translation engine and API keys in Settings → Translation</string>
+    <!-- Novel Translation Settings (see Translation Settings section below) -->
 
     <!-- Novel Download Settings -->
     <string name="pref_novel_reader_summary">Novel reading mode, fonts, colors</string>
@@ -124,8 +133,10 @@
     <string name="pref_novel_download_throttling_summary">Add delays between downloads to avoid rate limiting</string>
     <string name="pref_novel_download_delay">Download delay</string>
     <string name="pref_novel_download_delay_summary">Base delay between chapter downloads (ms)</string>
-    <string name="pref_novel_random_delay">Random delay range</string>
-    <string name="pref_novel_random_delay_summary">Additional random delay (0 to this value in ms)</string>
+    <string name="pref_novel_random_delay">Random delay max</string>
+    <string name="pref_novel_random_delay_summary">Maximum random delay added to base delay (ms)</string>
+    <string name="pref_novel_random_delay_min">Random delay min</string>
+    <string name="pref_novel_random_delay_min_summary">Minimum random delay added to base delay (ms)</string>
     <string name="pref_novel_update_throttling">Update throttling</string>
     <string name="pref_novel_update_throttling_summary">Add delays during library updates for novels</string>
     <string name="pref_novel_update_delay">Update delay</string>
@@ -134,7 +145,21 @@
     <string name="pref_novel_mass_import_throttling_summary">Add delays during mass import operations</string>
     <string name="pref_novel_mass_import_delay">Mass import delay</string>
     <string name="pref_novel_mass_import_delay_summary">Delay between imports (ms)</string>
+    <string name="pref_novel_low_delay_warning">\n⚠ Low delay values may cause sources to rate-limit or block your IP. A minimum of 3 seconds is recommended.</string>
+    <string name="pref_novel_update_delay_subtitle">Delay between novels for the same extension</string>
+    <string name="pref_novel_parallel_updates">Parallel novel updates</string>
+    <string name="pref_novel_parallel_updates_summary">Number of different extensions updating simultaneously (not within same extension)</string>
+    <string name="pref_novel_mass_import_category">Mass Import</string>
+    <string name="pref_novel_mass_import_throttling_subtitle">Apply delays between novels from the same source only</string>
+    <string name="pref_novel_mass_import_delay_subtitle">Delay between imports from the same source (different sources run concurrently)</string>
+    <string name="pref_novel_concurrent_imports">Concurrent Mass Imports</string>
+    <string name="pref_novel_concurrent_imports_summary">Number of different sources importing simultaneously (throttle between same source is in delay setting)</string>
+    <string name="pref_novel_deflate_level">Deflate level %d</string>
     <string name="pref_novel_parallel_downloads">Parallel novel downloads</string>
+    <string name="pref_novel_resume_queue_on_new">Resume queue on new chapters</string>
+    <string name="pref_novel_resume_queue_on_new_summary">Automatically resume paused download queue when new chapters are added</string>
+    <string name="pref_novel_compression_level">ZIP compression level</string>
+    <string name="pref_novel_compression_level_summary">0 = store (no compression, fastest), 1-9 = deflate (smaller files, slower)</string>
 
     <!-- Novel Image Embedding -->
     <string name="pref_novel_download_images">Download chapter images</string>
@@ -184,6 +209,12 @@
     <string name="epub_content_options">Content Options</string>
     <string name="epub_downloaded_only">Downloaded chapters only</string>
     <string name="epub_prefer_translated">Prefer translated chapters</string>
+    <string name="epub_translation_mode">Translation</string>
+    <string name="epub_translation_original">Original only</string>
+    <string name="epub_translation_translated">Translated only</string>
+    <string name="epub_translation_both">Both (two separate files)</string>
+    <string name="epub_translation_translated_info">Only chapters with translations will be included.</string>
+    <string name="epub_translation_both_info">Two EPUB files will be created — one original, one translated.</string>
     <string name="epub_filename_options">Filename Options</string>
     <string name="epub_include_chapter_count">Include chapter count (e.g. [50ch])</string>
     <string name="epub_include_chapter_range">Include chapter range (e.g. [ch1-50])</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -58,6 +58,7 @@
     <string name="action_filter_tracked">Tracked</string>
     <string name="action_filter_unread">Unread</string>
     <string name="action_filter_interval_custom">Customized update frequency</string>
+    <string name="action_filter_custom_extension">Custom extension</string>
     <!-- reserved for #4048 -->
     <string name="action_filter_empty">Remove filter</string>
     <string name="action_sort_alpha">Alphabetically</string>
@@ -95,6 +96,7 @@
     <string name="action_add_category">Add category</string>
     <string name="action_edit_categories">Edit categories</string>
     <string name="action_rename_category">Rename category</string>
+    <string name="action_move">Move</string>
     <string name="action_move_category">Set categories</string>
     <string name="delete_category_confirmation">Do you wish to delete the category \"%s\"?</string>
     <string name="delete_category">Delete category</string>
@@ -882,10 +884,85 @@
     <string name="migration_dialog_what_to_include">Select data to include</string>
     <string name="migration_selection_prompt">Select a source to migrate from</string>
     <string name="migrate">Migrate</string>
+    <string name="action_quick_migrate">Quick</string>
+    <string name="quick_migrate_select_source">Select target source</string>
+    <string name="quick_migrate_confirm_message">Update source to \"%1$s\" for %2$d entries?</string>
+    <string name="quick_migrate_skip_message">%1$d entries will be skipped (already exist in target)</string>
+    <string name="quick_migrate_complete">Quick migrated %1$d entries</string>
     <!-- Make a copy (noun) when migrating. Don't use for copying to clipboard. -->
     <string name="copy">Copy</string>
     <string name="empty_screen">Well, this is awkward</string>
     <string name="not_installed">Not installed</string>
+
+    <!-- Duplicate detection screen -->
+    <string name="duplicate_find_duplicates">Find Duplicates</string>
+    <string name="duplicate_n_selected">%d selected</string>
+    <string name="duplicate_copy_links">Copy Links</string>
+    <string name="duplicate_delete_selected">Delete Selected</string>
+    <string name="duplicate_move_to_category">Move to Category</string>
+    <string name="duplicate_selection_options">Selection Options</string>
+    <string name="duplicate_select_all">Select ALL Duplicates</string>
+    <string name="duplicate_select_all_except_first">Select All Except First</string>
+    <string name="duplicate_select_lowest_ch">Select With Lowest Ch Count</string>
+    <string name="duplicate_select_highest_ch">Select With Highest Ch Count</string>
+    <string name="duplicate_select_highest_dl">Select With Highest Downloads</string>
+    <string name="duplicate_select_lowest_dl">Select With Lowest Downloads</string>
+    <string name="duplicate_select_highest_read">Select With Highest Read Count</string>
+    <string name="duplicate_select_lowest_read">Select With Lowest Read Count</string>
+    <string name="duplicate_select_pinned">Select Pinned Sources</string>
+    <string name="duplicate_select_non_pinned">Select Non-Pinned Sources</string>
+    <string name="duplicate_select_lowest_priority">Select Lowest Priority</string>
+    <string name="duplicate_select_highest_priority">Select Highest Priority</string>
+    <string name="duplicate_clear_selection">Clear Selection</string>
+    <string name="duplicate_invert_selection">Invert Selection</string>
+    <string name="duplicate_match_exact">Exact</string>
+    <string name="duplicate_match_contains">Contains</string>
+    <string name="duplicate_match_url">Same URL</string>
+    <string name="duplicate_filters_sort">Filters &amp; Sort</string>
+    <string name="duplicate_type_label">Type:</string>
+    <string name="duplicate_type_all">All</string>
+    <string name="duplicate_type_manga">Manga</string>
+    <string name="duplicate_type_novel">Novel</string>
+    <string name="duplicate_show_full_urls">Show full URLs</string>
+    <string name="duplicate_sort_label">Sort:</string>
+    <string name="duplicate_sort_name">Name</string>
+    <string name="duplicate_sort_latest">Latest</string>
+    <string name="duplicate_sort_ch_desc">Ch↓</string>
+    <string name="duplicate_sort_dl_desc">DL↓</string>
+    <string name="duplicate_sort_read_desc">Read↓</string>
+    <string name="duplicate_category_label">Category:</string>
+    <string name="duplicate_category_clear">Clear</string>
+    <string name="duplicate_source_priority">Source Priority</string>
+    <string name="duplicate_source_priority_desc">Set priority per source type. Higher = preferred when resolving duplicates.</string>
+    <string name="duplicate_specific_source_priority">Individual Source Priority</string>
+    <string name="duplicate_specific_source_priority_desc">Override priority for specific sources. Takes precedence over type-level priority.</string>
+    <string name="duplicate_source_type_js">JS Plugin</string>
+    <string name="duplicate_source_type_kt">KT Ext</string>
+    <string name="duplicate_source_type_custom">Custom</string>
+    <string name="duplicate_source_type_local">Local</string>
+    <string name="duplicate_sort_priority">Priority</string>
+    <string name="duplicate_initial_title">Find Duplicate Entries</string>
+    <string name="duplicate_initial_description">Analyze your library to find duplicate entries.\nSelect a match mode above and click Start.</string>
+    <string name="duplicate_start_analysis">Start Analysis</string>
+    <string name="duplicate_no_duplicates">No duplicates found in your library.</string>
+    <string name="duplicate_no_matches_filter">No duplicates match the selected filters.</string>
+    <string name="duplicate_reanalyze">Re-analyze</string>
+    <string name="duplicate_results_summary">Found %1$d groups with %2$d potential duplicates</string>
+    <string name="duplicate_results_filtered"> (filtered)</string>
+    <string name="duplicate_urls_copied">%d URLs copied</string>
+    <string name="duplicate_deleted_count">Deleted %d entries</string>
+    <string name="duplicate_moved_count">Moved %d entries</string>
+    <string name="duplicate_n_in_group">%d entries in this group</string>
+    <string name="duplicate_select_group">Select Group</string>
+    <string name="duplicate_original">ORIGINAL</string>
+    <string name="duplicate_n_chapters">%d ch</string>
+    <string name="duplicate_n_downloads">%d dl</string>
+    <string name="duplicate_n_read">%d read</string>
+    <string name="duplicate_categories_label">Categories: %s</string>
+    <string name="duplicate_delete_title">Delete %d entries?</string>
+    <string name="duplicate_delete_message">This will remove the selected entries from your library.</string>
+    <string name="duplicate_delete_downloaded_chapters">Delete downloaded chapters</string>
+    <string name="duplicate_delete_from_database">Delete from database</string>
 
     <!-- Crash screen -->
     <string name="crash_screen_title">Whoops!</string>
@@ -1049,4 +1126,114 @@
     <string name="migrationListScreen.migrateDialog.cancelLabel">Cancel</string>
     <string name="migrationListScreen.progressDialog.cancelLabel">Cancel</string>
     <string name="migrationListScreen.matchWithoutChapterToast">No chapters found, this entry cannot be used for migration</string>
+
+    <!-- Translation settings -->
+    <string name="pref_translation_replace_title">Replace title with translation</string>
+    <string name="pref_translation_replace_title_desc">When translating, replace the manga/novel title with the translated version. Original title is saved to alternative titles.</string>
+    <string name="pref_translation_save_alt_titles">Save translated titles as alternative</string>
+    <string name="pref_translation_save_alt_titles_desc">Store translated titles in alternative_titles for reference</string>
+    <string name="pref_translation_translate_tags">Translate tags</string>
+    <string name="pref_translation_translate_tags_desc">Translate genre tags and merge with original tags</string>
+    <string name="pref_translation_smart_auto">Smart auto-translate</string>
+    <string name="pref_translation_smart_auto_desc">Detect source language and skip translation if it matches target language</string>
+    <string name="pref_translation_chunk_mode">Translation chunk mode</string>
+    <string name="pref_translation_chunk_mode_paragraphs">Group by paragraphs (%d per chunk)</string>
+    <string name="pref_translation_chunk_mode_characters">Group by characters (%d per chunk)</string>
+    <string name="pref_translation_chunk_mode_words">Group by words (%d per chunk)</string>
+    <string name="pref_translation_chunk_paragraphs">Paragraphs</string>
+    <string name="pref_translation_chunk_characters">Characters</string>
+    <string name="pref_translation_chunk_words">Words</string>
+    <string name="pref_translation_chunk_size">Translation chunk size</string>
+    <string name="pref_translation_chunk_paragraphs_rec">Paragraphs per chunk (recommended: 20–100)</string>
+    <string name="pref_translation_chunk_characters_rec">Characters per chunk (recommended: 1000–5000)</string>
+    <string name="pref_translation_chunk_words_rec">Words per chunk (recommended: 200–2000)</string>
+    <string name="pref_translation_chunk_units">Units per chunk</string>
+    <string name="pref_translation_contextual_anchoring">Contextual anchoring</string>
+    <string name="pref_translation_contextual_anchoring_desc">Send previous translated paragraphs as context to LLM engines for better consistency</string>
+    <string name="pref_translation_contextual_anchoring_paragraphs">Context paragraphs</string>
+    <string name="pref_translation_contextual_anchoring_paragraphs_desc">Number of paragraphs from the previous chunk to include as context</string>
+    <string name="pref_translation_offline_suffix"> (Offline)</string>
+    <string name="pref_translation_queue">Translation Queue</string>
+    <string name="pref_translation_status">Status</string>
+    <string name="pref_translation_status_cancelling">Cancelling…</string>
+    <string name="pref_translation_status_paused">Paused — %1$d/%2$d completed</string>
+    <string name="pref_translation_status_chunk_info"> (chunk %1$d/%2$d)</string>
+    <string name="pref_translation_status_translating">Translating: %1$s%2$s (%3$d/%4$d)</string>
+    <string name="pref_translation_status_done">Done — %d chapters translated</string>
+    <string name="pref_translation_status_idle">Idle — no tasks in queue</string>
+    <string name="pref_translation_resume">Resume</string>
+    <string name="pref_translation_pause">Pause</string>
+    <string name="pref_translation_resume_desc">Resume processing queued translations</string>
+    <string name="pref_translation_pause_desc">Pause translation processing</string>
+    <string name="pref_translation_cancel">Cancel</string>
+    <string name="pref_translation_cancel_desc">Cancel current translation (saves partial progress)</string>
+    <string name="pref_translation_clear_queue">Clear Queue</string>
+    <string name="pref_translation_clear_queue_desc">Remove all pending translations from the queue</string>
+    <string name="pref_translation_test_engine">Test %s</string>
+    <string name="pref_translation_testing">Testing…</string>
+    <string name="pref_translation_test_send">Send a test translation</string>
+    <string name="pref_translation_test_text">Hello, this is a test.</string>
+    <string name="pref_translation_system_prompt">System Prompt</string>
+    <string name="pref_translation_system_prompt_desc">Custom system prompt for GPT models. Leave empty for default.</string>
+    <string name="pref_translation_user_prompt">User Prompt Template</string>
+    <string name="pref_translation_user_prompt_desc">Use {SOURCE_LANG}, {TARGET_LANG}, {TEXT} as placeholders.</string>
+    <string name="pref_translation_api_key">API Key</string>
+    <string name="pref_translation_api_url">API URL</string>
+    <string name="pref_translation_custom_prompt">Custom Prompt</string>
+    <string name="pref_translation_request_template">Request Template</string>
+    <string name="pref_translation_request_template_desc">Use {texts}, {text}, {source}, {target}</string>
+    <string name="pref_translation_response_path">Response Path</string>
+
+    <!-- EPUB compression settings -->
+    <string name="pref_epub_compression_level">EPUB compression level</string>
+    <string name="pref_epub_compression_default">Default (library decides)</string>
+    <string name="pref_epub_compression_none">No compression (fastest)</string>
+    <string name="pref_epub_compression_low">Low compression</string>
+    <string name="pref_epub_compression_medium">Medium compression</string>
+    <string name="pref_epub_compression_high">High compression (smallest)</string>
+    <string name="pref_epub_compression_default_label">Default</string>
+    <string name="pref_epub_compression_level_label">Level %d</string>
+
+    <!-- Advanced settings - data section -->
+    <string name="pref_delete_all_translations">Delete all translations</string>
+    <string name="pref_delete_all_translations_subtitle">Deletes all downloaded translations</string>
+    <string name="pref_delete_all_translations_confirm">Are you sure you want to delete all downloaded translations? This cannot be undone.</string>
+    <string name="pref_all_translations_deleted">All translations deleted</string>
+    <string name="pref_clear_temp_files">Clear temp files</string>
+    <string name="pref_clear_temp_files_subtitle">Clears temporary files from app cache (epub exports, network cache, etc.)</string>
+    <string name="pref_temp_files_cleared">Cleared %s of temp files</string>
+    <string name="pref_temp_files_error">Error clearing temp files</string>
+    <string name="pref_reset_settings">Reset settings to default</string>
+    <string name="pref_reset_settings_confirm">Are you sure you want to reset all app settings to their default values? This will not delete your library data, downloads, or backups. The app will restart afterwards.</string>
+    <string name="pref_reset_settings_action">Reset</string>
+    <string name="pref_normalize_urls">Normalize manga URLs</string>
+    <string name="pref_normalize_urls_subtitle">Removes trailing slashes from all manga URLs in database</string>
+    <string name="pref_remove_duplicate_urls">Remove duplicate URL entries</string>
+    <string name="pref_remove_duplicate_urls_subtitle">Unfavorite manga that would conflict after URL normalization</string>
+    <string name="pref_db_statistics">Database statistics</string>
+    <string name="pref_db_statistics_subtitle">Show detailed database size breakdown</string>
+    <string name="pref_db_maintenance">Database maintenance</string>
+    <string name="pref_db_maintenance_subtitle">VACUUM, REINDEX, and ANALYZE database</string>
+    <string name="pref_bulk_remove_url">Bulk remove by URL</string>
+    <string name="pref_bulk_remove_url_subtitle">Remove multiple entries from library by URL list</string>
+
+    <!-- Translation queue / batch -->
+    <string name="translation_all_downloaded_already_translated">All downloaded chapters are already translated</string>
+    <string name="translation_selected_already_translated">Selected chapters are already translated</string>
+
+    <!-- Batch update -->
+    <string name="batch_updating_entries">Updating %d entries…</string>
+    <string name="batch_update_complete">Updated %d entries</string>
+    <string name="batch_update_complete_with_failures">Updated %1$d/%2$d entries (%3$d failed)</string>
+
+    <!-- Duplicate detection -->
+    <string name="duplicate_source_type_js_extensions">JS Extensions</string>
+    <string name="duplicate_source_type_kt_extensions">Kotlin Extensions</string>
+    <string name="duplicate_source_type_custom_extensions">Custom Extensions</string>
+    <string name="duplicate_source_type_local_source">Local Source</string>
+    <string name="duplicate_no_sources_found">No sources with library entries found</string>
+
+    <!-- Misc UI -->
+    <string name="action_collapse">Collapse</string>
+    <string name="action_expand">Expand</string>
 </resources>


### PR DESCRIPTION


**Dialog Refactoring and UI Improvements**
* Refactored `DeleteLibraryMangaDialog` to replace the previous `CheckboxState` list with individual `mutableStateOf` variables and a new `CheckboxItem` data class, allowing more flexible and readable checkbox management. Also added a new checkbox for deleting translations and updated the confirm logic to pass four booleans instead of three. [[1]](diffhunk://#diff-12d2704717030c44a347f6fde9836b2b431e2350c41cae291f0c54b92c84cd66L13) [[2]](diffhunk://#diff-12d2704717030c44a347f6fde9836b2b431e2350c41cae291f0c54b92c84cd66L23-R45) [[3]](diffhunk://#diff-12d2704717030c44a347f6fde9836b2b431e2350c41cae291f0c54b92c84cd66L45-R62) [[4]](diffhunk://#diff-12d2704717030c44a347f6fde9836b2b431e2350c41cae291f0c54b92c84cd66L63-R78)

**Export Options Enhancements**
* Updated `BatchExportEpubDialog` to replace the `preferTranslated` boolean with a `TranslationMode` enum, allowing users to choose between original, translated, or both chapter versions for EPUB export. The dialog now uses radio buttons for this selection, and the export logic and info text have been updated accordingly. The exported file is now a ZIP when multiple files are needed. [[1]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bR26-R38) [[2]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL60-R69) [[3]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL75-R79) [[4]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL142-R169) [[5]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL181-R208) [[6]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL194-R223)

**Manga Screen Action Expansion**
* Added new callback handlers and UI actions to the manga screen for multi-chapter translation management, including deleting translations, translating selected chapters, and re-translating chapters. These actions are now available in both small and large screen implementations and the shared bottom action menu. [[1]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR138-R140) [[2]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR199-R201) [[3]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR249-R251) [[4]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR311-R313) [[5]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR429-R431) [[6]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR626-R628) [[7]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR741-R743) [[8]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR897-R899) [[9]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR935-R955)

**Library Settings Dialog Addition**
* Added a new filter for chapter count in the library settings dialog, allowing users to filter manga by chapter count with a configurable threshold and tri-state toggle. The threshold can be set via an outlined text field that appears when the filter is enabled. [[1]](diffhunk://#diff-d881cb2d55cda15653cc80617c3f2703c5fbc51b175cd0fe6db2c84716f22ef3R42-R44) [[2]](diffhunk://#diff-d881cb2d55cda15653cc80617c3f2703c5fbc51b175cd0fe6db2c84716f22ef3R174-R204)

**Minor UI Adjustment**
* Added missing `padding` import in the `ExportEpubDialog` to support layout changes.