### PR TITLE
Feat/translation

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/TranslateMangaDetailsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/TranslateMangaDetailsDialog.kt
@@ -28,6 +28,9 @@ import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.translation.model.TranslationResult
+import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.i18n.novel.TDMR
+import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -50,6 +53,7 @@ fun TranslateMangaDetailsDialog(
     onConfirm: (details: TranslatedMangaDetails) -> Unit,
 ) {
     val translationEngineManager: TranslationEngineManager = remember { Injekt.get() }
+    val translationPreferences: TranslationPreferences = remember { Injekt.get() }
 
     var isTranslating by remember { mutableStateOf(false) }
     var translatedTitle by remember { mutableStateOf<String?>(null) }
@@ -74,8 +78,11 @@ fun TranslateMangaDetailsDialog(
                 return@LaunchedEffect
             }
 
+            val sourceLang = translationPreferences.sourceLanguage().get()
+            val targetLang = translationPreferences.targetLanguage().get()
+
             // Translate title
-            val titleResult = engine.translateSingle(manga.title, sourceLanguage = "auto", targetLanguage = "en")
+            val titleResult = engine.translateSingle(manga.title, sourceLanguage = sourceLang, targetLanguage = targetLang)
             when (titleResult) {
                 is TranslationResult.Success -> {
                     translatedTitle = titleResult.translatedTexts.firstOrNull()
@@ -89,7 +96,7 @@ fun TranslateMangaDetailsDialog(
             // Translate description if present
             manga.description?.let { desc ->
                 if (desc.isNotBlank()) {
-                    val descResult = engine.translateSingle(desc, sourceLanguage = "auto", targetLanguage = "en")
+                    val descResult = engine.translateSingle(desc, sourceLanguage = sourceLang, targetLanguage = targetLang)
                     when (descResult) {
                         is TranslationResult.Success -> {
                             translatedDescription = descResult.translatedTexts.firstOrNull()
@@ -105,7 +112,7 @@ fun TranslateMangaDetailsDialog(
             // Translate genres if present
             val genres = manga.genre
             if (!genres.isNullOrEmpty()) {
-                val genresResult = engine.translate(genres, sourceLanguage = "auto", targetLanguage = "en")
+                val genresResult = engine.translate(genres, sourceLanguage = sourceLang, targetLanguage = targetLang)
                 when (genresResult) {
                     is TranslationResult.Success -> {
                         translatedGenres = genresResult.translatedTexts
@@ -125,7 +132,7 @@ fun TranslateMangaDetailsDialog(
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        title = { Text("Translate Novel Details") },
+        title = { Text(stringResource(TDMR.strings.translate_details_title)) },
         text = {
             Column(
                 modifier = Modifier
@@ -141,7 +148,7 @@ fun TranslateMangaDetailsDialog(
                     ) {
                         CircularProgressIndicator()
                         Spacer(modifier = Modifier.padding(horizontal = 8.dp))
-                        Text("Translating...")
+                        Text(stringResource(TDMR.strings.translate_details_translating))
                     }
                 } else if (error != null) {
                     Text(
@@ -152,7 +159,7 @@ fun TranslateMangaDetailsDialog(
                 } else {
                     // Original title
                     Text(
-                        text = "Original Title:",
+                        text = stringResource(TDMR.strings.translate_details_original_title),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -165,7 +172,7 @@ fun TranslateMangaDetailsDialog(
                     if (translatedTitle != null) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "Translated Title:",
+                            text = stringResource(TDMR.strings.translate_details_translated_title),
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary,
                         )
@@ -186,7 +193,7 @@ fun TranslateMangaDetailsDialog(
                                 onCheckedChange = { addToAltTitles = it },
                             )
                             Text(
-                                text = "Add translated title to alternative titles",
+                                text = stringResource(TDMR.strings.translate_details_add_alt_titles),
                                 style = MaterialTheme.typography.bodySmall,
                             )
                         }
@@ -203,7 +210,7 @@ fun TranslateMangaDetailsDialog(
                                 onCheckedChange = { saveTagsToNotes = it },
                             )
                             Text(
-                                text = "Save translated tags to notes",
+                                text = stringResource(TDMR.strings.translate_details_save_tags_notes),
                                 style = MaterialTheme.typography.bodySmall,
                             )
                         }
@@ -213,7 +220,7 @@ fun TranslateMangaDetailsDialog(
                     if (!manga.description.isNullOrBlank()) {
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
-                            text = "Original Description:",
+                            text = stringResource(TDMR.strings.translate_details_original_desc),
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary,
                         )
@@ -226,7 +233,7 @@ fun TranslateMangaDetailsDialog(
                         if (translatedDescription != null) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = "Translated Description:",
+                                text = stringResource(TDMR.strings.translate_details_translated_desc),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary,
                             )
@@ -243,7 +250,7 @@ fun TranslateMangaDetailsDialog(
                     if (!manga.genre.isNullOrEmpty()) {
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
-                            text = "Original Genres:",
+                            text = stringResource(TDMR.strings.translate_details_original_genres),
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary,
                         )
@@ -257,7 +264,7 @@ fun TranslateMangaDetailsDialog(
                         if (translatedGenres != null) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = "Translated Genres:",
+                                text = stringResource(TDMR.strings.translate_details_translated_genres),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary,
                             )
@@ -280,7 +287,7 @@ fun TranslateMangaDetailsDialog(
                                     onCheckedChange = { translateGenres = it },
                                 )
                                 Text(
-                                    text = "Save translated genres",
+                                    text = stringResource(TDMR.strings.translate_details_save_genres),
                                     style = MaterialTheme.typography.bodySmall,
                                 )
                             }
@@ -298,7 +305,7 @@ fun TranslateMangaDetailsDialog(
                                         onCheckedChange = { mergeGenres = it },
                                     )
                                     Text(
-                                        text = "Add to existing genres (don't replace)",
+                                        text = stringResource(TDMR.strings.translate_details_merge_genres),
                                         style = MaterialTheme.typography.bodySmall,
                                     )
                                 }
@@ -322,7 +329,7 @@ fun TranslateMangaDetailsDialog(
                         ),
                     )
                 },
-                enabled = !isTranslating && translatedTitle != null,
+                enabled = !isTranslating && (translatedTitle != null || translatedDescription != null || translatedGenres != null),
             ) {
                 Text("Save")
             }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
@@ -2,12 +2,20 @@ package eu.kanade.presentation.more.settings.screen
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.launch
+import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
@@ -26,7 +34,6 @@ object SettingsTranslationScreen : SearchableSettings {
         return listOf(
             prefs.rateLimitDelayMs(),
             prefs.translationTimeoutMs(),
-            prefs.rateLimitWarningThreshold(),
             prefs.maxParallelTranslations(),
         )
     }
@@ -39,12 +46,32 @@ object SettingsTranslationScreen : SearchableSettings {
     override fun getPreferences(): List<Preference> {
         val translationPreferences = remember { Injekt.get<TranslationPreferences>() }
         val engineManager = remember { Injekt.get<TranslationEngineManager>() }
+        val translationService = remember { Injekt.get<eu.kanade.tachiyomi.data.translation.TranslationService>() }
+        val navigator = LocalNavigator.currentOrThrow
+
+        val progress by translationService.progressState.collectAsState()
+        val isPaused by translationService.isPaused.collectAsState()
+        val queueStatusText = when {
+            progress.isCancelling -> stringResource(MR.strings.pref_translation_status_cancelling)
+            progress.isRunning && isPaused -> stringResource(MR.strings.pref_translation_status_paused, progress.completedChapters, progress.totalChapters)
+            progress.isRunning -> stringResource(MR.strings.pref_translation_status_translating, progress.currentChapterName ?: "...", "", progress.completedChapters, progress.totalChapters)
+            else -> stringResource(MR.strings.pref_translation_status_idle)
+        }
 
         return listOf(
             getGeneralGroup(translationPreferences, engineManager),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_translation_queue),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(MR.strings.pref_translation_queue),
+                        subtitle = queueStatusText,
+                        onClick = { navigator.push(eu.kanade.tachiyomi.ui.setting.TranslationQueueScreen) },
+                    ),
+                ),
+            ),
             getRateLimitGroup(translationPreferences),
-            getApiKeysGroup(translationPreferences),
-        )
+        ) + getEngineConfigGroups(translationPreferences, engineManager)
     }
 
     @Composable
@@ -56,6 +83,9 @@ object SettingsTranslationScreen : SearchableSettings {
         val selectedEngineId by prefs.selectedEngineId().collectAsState()
         val sourceLanguage by prefs.sourceLanguage().collectAsState()
         val targetLanguage by prefs.targetLanguage().collectAsState()
+        val chunkSize by prefs.translationChunkSize().collectAsState()
+        val anchoringEnabled by prefs.contextualAnchoringEnabled().collectAsState()
+        val anchoringParagraphs by prefs.contextualAnchoringParagraphs().collectAsState()
 
         val engines = engineManager.engines
         val engineEntries = engines.associate { it.id.toString() to it.name }.toImmutableMap()
@@ -74,7 +104,7 @@ object SettingsTranslationScreen : SearchableSettings {
                 Preference.PreferenceItem.ListPreference(
                     preference = prefs.selectedEngineId(),
                     title = stringResource(TDMR.strings.pref_translation_engine),
-                    subtitle = selectedEngine.name + if (selectedEngine.isOffline) " (Offline)" else "",
+                    subtitle = selectedEngine.name + if (selectedEngine.isOffline) stringResource(MR.strings.pref_translation_offline_suffix) else "",
                     entries = engineEntries.mapKeys { it.key.toLong() }.toImmutableMap(),
                     enabled = enabled,
                 ),
@@ -114,21 +144,50 @@ object SettingsTranslationScreen : SearchableSettings {
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = prefs.replaceTitle(),
-                    title = "Replace title with translation",
-                    subtitle = "When translating, replace the manga/novel title with the translated version. Original title is saved to alternative titles.",
+                    title = stringResource(MR.strings.pref_translation_replace_title),
+                    subtitle = stringResource(MR.strings.pref_translation_replace_title_desc),
                     enabled = enabled,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = prefs.saveTranslatedTitleAsAlternative(),
-                    title = "Save translated titles as alternative",
-                    subtitle = "Store translated titles in alternative_titles for reference",
+                    title = stringResource(MR.strings.pref_translation_save_alt_titles),
+                    subtitle = stringResource(MR.strings.pref_translation_save_alt_titles_desc),
                     enabled = enabled,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = prefs.translateTags(),
-                    title = "Translate tags",
-                    subtitle = "Translate genre tags and merge with original tags",
+                    title = stringResource(MR.strings.pref_translation_translate_tags),
+                    subtitle = stringResource(MR.strings.pref_translation_translate_tags_desc),
                     enabled = enabled,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = prefs.smartAutoTranslate(),
+                    title = stringResource(MR.strings.pref_translation_smart_auto),
+                    subtitle = stringResource(MR.strings.pref_translation_smart_auto_desc),
+                    enabled = enabled,
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = chunkSize,
+                    valueRange = 1..500,
+                    title = stringResource(MR.strings.pref_translation_chunk_size),
+                    subtitle = stringResource(MR.strings.pref_translation_chunk_paragraphs_rec),
+                    valueString = "$chunkSize ${stringResource(MR.strings.pref_translation_chunk_paragraphs)}",
+                    onValueChanged = { prefs.translationChunkSize().set(it) },
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = prefs.contextualAnchoringEnabled(),
+                    title = stringResource(MR.strings.pref_translation_contextual_anchoring),
+                    subtitle = stringResource(MR.strings.pref_translation_contextual_anchoring_desc),
+                    enabled = enabled,
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = anchoringParagraphs,
+                    valueRange = 1..10,
+                    title = stringResource(MR.strings.pref_translation_contextual_anchoring_paragraphs),
+                    subtitle = stringResource(MR.strings.pref_translation_contextual_anchoring_paragraphs_desc),
+                    valueString = "$anchoringParagraphs",
+                    onValueChanged = { prefs.contextualAnchoringParagraphs().set(it) },
+                    enabled = anchoringEnabled && enabled,
                 ),
             ),
         )
@@ -139,7 +198,6 @@ object SettingsTranslationScreen : SearchableSettings {
         prefs: TranslationPreferences,
     ): Preference.PreferenceGroup {
         val rateLimitDelay by prefs.rateLimitDelayMs().collectAsState()
-        val warningThreshold by prefs.rateLimitWarningThreshold().collectAsState()
         val maxParallel by prefs.maxParallelTranslations().collectAsState()
         val timeoutMs by prefs.translationTimeoutMs().collectAsState()
 
@@ -163,19 +221,6 @@ object SettingsTranslationScreen : SearchableSettings {
                     onValueChanged = { prefs.translationTimeoutMs().set(it.toLong() * 1000) },
                 ),
                 Preference.PreferenceItem.SliderPreference(
-                    value = warningThreshold,
-                    valueRange = 1..50,
-                    title = stringResource(TDMR.strings.pref_translation_warning_threshold),
-                    subtitle = stringResource(TDMR.strings.pref_translation_warning_threshold_summary),
-                    valueString = "$warningThreshold chapters",
-                    onValueChanged = { prefs.rateLimitWarningThreshold().set(it) },
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = prefs.bypassRateLimitWarning(),
-                    title = stringResource(TDMR.strings.pref_translation_bypass_warning),
-                    subtitle = stringResource(TDMR.strings.pref_translation_bypass_warning_summary),
-                ),
-                Preference.PreferenceItem.SliderPreference(
                     value = maxParallel,
                     valueRange = 1..10,
                     title = stringResource(TDMR.strings.pref_translation_max_parallel),
@@ -188,106 +233,223 @@ object SettingsTranslationScreen : SearchableSettings {
     }
 
     @Composable
-    private fun getApiKeysGroup(
+    private fun getEngineConfigGroups(
         prefs: TranslationPreferences,
-    ): Preference.PreferenceGroup {
+        engineManager: TranslationEngineManager,
+    ): List<Preference.PreferenceGroup> {
+        val sourceLanguage by prefs.sourceLanguage().collectAsState()
+        val targetLanguage by prefs.targetLanguage().collectAsState()
+        val scope = rememberCoroutineScope()
+
+        // Per-engine test state
+        val testResults = remember { mutableMapOf<Long, String>() }
+        var testingEngineId by remember { mutableStateOf<Long?>(null) }
+
+        // Collect all preference states
         val openAiKey by prefs.openAiApiKey().collectAsState()
         val deepSeekKey by prefs.deepSeekApiKey().collectAsState()
+        val systranKey by prefs.systranApiKey().collectAsState()
+        val deepLKey by prefs.deepLApiKey().collectAsState()
+        val googleKey by prefs.googleApiKey().collectAsState()
         val libreTranslateUrl by prefs.libreTranslateUrl().collectAsState()
         val libreTranslateKey by prefs.libreTranslateApiKey().collectAsState()
         val ollamaUrl by prefs.ollamaUrl().collectAsState()
         val ollamaModel by prefs.ollamaModel().collectAsState()
-        val systranKey by prefs.systranApiKey().collectAsState()
-        val deepLKey by prefs.deepLApiKey().collectAsState()
-        val googleKey by prefs.googleApiKey().collectAsState()
         val customHttpUrl by prefs.customHttpUrl().collectAsState()
         val customHttpApiKey by prefs.customHttpApiKey().collectAsState()
-        val customHttpRequestTemplate by prefs.customHttpRequestTemplate().collectAsState()
         val customHttpResponsePath by prefs.customHttpResponsePath().collectAsState()
 
-        return Preference.PreferenceGroup(
-            title = stringResource(TDMR.strings.pref_translation_api_keys),
-            preferenceItems = persistentListOf(
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.openAiApiKey(),
-                    title = stringResource(TDMR.strings.pref_translation_openai_key),
-                    subtitle = if (openAiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+        // Pre-resolve strings for non-composable testButton function
+        val testEngineFormat = stringResource(MR.strings.pref_translation_test_engine)
+        val testingStr = stringResource(MR.strings.pref_translation_testing)
+        val testSendStr = stringResource(MR.strings.pref_translation_test_send)
+        val testTextStr = stringResource(MR.strings.pref_translation_test_text)
+
+        fun testButton(engine: tachiyomi.domain.translation.model.TranslationEngine): Preference.PreferenceItem.TextPreference {
+            val engineId = engine.id
+            return Preference.PreferenceItem.TextPreference(
+                title = testEngineFormat.format(engine.name),
+                subtitle = when {
+                    testingEngineId == engineId -> testingStr
+                    testResults.containsKey(engineId) -> testResults[engineId]!!
+                    else -> testSendStr
+                },
+                enabled = testingEngineId == null,
+                onClick = {
+                    testingEngineId = engineId
+                    testResults.remove(engineId)
+                    scope.launch {
+                        try {
+                            val result = engine.translate(
+                                listOf(testTextStr),
+                                sourceLanguage,
+                                targetLanguage,
+                            )
+                            testResults[engineId] = when (result) {
+                                is TranslationResult.Success ->
+                                    "✓ ${result.translatedTexts.joinToString(" | ")}"
+                                is TranslationResult.Error ->
+                                    "✗ ${result.message}"
+                            }
+                        } catch (e: Exception) {
+                            testResults[engineId] = "✗ ${e.message ?: e.javaClass.simpleName}"
+                        } finally {
+                            testingEngineId = null
+                        }
+                    }
+                },
+            )
+        }
+
+        return listOf(
+            // OpenAI
+            Preference.PreferenceGroup(
+                title = "OpenAI",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.openAiApiKey(),
+                        title = stringResource(TDMR.strings.pref_translation_openai_key),
+                        subtitle = if (openAiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.openAiSystemPrompt(),
+                        title = stringResource(MR.strings.pref_translation_system_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_system_prompt_desc),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.openAiUserPrompt(),
+                        title = stringResource(MR.strings.pref_translation_user_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("OpenAI") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.deepSeekApiKey(),
-                    title = stringResource(TDMR.strings.pref_translation_deepseek_key),
-                    subtitle = if (deepSeekKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+            ),
+            // DeepSeek
+            Preference.PreferenceGroup(
+                title = "DeepSeek",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.deepSeekApiKey(),
+                        title = stringResource(TDMR.strings.pref_translation_deepseek_key),
+                        subtitle = if (deepSeekKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("DeepSeek") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.systranApiKey(),
-                    title = "SYSTRAN API Key",
-                    subtitle = if (systranKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+            ),
+            // DeepL
+            Preference.PreferenceGroup(
+                title = "DeepL",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.deepLApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (deepLKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("DeepL") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.deepLApiKey(),
-                    title = "DeepL API Key",
-                    subtitle = if (deepLKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+            ),
+            // SYSTRAN
+            Preference.PreferenceGroup(
+                title = "SYSTRAN",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.systranApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (systranKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("SYSTRAN") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.googleApiKey(),
-                    title = "Google Translate API Key",
-                    subtitle = if (googleKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+            ),
+            // Google Translate (Paid)
+            Preference.PreferenceGroup(
+                title = "Google Translate",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.googleApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (googleKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    testButton(engineManager.engines.first { it.name == "Google Translate" }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.libreTranslateUrl(),
-                    title = stringResource(TDMR.strings.pref_translation_libretranslate_url),
-                    subtitle = libreTranslateUrl,
+            ),
+            // Google Translate Free (Scraper)
+            Preference.PreferenceGroup(
+                title = "Google Translate (Free)",
+                preferenceItems = persistentListOf(
+                    testButton(engineManager.engines.first { it.name.contains("Scraper") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.libreTranslateApiKey(),
-                    title = "LibreTranslate API Key",
-                    subtitle = if (libreTranslateKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+            ),
+            // LibreTranslate
+            Preference.PreferenceGroup(
+                title = "LibreTranslate",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.libreTranslateUrl(),
+                        title = stringResource(TDMR.strings.pref_translation_libretranslate_url),
+                        subtitle = libreTranslateUrl,
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.libreTranslateApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (libreTranslateKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("Libre") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.ollamaUrl(),
-                    title = stringResource(TDMR.strings.pref_translation_ollama_url),
-                    subtitle = ollamaUrl,
+            ),
+            // Ollama
+            Preference.PreferenceGroup(
+                title = "Ollama",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.ollamaUrl(),
+                        title = stringResource(TDMR.strings.pref_translation_ollama_url),
+                        subtitle = ollamaUrl,
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.ollamaModel(),
+                        title = stringResource(TDMR.strings.pref_translation_ollama_model),
+                        subtitle = ollamaModel,
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.ollamaPrompt(),
+                        title = stringResource(MR.strings.pref_translation_custom_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("Ollama") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.ollamaModel(),
-                    title = stringResource(TDMR.strings.pref_translation_ollama_model),
-                    subtitle = ollamaModel,
+            ),
+            // HuggingFace
+            Preference.PreferenceGroup(
+                title = "HuggingFace",
+                preferenceItems = persistentListOf(
+                    testButton(engineManager.engines.first { it.name.contains("Hugging") }),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.ollamaPrompt(),
-                    title = "Ollama Custom Prompt",
-                    subtitle = "Use {SOURCE_LANG}, {TARGET_LANG}, {TEXT} as placeholders. Leave empty for default.",
-                ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.openAiSystemPrompt(),
-                    title = "OpenAI System Prompt",
-                    subtitle = "Custom system prompt for GPT models. Leave empty for default.",
-                ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.openAiUserPrompt(),
-                    title = "OpenAI User Prompt Template",
-                    subtitle = "Use {SOURCE_LANG}, {TARGET_LANG}, {TEXT} as placeholders. Leave empty for default.",
-                ),
-                // Custom HTTP settings
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.customHttpUrl(),
-                    title = "Custom HTTP API URL",
-                    subtitle = if (customHttpUrl.isNotBlank()) customHttpUrl else stringResource(TDMR.strings.not_set),
-                ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.customHttpApiKey(),
-                    title = "Custom HTTP API Key",
-                    subtitle = if (customHttpApiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
-                ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.customHttpRequestTemplate(),
-                    title = "Custom HTTP Request Template",
-                    subtitle = "Use {texts}, {text}, {source}, {target}",
-                ),
-                Preference.PreferenceItem.EditTextPreference(
-                    preference = prefs.customHttpResponsePath(),
-                    title = "Custom HTTP Response Path",
-                    subtitle = customHttpResponsePath.ifBlank { "translatedText" },
+            ),
+            // Custom HTTP
+            Preference.PreferenceGroup(
+                title = "Custom HTTP",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.customHttpUrl(),
+                        title = stringResource(MR.strings.pref_translation_api_url),
+                        subtitle = if (customHttpUrl.isNotBlank()) customHttpUrl else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.customHttpApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (customHttpApiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.customHttpRequestTemplate(),
+                        title = stringResource(MR.strings.pref_translation_request_template),
+                        subtitle = stringResource(MR.strings.pref_translation_request_template_desc),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.customHttpResponsePath(),
+                        title = stringResource(MR.strings.pref_translation_response_path),
+                        subtitle = customHttpResponsePath.ifBlank { "translatedText" },
+                    ),
+                    testButton(engineManager.engines.first { it.name.contains("Custom") }),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/reader/TranslationLanguageSelectDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/TranslationLanguageSelectDialog.kt
@@ -26,10 +26,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AdaptiveSheet
+import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 /**
  * Data class representing a translation language option.
@@ -40,9 +43,9 @@ data class TranslationLanguage(
 )
 
 /**
- * List of available translation target languages.
+ * Fallback language list used only when the engine provides no languages.
  */
-val translationLanguages = listOf(
+private val fallbackLanguages = listOf(
     TranslationLanguage("en", "English"),
     TranslationLanguage("es", "Spanish"),
     TranslationLanguage("fr", "French"),
@@ -53,26 +56,7 @@ val translationLanguages = listOf(
     TranslationLanguage("ja", "Japanese"),
     TranslationLanguage("ko", "Korean"),
     TranslationLanguage("zh", "Chinese (Simplified)"),
-    TranslationLanguage("zh-TW", "Chinese (Traditional)"),
     TranslationLanguage("ar", "Arabic"),
-    TranslationLanguage("hi", "Hindi"),
-    TranslationLanguage("th", "Thai"),
-    TranslationLanguage("vi", "Vietnamese"),
-    TranslationLanguage("id", "Indonesian"),
-    TranslationLanguage("ms", "Malay"),
-    TranslationLanguage("nl", "Dutch"),
-    TranslationLanguage("pl", "Polish"),
-    TranslationLanguage("tr", "Turkish"),
-    TranslationLanguage("uk", "Ukrainian"),
-    TranslationLanguage("cs", "Czech"),
-    TranslationLanguage("sv", "Swedish"),
-    TranslationLanguage("da", "Danish"),
-    TranslationLanguage("fi", "Finnish"),
-    TranslationLanguage("no", "Norwegian"),
-    TranslationLanguage("el", "Greek"),
-    TranslationLanguage("he", "Hebrew"),
-    TranslationLanguage("hu", "Hungarian"),
-    TranslationLanguage("ro", "Romanian"),
 )
 
 @Composable
@@ -105,6 +89,19 @@ private fun DialogContent(
 ) {
     var selected by remember { mutableStateOf(currentLanguage) }
 
+    // Use the selected engine's supported languages, falling back to a basic list
+    val engineManager = remember { Injekt.get<TranslationEngineManager>() }
+    val languages = remember {
+        val engineLangs = engineManager.getSupportedLanguages()
+        if (engineLangs.isNotEmpty()) {
+            engineLangs
+                .filter { it.first != "auto" }
+                .map { TranslationLanguage(it.first, it.second) }
+        } else {
+            fallbackLanguages
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -127,11 +124,11 @@ private fun DialogContent(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Smart Auto-Translate",
+                    text = stringResource(TDMR.strings.translation_smart_auto),
                     style = MaterialTheme.typography.bodyLarge,
                 )
                 Text(
-                    text = "Only translate if language differs from target",
+                    text = stringResource(TDMR.strings.translation_smart_auto_summary),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -145,7 +142,7 @@ private fun DialogContent(
         }
 
         Text(
-            text = "Select target language for translation",
+            text = stringResource(TDMR.strings.translation_select_target_language),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = MaterialTheme.padding.small),
@@ -158,7 +155,7 @@ private fun DialogContent(
                 .fillMaxWidth()
                 .weight(1f, fill = false),
         ) {
-            items(translationLanguages) { language ->
+            items(languages) { language ->
                 LanguageItem(
                     language = language,
                     isSelected = selected == language.code,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -85,6 +85,13 @@ object Notifications {
     const val ID_MASS_IMPORT_COMPLETE = -602
 
     /**
+     * Notification channel and ids used by translation.
+     */
+    const val CHANNEL_TRANSLATION = "translation_channel"
+    const val ID_TRANSLATION_PROGRESS = -610
+    const val ID_TRANSLATION_COMPLETE = -611
+
+    /**
      * Notification channel and ids used by EPUB export.
      */
     const val CHANNEL_EPUB_EXPORT = "epub_export_channel"
@@ -191,6 +198,10 @@ object Notifications {
                 },
                 buildNotificationChannel(CHANNEL_MASS_IMPORT, IMPORTANCE_LOW) {
                     setName(context.stringResource(TDMR.strings.channel_mass_import))
+                    setShowBadge(false)
+                },
+                buildNotificationChannel(CHANNEL_TRANSLATION, IMPORTANCE_LOW) {
+                    setName(context.stringResource(TDMR.strings.channel_translation))
                     setShowBadge(false)
                 },
                 buildNotificationChannel(CHANNEL_EPUB_EXPORT, IMPORTANCE_LOW) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationJob.kt
@@ -8,15 +8,16 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
-import androidx.work.workDataOf
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.notify
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import logcat.LogPriority
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.i18n.novel.TDMR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -29,13 +30,13 @@ class TranslationJob(context: Context, workerParams: WorkerParameters) : Corouti
     private val translationService: TranslationService = Injekt.get()
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_MASS_IMPORT) {
-            setContentTitle("Translating chapters...")
+        val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_TRANSLATION) {
+            setContentTitle(applicationContext.stringResource(TDMR.strings.translation_job_translating))
             setSmallIcon(android.R.drawable.stat_sys_download)
             setOngoing(true)
         }.build()
         return ForegroundInfo(
-            Notifications.ID_MASS_IMPORT_PROGRESS,
+            Notifications.ID_TRANSLATION_PROGRESS,
             notification,
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
@@ -47,33 +48,35 @@ class TranslationJob(context: Context, workerParams: WorkerParameters) : Corouti
 
     override suspend fun doWork(): Result {
         return try {
-            val chapterId = inputData.getLong(KEY_CHAPTER_ID, -1L)
-            val mangaId = inputData.getLong(KEY_MANGA_ID, -1L)
-
-            if (chapterId == -1L || mangaId == -1L) {
-                return Result.success()
-            }
-
             setForegroundSafely()
 
-            // The TranslationService will start processing the queue
+            // Start queue processing if not already running
             translationService.start()
 
-            // Collect progress updates and update notifications
-            translationService.progressState.collectLatest { progress ->
+            // Wait for completion by collecting until no longer running
+            translationService.progressState.first { progress ->
                 if (progress.isRunning) {
-                    val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_MASS_IMPORT) {
-                        setContentTitle("Translating chapters...")
-                        setContentText(progress.currentChapterName ?: "Processing...")
+                    // Update notification with progress
+                    val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_TRANSLATION) {
+                        setContentTitle(applicationContext.stringResource(TDMR.strings.translation_job_translating))
+                        setContentText(progress.currentChapterName ?: applicationContext.stringResource(TDMR.strings.translation_job_processing))
                         setProgress(progress.totalChapters, progress.completedChapters, false)
                         setSmallIcon(android.R.drawable.stat_sys_download)
                         setOngoing(true)
                         setOnlyAlertOnce(true)
                     }.build()
+                    applicationContext.notify(Notifications.ID_TRANSLATION_PROGRESS, notification)
+                    false // keep collecting
+                } else {
+                    // Done (either finished or was never running)
+                    true // stop collecting
                 }
             }
 
-            showCompletionNotification()
+            val completed = translationService.progressState.value.completedChapters
+            if (completed > 0) {
+                showCompletionNotification(completed)
+            }
             Result.success()
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Translation job failed" }
@@ -81,27 +84,27 @@ class TranslationJob(context: Context, workerParams: WorkerParameters) : Corouti
         }
     }
 
-    private fun showCompletionNotification() {
-        val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_MASS_IMPORT) {
-            setContentTitle("Translation Complete")
-            setSmallIcon(android.R.drawable.stat_sys_download_done)
-            setAutoCancel(true)
-        }.build()
+    private fun showCompletionNotification(completedCount: Int) {
+        // Cancel progress notification
+        applicationContext.notify(
+            Notifications.ID_TRANSLATION_PROGRESS,
+            applicationContext.notificationBuilder(Notifications.CHANNEL_TRANSLATION) {
+                setContentTitle(applicationContext.stringResource(TDMR.strings.translation_job_complete))
+                setContentText(
+                    applicationContext.stringResource(TDMR.strings.translation_job_complete_count, completedCount),
+                )
+                setSmallIcon(android.R.drawable.stat_sys_download_done)
+                setAutoCancel(true)
+                setOngoing(false)
+            }.build(),
+        )
     }
 
     companion object {
         private const val TAG = "TranslationJob"
-        private const val KEY_CHAPTER_ID = "chapter_id"
-        private const val KEY_MANGA_ID = "manga_id"
 
-        fun start(context: Context, chapterId: Long = -1L, mangaId: Long = -1L) {
-            val data = workDataOf(
-                KEY_CHAPTER_ID to chapterId,
-                KEY_MANGA_ID to mangaId,
-            )
-
+        fun start(context: Context) {
             val request = OneTimeWorkRequestBuilder<TranslationJob>()
-                .setInputData(data)
                 .build()
 
             context.workManager.enqueueUniqueWork(TAG, ExistingWorkPolicy.KEEP, request)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -4,7 +4,10 @@ import android.content.Context
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.data.translation.engine.DeepSeekTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.LibreTranslateEngine
+import eu.kanade.tachiyomi.data.translation.engine.OllamaTranslateEngine
+import eu.kanade.tachiyomi.data.translation.engine.OpenAITranslateEngine
 import eu.kanade.tachiyomi.source.fetchNovelPageText
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.Page
@@ -407,10 +410,31 @@ class TranslationService(
         }
 
         var failedChunkIndex = -1
+        // Contextual anchoring: send previous raw + translated paragraphs as context for LLM engines
+        val isLlmEngine = engine.id in LLM_ENGINE_IDS
+        val anchoringEnabled = translationPreferences.contextualAnchoringEnabled().get()
+        val anchoringParagraphs = translationPreferences.contextualAnchoringParagraphs().get()
+        val useAnchoring = isLlmEngine && anchoringEnabled && anchoringParagraphs > 0
+
+        // Build per-chunk paragraph lists for context tracking
+        val chunkParagraphsList = chunks.map { c -> c.split("\n\n").filter { it.isNotBlank() } }
+        // Track the raw paragraphs of the previously translated chunk
+        var previousRawParagraphs = emptyList<String>()
+        // Track the translated paragraphs of the previous chunk
+        var previousTranslatedParagraphs = emptyList<String>()
+
         for ((chunkIndex, chunk) in chunks.withIndex()) {
             // Skip already-translated chunks
             if (chunkIndex < resumeFromChunk) {
                 logcat(LogPriority.DEBUG) { "Skipping chunk ${chunkIndex + 1}/${chunks.size} (already translated)" }
+                // Track the last skipped chunk's paragraphs for contextual anchoring
+                if (useAnchoring) {
+                    previousRawParagraphs = chunkParagraphsList[chunkIndex]
+                    // Estimate translated paragraphs from existing tmp data
+                    val startIdx = chunkParagraphsList.take(chunkIndex).sumOf { it.size }
+                    val endIdx = startIdx + chunkParagraphsList[chunkIndex].size
+                    previousTranslatedParagraphs = existingTmpParagraphs.drop(startIdx).take(endIdx - startIdx)
+                }
                 _progressState.update { current ->
                     current.copy(
                         currentChapterProgress = 0.5f + 0.5f * (chunkIndex + 1f) / chunks.size,
@@ -428,15 +452,47 @@ class TranslationService(
 
             logcat(LogPriority.DEBUG) { "Sending chunk ${chunkIndex + 1}/${chunks.size} for translation (${chunk.length} chars)" }
 
+            // Build the text to send, optionally wrapping with context for LLM engines
+            val textToSend = if (useAnchoring && chunkIndex > 0 && previousRawParagraphs.isNotEmpty()) {
+                val rawContext = previousRawParagraphs.takeLast(anchoringParagraphs).joinToString("\n\n")
+                val translatedContext = previousTranslatedParagraphs.takeLast(anchoringParagraphs).joinToString("\n\n")
+                val currentParagraphCount = chunkParagraphsList[chunkIndex].size
+                buildString {
+                    appendLine("You are translating a novel.")
+                    appendLine("Below is previous context. Do NOT translate it.")
+                    appendLine("=== PREVIOUS RAW ===")
+                    appendLine(rawContext)
+                    appendLine("=== PREVIOUS TRANSLATION ===")
+                    appendLine(translatedContext)
+                    appendLine("=== TEXT TO TRANSLATE (RETURN ONLY THIS SECTION) ===")
+                    appendLine(chunk)
+                    appendLine("Translate ONLY the section under \"TEXT TO TRANSLATE\".")
+                    appendLine("Preserve paragraph breaks exactly.")
+                    appendLine("Do not merge or split paragraphs.")
+                    append("Return exactly $currentParagraphCount paragraphs.")
+                }
+            } else {
+                chunk
+            }
+
             var chunkSuccess = false
             for (attempt in 1..2) {
                 try {
-                    val result = engine.translate(listOf(chunk), task.sourceLanguage, task.targetLanguage)
+                    val result = engine.translate(listOf(textToSend), task.sourceLanguage, task.targetLanguage)
                     when (result) {
                         is TranslationResult.Success -> {
                             val translated = result.translatedTexts.firstOrNull() ?: ""
-                            val translatedParagraphs = translated.split("\n\n").filter { it.isNotBlank() }
-                            allTranslated.addAll(translatedParagraphs.ifEmpty { listOf(translated) })
+                            // Strip any contextual anchoring markers that the LLM might echo back
+                            val cleanedTranslation = if (useAnchoring && chunkIndex > 0) {
+                                stripContextLeakage(translated)
+                            } else {
+                                translated
+                            }
+                            val translatedParagraphs = cleanedTranslation.split("\n\n").filter { it.isNotBlank() }
+                            // Update previous chunk tracking for next iteration
+                            previousRawParagraphs = chunkParagraphsList[chunkIndex]
+                            previousTranslatedParagraphs = translatedParagraphs.ifEmpty { listOf(cleanedTranslation) }
+                            allTranslated.addAll(previousTranslatedParagraphs)
                             chunkSuccess = true
                         }
                         is TranslationResult.Error -> {
@@ -959,6 +1015,20 @@ class TranslationService(
         }
     }
 
+    /**
+     * Strip contextual anchoring markers that the LLM might echo back in its response.
+     * Only keeps text after the "TEXT TO TRANSLATE" marker if present.
+     */
+    private fun stripContextLeakage(translated: String): String {
+        val marker = "=== TEXT TO TRANSLATE"
+        val markerIndex = translated.indexOf(marker)
+        if (markerIndex < 0) return translated
+        // Find the end of the marker line
+        val afterMarker = translated.indexOf("\n", markerIndex)
+        if (afterMarker < 0) return translated
+        return translated.substring(afterMarker + 1).trim()
+    }
+
     companion object {
         /**
          * Priority values for translation queue.
@@ -967,5 +1037,14 @@ class TranslationService(
         const val PRIORITY_NORMAL = 50
         const val PRIORITY_HIGH = 100
         const val PRIORITY_MANUAL_READ = 200 // User manually opened chapter
+
+        /**
+         * Engine IDs for LLM-based translation engines that support contextual anchoring.
+         */
+        val LLM_ENGINE_IDS = setOf(
+            OpenAITranslateEngine.ENGINE_ID,
+            DeepSeekTranslateEngine.ENGINE_ID,
+            OllamaTranslateEngine.ENGINE_ID,
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
@@ -116,7 +116,13 @@ class DeepSeekTranslateEngine(
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
 
-        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. Translate the following text from $sourceLangName to $targetLangName.
+        val fromClause = if (sourceLanguage == "auto") {
+            "Detect the source language and translate the following text to $targetLangName."
+        } else {
+            "Translate the following text from $sourceLangName to $targetLangName."
+        }
+
+        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
 Rules:
 - Only output the translation, nothing else
 - Preserve paragraph structure (keep empty lines between paragraphs)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
@@ -116,6 +116,12 @@ class OllamaTranslateEngine(
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
 
+        val fromClause = if (sourceLanguage == "auto") {
+            "Detect the source language and translate the following text to $targetLangName."
+        } else {
+            "Translate the following text from $sourceLangName to $targetLangName."
+        }
+
         // Use custom prompt if configured
         val customPrompt = preferences.ollamaPrompt().get()
         val prompt = if (customPrompt.isNotBlank()) {
@@ -125,7 +131,7 @@ class OllamaTranslateEngine(
                 .replace("{TEXT}", text)
         } else {
             """You are a professional translator specializing in novel/fiction translation.
-Translate the following text from $sourceLangName to $targetLangName.
+$fromClause
 Rules:
 - Only output the translation, nothing else
 - Preserve paragraph structure (keep empty lines between paragraphs)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
@@ -116,7 +116,13 @@ class OpenAITranslateEngine(
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
 
-        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. Translate the following text from $sourceLangName to $targetLangName.
+        val fromClause = if (sourceLanguage == "auto") {
+            "Detect the source language and translate the following text to $targetLangName."
+        } else {
+            "Translate the following text from $sourceLangName to $targetLangName."
+        }
+
+        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
 Rules:
 - Only output the translation, nothing else
 - Preserve paragraph structure (keep empty lines between paragraphs)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/TranslationQueueScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/TranslationQueueScreen.kt
@@ -1,0 +1,235 @@
+package eu.kanade.tachiyomi.ui.setting
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.translation.TranslationService
+import tachiyomi.domain.translation.model.TranslationTask
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+object TranslationQueueScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val translationService = remember { Injekt.get<TranslationService>() }
+        val progress by translationService.progressState.collectAsState()
+        val isPaused by translationService.isPaused.collectAsState()
+        val queueItems by translationService.queueState.collectAsState()
+
+        val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+        Scaffold(
+            topBar = {
+                AppBar(
+                    title = stringResource(MR.strings.pref_translation_queue),
+                    navigateUp = navigator::pop,
+                    navigationIcon = Icons.AutoMirrored.Outlined.ArrowBack,
+                    scrollBehavior = scrollBehavior,
+                    actions = {
+                        if (progress.isRunning && !progress.isCancelling) {
+                            IconButton(
+                                onClick = {
+                                    if (isPaused) translationService.resume() else translationService.pause()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = if (isPaused) Icons.Filled.PlayArrow else Icons.Filled.Pause,
+                                    contentDescription = if (isPaused) {
+                                        stringResource(MR.strings.pref_translation_resume)
+                                    } else {
+                                        stringResource(MR.strings.pref_translation_pause)
+                                    },
+                                )
+                            }
+                            IconButton(onClick = { translationService.cancel() }) {
+                                Icon(
+                                    imageVector = Icons.Filled.Stop,
+                                    contentDescription = stringResource(MR.strings.pref_translation_cancel),
+                                )
+                            }
+                        }
+                        if (queueItems.isNotEmpty()) {
+                            IconButton(onClick = { translationService.clearQueue() }) {
+                                Icon(
+                                    imageVector = Icons.Filled.DeleteSweep,
+                                    contentDescription = stringResource(MR.strings.pref_translation_clear_queue),
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+        ) { contentPadding ->
+            if (queueItems.isEmpty() && !progress.isRunning) {
+                EmptyScreen(
+                    stringRes = MR.strings.pref_translation_status_idle,
+                    modifier = Modifier.padding(contentPadding),
+                )
+                return@Scaffold
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding),
+            ) {
+                // Status bar
+                if (progress.isRunning) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        ),
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            val statusText = when {
+                                progress.isCancelling -> stringResource(MR.strings.pref_translation_status_cancelling)
+                                isPaused -> stringResource(MR.strings.pref_translation_status_paused, progress.completedChapters, progress.totalChapters)
+                                else -> {
+                                    val current = progress.currentChapterName ?: "..."
+                                    val chunkInfo = if (progress.totalChunks > 1) {
+                                        stringResource(MR.strings.pref_translation_status_chunk_info, progress.currentChunkIndex, progress.totalChunks)
+                                    } else {
+                                        ""
+                                    }
+                                    stringResource(MR.strings.pref_translation_status_translating, current, chunkInfo, progress.completedChapters, progress.totalChapters)
+                                }
+                            }
+                            Text(
+                                text = statusText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                            if (progress.currentChapterProgress > 0f) {
+                                LinearProgressIndicator(
+                                    progress = { progress.currentChapterProgress },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 8.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Queue list
+                LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(
+                        items = queueItems,
+                        key = { it.chapterId },
+                    ) { task ->
+                        TranslationQueueItem(
+                            task = task,
+                            isCurrentlyTranslating = progress.isRunning &&
+                                task.status == tachiyomi.domain.translation.model.TranslationStatus.QUEUED &&
+                                queueItems.indexOf(task) == 0,
+                            onRemove = { translationService.dequeue(task.chapterId) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun TranslationQueueItem(
+        task: TranslationTask,
+        isCurrentlyTranslating: Boolean,
+        onRemove: () -> Unit,
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = if (isCurrentlyTranslating) {
+                    MaterialTheme.colorScheme.secondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.surfaceContainerLow
+                },
+            ),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(
+                        text = task.chapterName.ifBlank { "#${task.chapterId}" },
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = "${task.sourceLanguage} → ${task.targetLanguage}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (task.errorMessage != null) {
+                        Text(
+                            text = task.errorMessage!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                IconButton(onClick = onRemove) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(MR.strings.action_remove),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -304,4 +304,23 @@ class TranslationPreferences(
         "translation_chunk_size",
         50,
     )
+
+    /**
+     * Whether to send previous translated paragraphs as context to LLM engines.
+     * This improves translation consistency across chunks by giving the LLM
+     * context from the end of the previous chunk.
+     */
+    fun contextualAnchoringEnabled() = preferenceStore.getBoolean(
+        "translation_contextual_anchoring_enabled",
+        true,
+    )
+
+    /**
+     * Number of paragraphs from the end of the previous chunk to send as context.
+     * Only applies when contextual anchoring is enabled and the engine is an LLM.
+     */
+    fun contextualAnchoringParagraphs() = preferenceStore.getInt(
+        "translation_contextual_anchoring_paragraphs",
+        2,
+    )
 }

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Common actions (In MR)
     ext_update: Update
@@ -113,7 +113,7 @@
     <string name="translate_details_merge_genres">Add to existing genres (don\'t replace)</string>
     <string name="action_export_epub">Export as EPUB</string>
     <string name="action_export_epub_bulk">Export selected as EPUB</string>
-    <string name="export_epub_progress">Exporting %1$d of %2$d chapters…</string>
+    <string name="export_epub_progress">Exporting %1$d of %2$d chaptersâ€¦</string>
     <string name="export_epub_success">EPUB exported successfully</string>
     <string name="export_epub_error">Failed to export EPUB: %s</string>
     <string name="action_remove_chapters">Remove chapters</string>
@@ -125,7 +125,13 @@
     <string name="action_copy_links">Copy links</string>
     <string name="action_mass_import">Mass import</string>
 
-    <!-- Novel Translation Settings (see Translation Settings section below) -->
+    <!-- Novel Translation Settings (reader panel) -->
+    <string name="pref_novel_translation_settings">Translation</string>
+    <string name="pref_novel_translation_enabled">Enable translation</string>
+    <string name="pref_novel_realtime_translation">Real-time translation</string>
+    <string name="pref_novel_translation_engine_label">Engine</string>
+    <string name="pref_novel_translation_target_label">Target language</string>
+    <string name="pref_novel_translation_hint">Configure translation engine and API keys in Settings &#x2192; Translation</string>
 
     <!-- Novel Download Settings -->
     <string name="pref_novel_reader_summary">Novel reading mode, fonts, colors</string>
@@ -205,7 +211,7 @@
     <string name="epub_import_error_count">%d failed</string>
     <string name="epub_create_dir_failed">Failed to create directory for: %s</string>
     <string name="epub_novels_export_count">%d novel(s) will be exported.</string>
-    <string name="epub_and_more">… and %d more</string>
+    <string name="epub_and_more">â€¦ and %d more</string>
     <string name="epub_content_options">Content Options</string>
     <string name="epub_downloaded_only">Downloaded chapters only</string>
     <string name="epub_prefer_translated">Prefer translated chapters</string>
@@ -261,7 +267,7 @@
     <string name="novel_sort_source">Source order</string>
     <string name="novel_sort_chapter">Chapter number</string>
     <string name="novel_auto_split">Auto-split long chapters</string>
-    <string name="novel_split_word_count">Split word count (×50)</string>
+    <string name="novel_split_word_count">Split word count (Ã—50)</string>
     <string name="novel_force_lowercase">Force text to lowercase</string>
     <string name="novel_engine_format">Engine #%d</string>
     <string name="novel_enabled">Enabled</string>
@@ -271,7 +277,7 @@
     <string name="novel_add_rule">Add rule</string>
     <string name="novel_tag_regex">regex</string>
     <string name="novel_tag_text">text</string>
-    <string name="novel_rule_format">/%1$s/ → %2$s</string>
+    <string name="novel_rule_format">/%1$s/ â†’ %2$s</string>
     <string name="novel_rule_remove">(remove)</string>
     <string name="novel_no_rules">No rules added. Rules apply to chapter content before rendering.</string>
     <string name="novel_edit_rule">Edit Rule</string>
@@ -337,7 +343,7 @@
     <string name="pref_novel_realtime_translation">Real-time translation while reading</string>
     <string name="pref_novel_translation_engine_label">Engine</string>
     <string name="pref_novel_translation_target_label">Target language</string>
-    <string name="pref_novel_translation_hint">Configure translation engines in Settings → Novel → Translation</string>
+    <string name="pref_novel_translation_hint">Configure translation engines in Settings â†’ Novel â†’ Translation</string>
     <string name="action_disable_translation">Disable translation</string>
     <string name="not_configured">Not configured</string>
 
@@ -481,11 +487,11 @@
 
     <!-- Custom Source - Test screen -->
     <string name="custom_source_test_title">Test Source</string>
-    <string name="custom_source_testing">Testing source…</string>
+    <string name="custom_source_testing">Testing sourceâ€¦</string>
     <string name="custom_source_run_test">Run Test</string>
     <string name="custom_source_test_again">Test Again</string>
-    <string name="custom_source_all_tests_passed">✓ All tests passed</string>
-    <string name="custom_source_some_tests_failed">✗ Some tests failed</string>
+    <string name="custom_source_all_tests_passed">âœ“ All tests passed</string>
+    <string name="custom_source_some_tests_failed">âœ— Some tests failed</string>
     <string name="custom_source_export_subject">Custom Source: %s</string>
 
     <!-- Custom Source - WebView Element Selector Wizard -->
@@ -589,4 +595,38 @@
     <string name="custom_selector_test">Test</string>
     <string name="custom_selector_use">Use</string>
     <string name="custom_selector_select_parent_format">Select Parent &lt;%1$s&gt;</string>
+    <!-- Translation UI strings -->
+    <string name="action_retranslate">Retranslate</string>
+    <string name="action_delete_translation">Delete translation</string>
+    <string name="translation_smart_auto">Smart Auto-Translate</string>
+    <string name="translation_smart_auto_summary">Only translate if language differs from target</string>
+    <string name="translation_select_target_language">Select target language for translation</string>
+    <string name="translate_details_title">Translate Details</string>
+    <string name="translate_details_no_engine">No translation engine configured. Please configure one in Settings &gt; Translation.</string>
+    <string name="translate_details_translating">Translating&#8230;</string>
+    <string name="translate_details_original_title">Original Title:</string>
+    <string name="translate_details_translated_title">Translated Title:</string>
+    <string name="translate_details_add_alt_titles">Add translated title to alternative titles</string>
+    <string name="translate_details_save_tags_notes">Save translated tags to notes</string>
+    <string name="translate_details_original_desc">Original Description:</string>
+    <string name="translate_details_translated_desc">Translated Description:</string>
+    <string name="translate_details_original_genres">Original Genres:</string>
+    <string name="translate_details_translated_genres">Translated Genres:</string>
+    <string name="translate_details_save_genres">Save translated genres</string>
+    <string name="translate_details_merge_genres">Add to existing genres (don\'t replace)</string>
+    <!-- EPUB translation mode strings -->
+    <string name="epub_translation_mode">Translation</string>
+    <string name="epub_translation_original">Original only</string>
+    <string name="epub_translation_translated">Translated only</string>
+    <string name="epub_translation_both">Both (two separate files)</string>
+    <string name="epub_translation_translated_info">Only chapters with translations will be included.</string>
+    <string name="epub_translation_both_info">Two EPUB files will be created &#8212; one original, one translated.</string>
+    <!-- Translation notifications -->
+    <string name="channel_translation">Translation</string>
+    <string name="translation_job_translating">Translating chapters&#8230;</string>
+    <string name="translation_job_processing">Processing&#8230;</string>
+    <string name="translation_job_complete">Translation Complete</string>
+    <string name="translation_job_complete_count">%d chapters translated</string>
 </resources>
+
+


### PR DESCRIPTION
This pull request introduces enhancements to the EPUB export dialogs and chapter selection actions, primarily focused on supporting multiple translation modes and expanding batch actions for chapters. The most significant changes involve replacing the simple "prefer translated" option with a more flexible `TranslationMode` (Original, Translated, Both) in both batch and single export dialogs, updating the UI to reflect these options, and adding new multi-chapter actions related to translations.

### EPUB Export Dialog Improvements

* Replaced the `preferTranslated` boolean with a `translationMode` enum in both `EpubExportOptions` and dialog state, allowing users to choose between exporting original, translated, or both versions of chapters. The UI now uses radio buttons for this selection, and the export logic adapts the file type (EPUB or ZIP) based on the chosen mode. (`app/src/main/java/eu/kanade/presentation/library/components/BatchExportEpubDialog.kt`, [[1]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bR26-R38) [[2]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL60-R69) [[3]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL75-R79) [[4]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL142-R169) [[5]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL181-R208) [[6]](diffhunk://#diff-ade4cb769dbfdca5176365fe414d005ced4808fb2bc0d50da7f88092d5836f2bL194-R223); `app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt`, [[7]](diffhunk://#diff-88d9988e2676aa98a36e162241e2452d3b3a19f4262bbfb1fc23440a21277fafR25-R65) [[8]](diffhunk://#diff-88d9988e2676aa98a36e162241e2452d3b3a19f4262bbfb1fc23440a21277fafR94-R186)

* Updated the export dialogs to display additional options: users can now include chapter count, range, and status in filenames, and see contextual info messages based on their selections. (`app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt`, [app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.ktR94-R186](diffhunk://#diff-88d9988e2676aa98a36e162241e2452d3b3a19f4262bbfb1fc23440a21277fafR94-R186))

### Chapter Selection and Batch Actions

* Added new callback parameters and wiring for multi-chapter actions: delete translation, translate selected, and retranslate selected chapters. These are propagated through the various `MangaScreen` implementations and the bottom action menu, allowing bulk operations on chapter translations. (`app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt`, [[1]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR138-R140) [[2]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR199-R201) [[3]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR249-R251) [[4]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR311-R313) [[5]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR429-R431) [[6]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR626-R628) [[7]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR741-R743) [[8]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR897-R899) [[9]](diffhunk://#diff-76b8d8a0a0eeb12da3a47851805183aae5327d1ce2e3c1f84a7c984328d5091dR935-R955)

* Updated the bottom action menu to support new overflow actions for translation-related operations, showing these options only when relevant chapters are selected. (`app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt`, [[1]](diffhunk://#diff-34d488b5075f9524bd445b66d441c429da916f47370d13af40191af707cf4a23R86-R88) [[2]](diffhunk://#diff-34d488b5075f9524bd445b66d441c429da916f47370d13af40191af707cf4a23L192-R195)

These changes make the export and batch chapter actions more flexible and user-friendly, especially for users working with translated content.