### PR TITLE
feat: database maintenance as WorkManager job

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -56,6 +56,7 @@ import eu.kanade.domain.extension.interactor.TrustExtension
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.screen.advanced.ClearDatabaseScreen
 import eu.kanade.presentation.more.settings.screen.debug.DebugInfoScreen
+import eu.kanade.tachiyomi.data.database.DatabaseMaintenanceJob
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.library.MetadataUpdateJob
 import eu.kanade.tachiyomi.network.NetworkHelper
@@ -102,6 +103,7 @@ import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
@@ -890,8 +892,8 @@ object SettingsAdvancedScreen : SearchableSettings {
                                         val estChapterTableSize = (chapterCount * estChapterRowSize).toLong()
                                         appendLine("Chapters data: ~${formatSize(estChapterTableSize)}")
 
-                                        // 4 indexes on chapters table, each ~16-40 bytes per row
-                                        val estChapterIndexSize = chapterCount * 100 // ~100 bytes per row for all indexes
+                                        // 6 indexes on chapters table, each ~16-40 bytes per row
+                                        val estChapterIndexSize = chapterCount * 150 // ~150 bytes per row for all indexes
                                         appendLine("Chapter indexes: ~${formatSize(estChapterIndexSize)}")
 
                                         if (avgDescBytes > 0 && mangaCount > 0) {
@@ -919,47 +921,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_db_maintenance),
                     subtitle = stringResource(MR.strings.pref_db_maintenance_subtitle),
                     onClick = {
-                        scope.launch {
-                            try {
-                                val handler = Injekt.get<tachiyomi.data.DatabaseHandler>()
-
-                                // Get stats before
-                                val statsBefore = handler.getDatabaseStats()
-                                val sizeBefore = statsBefore["total_size_bytes"] ?: 0L
-
-                                withUIContext { context.toast("Running ANALYZE...") }
-                                handler.analyze()
-
-                                withUIContext { context.toast("Running REINDEX...") }
-                                handler.reindex()
-
-                                withUIContext { context.toast("Running VACUUM (this may take a while)...") }
-                                handler.vacuum()
-
-                                // Get stats after
-                                val statsAfter = handler.getDatabaseStats()
-                                val sizeAfter = statsAfter["total_size_bytes"] ?: 0L
-                                val saved = sizeBefore - sizeAfter
-
-                                val savedStr = when {
-                                    saved >= 1024 * 1024 -> "%.2f MB".format(saved / (1024.0 * 1024.0))
-                                    saved >= 1024 -> "%.2f KB".format(saved / 1024.0)
-                                    else -> "$saved bytes"
-                                }
-
-                                withUIContext {
-                                    if (saved > 0) {
-                                        context.toast("Database optimized! Saved $savedStr")
-                                    } else {
-                                        context.toast("Database optimized!")
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                logcat(LogPriority.ERROR, e) { "Database maintenance failed" }
-                                withUIContext {
-                                    context.toast("Database maintenance failed: ${e.message}")
-                                }
-                            }
+                        if (DatabaseMaintenanceJob.isRunning(context)) {
+                            context.toast(context.contextStringResource(TDMR.strings.db_maintenance_already_running))
+                        } else {
+                            DatabaseMaintenanceJob.start(context)
+                            context.toast(context.contextStringResource(TDMR.strings.db_maintenance_started))
                         }
                     },
                 ),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DatabaseMaintenanceJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DatabaseMaintenanceJob.kt
@@ -1,0 +1,139 @@
+package eu.kanade.tachiyomi.data.database
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkerParameters
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.isRunning
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import eu.kanade.tachiyomi.util.system.notify
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import kotlinx.coroutines.CancellationException
+import logcat.LogPriority
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.i18n.novel.TDMR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class DatabaseMaintenanceJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val handler: DatabaseHandler = Injekt.get()
+
+    override suspend fun doWork(): Result {
+        setForegroundSafely()
+
+        return withIOContext {
+            try {
+                val statsBefore = handler.getDatabaseStats()
+                val sizeBefore = statsBefore["total_size_bytes"] ?: 0L
+
+                updateNotification(context.stringResource(TDMR.strings.db_maintenance_running_analyze))
+                handler.analyze()
+
+                updateNotification(context.stringResource(TDMR.strings.db_maintenance_running_reindex))
+                handler.reindex()
+
+                updateNotification(context.stringResource(TDMR.strings.db_maintenance_running_vacuum))
+                handler.vacuum()
+
+                val statsAfter = handler.getDatabaseStats()
+                val sizeAfter = statsAfter["total_size_bytes"] ?: 0L
+                val saved = sizeBefore - sizeAfter
+
+                val savedStr = when {
+                    saved >= 1024 * 1024 -> "%.2f MB".format(saved / (1024.0 * 1024.0))
+                    saved >= 1024 -> "%.2f KB".format(saved / 1024.0)
+                    else -> "$saved bytes"
+                }
+
+                val message = if (saved > 0) {
+                    context.stringResource(TDMR.strings.db_maintenance_optimized_saved, savedStr)
+                } else {
+                    context.stringResource(TDMR.strings.db_maintenance_optimized)
+                }
+                showComplete(message)
+                Result.success()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                logcat(LogPriority.ERROR, e) { "Database maintenance failed" }
+                showComplete(context.stringResource(TDMR.strings.db_maintenance_failed, e.message ?: ""))
+                Result.failure()
+            } finally {
+                context.cancelNotification(Notifications.ID_DB_MAINTENANCE_PROGRESS)
+            }
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val notification = context.notificationBuilder(Notifications.CHANNEL_DB_MAINTENANCE) {
+            setSmallIcon(android.R.drawable.ic_popup_sync)
+            setContentTitle(context.stringResource(TDMR.strings.db_maintenance_title))
+            setContentText(context.stringResource(TDMR.strings.db_maintenance_starting))
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+            setProgress(0, 0, true)
+        }.build()
+        return ForegroundInfo(
+            Notifications.ID_DB_MAINTENANCE_PROGRESS,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    private fun updateNotification(step: String) {
+        val notification = context.notificationBuilder(Notifications.CHANNEL_DB_MAINTENANCE) {
+            setSmallIcon(android.R.drawable.ic_popup_sync)
+            setContentTitle(context.stringResource(TDMR.strings.db_maintenance_title))
+            setContentText(step)
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+            setProgress(0, 0, true)
+        }.build()
+        context.notify(Notifications.ID_DB_MAINTENANCE_PROGRESS, notification)
+    }
+
+    private fun showComplete(message: String) {
+        context.cancelNotification(Notifications.ID_DB_MAINTENANCE_PROGRESS)
+        val notification = context.notificationBuilder(Notifications.CHANNEL_DB_MAINTENANCE) {
+            setSmallIcon(android.R.drawable.ic_popup_sync)
+            setContentTitle(context.stringResource(TDMR.strings.db_maintenance_complete_title))
+            setContentText(message)
+            setAutoCancel(true)
+        }.build()
+        context.notify(Notifications.ID_DB_MAINTENANCE_COMPLETE, notification)
+    }
+
+    companion object {
+        private const val TAG = "DatabaseMaintenanceJob"
+
+        fun start(context: Context) {
+            val workRequest = OneTimeWorkRequestBuilder<DatabaseMaintenanceJob>()
+                .addTag(TAG)
+                .build()
+            context.workManager.enqueueUniqueWork(
+                TAG,
+                ExistingWorkPolicy.KEEP,
+                workRequest,
+            )
+        }
+
+        fun isRunning(context: Context): Boolean {
+            return context.workManager.isRunning(TAG)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -105,6 +105,13 @@ object Notifications {
     const val ID_LIBRARY_EXPORT_PROGRESS = -703
     const val ID_LIBRARY_EXPORT_COMPLETE = -704
 
+    /**
+     * Notification channel and ids used by database maintenance.
+     */
+    const val CHANNEL_DB_MAINTENANCE = "db_maintenance_channel"
+    const val ID_DB_MAINTENANCE_PROGRESS = -901
+    const val ID_DB_MAINTENANCE_COMPLETE = -902
+
     private val deprecatedChannels = listOf(
         "downloader_channel",
         "downloader_complete_channel",
@@ -210,6 +217,10 @@ object Notifications {
                 },
                 buildNotificationChannel(CHANNEL_LIBRARY_EXPORT, IMPORTANCE_LOW) {
                     setName("Library Export")
+                    setShowBadge(false)
+                },
+                buildNotificationChannel(CHANNEL_DB_MAINTENANCE, IMPORTANCE_LOW) {
+                    setName(context.stringResource(TDMR.strings.channel_db_maintenance))
                     setShowBadge(false)
                 },
             ),

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -20,8 +20,6 @@ CREATE TABLE chapters(
     ON DELETE CASCADE
 );
 
-CREATE INDEX chapters_manga_id_index ON chapters(manga_id);
-CREATE INDEX chapters_unread_by_manga_index ON chapters(manga_id, read) WHERE read = 0;
 CREATE INDEX chapters_library_aggregate_index ON chapters(manga_id, read, bookmark, date_upload, date_fetch);
 CREATE INDEX chapters_manga_scanlator_index ON chapters(manga_id, scanlator);
 CREATE INDEX chapters_read_progress_index ON chapters(manga_id, read, last_page_read) WHERE read = 1 OR last_page_read != 0;

--- a/data/src/main/sqldelight/tachiyomi/migrations/23.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/23.sqm
@@ -1,0 +1,5 @@
+-- Drop redundant chapter indexes:
+-- chapters_manga_id_index(manga_id) is covered by chapters_library_aggregate_index(manga_id, read, bookmark, date_upload, date_fetch)
+-- chapters_unread_by_manga_index(manga_id, read) WHERE read=0 is covered by chapters_library_aggregate_index leading columns
+DROP INDEX IF EXISTS chapters_manga_id_index;
+DROP INDEX IF EXISTS chapters_unread_by_manga_index;

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -642,4 +642,18 @@
     <string name="skip_update_days">Skip if updated in last %d day(s)</string>
     <string name="novel_ext_repos_js_header">JS Plugin Repos</string>
     <string name="novel_ext_repos_kt_header">Kotlin Extension Repos</string>
+
+    <!-- Database maintenance notifications -->
+    <string name="channel_db_maintenance">Database Maintenance</string>
+    <string name="db_maintenance_title">Database maintenance</string>
+    <string name="db_maintenance_starting">Starting&#8230;</string>
+    <string name="db_maintenance_running_analyze">Running ANALYZE&#8230;</string>
+    <string name="db_maintenance_running_reindex">Running REINDEX&#8230;</string>
+    <string name="db_maintenance_running_vacuum">Running VACUUM (this may take a while)&#8230;</string>
+    <string name="db_maintenance_complete_title">Database Maintenance</string>
+    <string name="db_maintenance_optimized_saved">Database optimized! Saved %s</string>
+    <string name="db_maintenance_optimized">Database optimized!</string>
+    <string name="db_maintenance_failed">Maintenance failed: %s</string>
+    <string name="db_maintenance_already_running">Database maintenance is already running</string>
+    <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
 </resources>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1213,7 +1213,7 @@
     <string name="pref_db_statistics">Database statistics</string>
     <string name="pref_db_statistics_subtitle">Show detailed database size breakdown</string>
     <string name="pref_db_maintenance">Database maintenance</string>
-    <string name="pref_db_maintenance_subtitle">VACUUM, REINDEX, and ANALYZE database</string>
+    <string name="pref_db_maintenance_subtitle">ANALYZE, REINDEX, and VACUUM. VACUUM temporarily needs free space equal to the database size.</string>
     <string name="pref_bulk_remove_url">Bulk remove by URL</string>
     <string name="pref_bulk_remove_url_subtitle">Remove multiple entries from library by URL list</string>
 


### PR DESCRIPTION
- Convert DB maintenance (ANALYZE/REINDEX/VACUUM) from composable scope to WorkManager CoroutineWorker
- Fixes ForgottenCoroutineScopeException when leaving settings during ANALYZE
- Shows progress notification for each step
- Drop redundant chapter indexes (chapters_manga_id_index, chapters_unread_by_manga_index)
- Update maintenance subtitle with VACUUM storage warning
- Localize all notification/toast strings to TDMR namespace

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
