### PR TITLE
feat: library clear operations as background WorkManager jobs

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -19,29 +19,61 @@ import tachiyomi.presentation.core.i18n.stringResource
 fun DeleteLibraryMangaDialog(
     containsLocalManga: Boolean,
     onDismissRequest: () -> Unit,
-    onConfirm: (Boolean, Boolean, Boolean, Boolean) -> Unit,
+    onConfirm: (
+        removeFromLibrary: Boolean,
+        deleteDownloads: Boolean,
+        clearChaptersFromDb: Boolean,
+        deleteTranslations: Boolean,
+        clearCovers: Boolean,
+        clearDescriptions: Boolean,
+        clearTags: Boolean,
+    ) -> Unit,
 ) {
     var removeFromLibrary by remember { mutableStateOf(false) }
     var deleteDownloads by remember { mutableStateOf(false) }
     var clearChaptersFromDb by remember { mutableStateOf(false) }
     var deleteTranslations by remember { mutableStateOf(false) }
+    var clearCovers by remember { mutableStateOf(false) }
+    var clearDescriptions by remember { mutableStateOf(false) }
+    var clearTags by remember { mutableStateOf(false) }
+
+    // Cascading: "remove from library" auto-checks clear operations (but not downloads/translations)
+    fun onRemoveFromLibraryChanged(checked: Boolean) {
+        removeFromLibrary = checked
+        if (checked) {
+            clearChaptersFromDb = true
+            clearCovers = true
+            clearDescriptions = true
+            clearTags = true
+        }
+    }
 
     data class CheckboxItem(
         val label: StringResource,
         val checked: Boolean,
         val onCheckedChange: (Boolean) -> Unit,
+        val enabled: Boolean = true,
     )
 
-    val checkboxItems = remember(containsLocalManga, removeFromLibrary, deleteDownloads, clearChaptersFromDb, deleteTranslations) {
+    val checkboxItems = remember(
+        containsLocalManga, removeFromLibrary, deleteDownloads, clearChaptersFromDb,
+        deleteTranslations, clearCovers, clearDescriptions, clearTags,
+    ) {
         buildList {
-            add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary) { removeFromLibrary = it })
+            add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary, { onRemoveFromLibraryChanged(it) }))
             if (!containsLocalManga) {
-                add(CheckboxItem(MR.strings.downloaded_chapters, deleteDownloads) { deleteDownloads = it })
+                add(CheckboxItem(MR.strings.downloaded_chapters, deleteDownloads, { deleteDownloads = it }))
             }
-            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb) { clearChaptersFromDb = it })
-            add(CheckboxItem(TDMR.strings.translated_chapters, deleteTranslations) { deleteTranslations = it })
+            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb, { clearChaptersFromDb = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.translated_chapters, deleteTranslations, { deleteTranslations = it }))
+            add(CheckboxItem(TDMR.strings.action_clear_covers, clearCovers, { clearCovers = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.action_clear_descriptions, clearDescriptions, { clearDescriptions = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.action_clear_tags, clearTags, { clearTags = it }, enabled = !removeFromLibrary))
         }
     }
+
+    val anyChecked = removeFromLibrary || deleteDownloads || clearChaptersFromDb ||
+        deleteTranslations || clearCovers || clearDescriptions || clearTags
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -52,7 +84,7 @@ fun DeleteLibraryMangaDialog(
         },
         confirmButton = {
             TextButton(
-                enabled = removeFromLibrary || deleteDownloads || clearChaptersFromDb || deleteTranslations,
+                enabled = anyChecked,
                 onClick = {
                     onDismissRequest()
                     onConfirm(
@@ -60,6 +92,9 @@ fun DeleteLibraryMangaDialog(
                         deleteDownloads && !containsLocalManga,
                         clearChaptersFromDb,
                         deleteTranslations,
+                        clearCovers,
+                        clearDescriptions,
+                        clearTags,
                     )
                 },
             ) {
@@ -76,6 +111,7 @@ fun DeleteLibraryMangaDialog(
                         label = stringResource(item.label),
                         checked = item.checked,
                         onCheckedChange = item.onCheckedChange,
+                        enabled = item.enabled,
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -56,8 +56,14 @@ fun DeleteLibraryMangaDialog(
     )
 
     val checkboxItems = remember(
-        containsLocalManga, removeFromLibrary, deleteDownloads, clearChaptersFromDb,
-        deleteTranslations, clearCovers, clearDescriptions, clearTags,
+        containsLocalManga,
+        removeFromLibrary,
+        deleteDownloads,
+        clearChaptersFromDb,
+        deleteTranslations,
+        clearCovers,
+        clearDescriptions,
+        clearTags,
     ) {
         buildList {
             add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary, { onRemoveFromLibraryChanged(it) }))

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -315,9 +315,6 @@ fun LibraryBottomActionMenu(
     onTranslateClicked: (() -> Unit)? = null,
     onRemoveChaptersClicked: (() -> Unit)? = null,
     onExportEpubClicked: (() -> Unit)? = null,
-    onClearCoversClicked: (() -> Unit)? = null,
-    onClearDescriptionsClicked: (() -> Unit)? = null,
-    onClearTagsClicked: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -468,33 +465,6 @@ fun LibraryBottomActionMenu(
                                     onClick = {
                                         overflowMenuOpen = false
                                         onExportEpubClicked()
-                                    },
-                                )
-                            }
-                            if (onClearCoversClicked != null) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(TDMR.strings.action_clear_covers)) },
-                                    onClick = {
-                                        overflowMenuOpen = false
-                                        onClearCoversClicked()
-                                    },
-                                )
-                            }
-                            if (onClearDescriptionsClicked != null) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(TDMR.strings.action_clear_descriptions)) },
-                                    onClick = {
-                                        overflowMenuOpen = false
-                                        onClearDescriptionsClicked()
-                                    },
-                                )
-                            }
-                            if (onClearTagsClicked != null) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(TDMR.strings.action_clear_tags)) },
-                                    onClick = {
-                                        overflowMenuOpen = false
-                                        onClearTagsClicked()
                                     },
                                 )
                             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryClearJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryClearJob.kt
@@ -1,0 +1,212 @@
+package eu.kanade.tachiyomi.data.library
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import eu.kanade.tachiyomi.util.system.notify
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import kotlinx.coroutines.CancellationException
+import logcat.LogPriority
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.interactor.RemoveChapters
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.model.MangaUpdate
+import tachiyomi.i18n.novel.TDMR
+import tachiyomi.source.local.isLocal
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+
+class LibraryClearJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val getManga: GetManga = Injekt.get()
+    private val updateManga: UpdateManga = Injekt.get()
+    private val coverCache: CoverCache = Injekt.get()
+    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get()
+    private val removeChapters: RemoveChapters = Injekt.get()
+
+    override suspend fun doWork(): Result {
+        val mangaIds = loadMangaIds() ?: return Result.failure()
+        val operation = inputData.getString(KEY_OPERATION) ?: return Result.failure()
+
+        setForegroundSafely()
+
+        return withIOContext {
+            try {
+                when (operation) {
+                    OP_CLEAR_COVERS -> clearCovers(mangaIds)
+                    OP_CLEAR_DESCRIPTIONS -> clearDescriptions(mangaIds)
+                    OP_CLEAR_TAGS -> clearTags(mangaIds)
+                    OP_CLEAR_CHAPTERS -> clearChapters(mangaIds)
+                    else -> return@withIOContext Result.failure()
+                }
+                Result.success()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                logcat(LogPriority.ERROR, e) { "Library clear job failed: $operation" }
+                Result.failure()
+            } finally {
+                context.cancelNotification(Notifications.ID_LIBRARY_CLEAR_PROGRESS)
+            }
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val operation = inputData.getString(KEY_OPERATION) ?: "Clear"
+        val title = when (operation) {
+            OP_CLEAR_COVERS -> context.stringResource(TDMR.strings.library_clear_clearing_covers)
+            OP_CLEAR_DESCRIPTIONS -> context.stringResource(TDMR.strings.library_clear_clearing_descriptions)
+            OP_CLEAR_TAGS -> context.stringResource(TDMR.strings.library_clear_clearing_tags)
+            OP_CLEAR_CHAPTERS -> context.stringResource(TDMR.strings.library_clear_clearing_chapters)
+            else -> context.stringResource(TDMR.strings.library_clear_clearing)
+        }
+        val notification = context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
+            setSmallIcon(android.R.drawable.ic_menu_delete)
+            setContentTitle(title)
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+            setProgress(0, 0, true)
+        }.build()
+        return ForegroundInfo(
+            Notifications.ID_LIBRARY_CLEAR_PROGRESS,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    private suspend fun clearCovers(mangaIds: LongArray) {
+        val total = mangaIds.size
+        mangaIds.forEachIndexed { index, id ->
+            val manga = getManga.await(id) ?: return@forEachIndexed
+            if (!manga.isLocal()) {
+                coverCache.deleteFromCache(manga, true)
+            }
+            updateManga.await(
+                MangaUpdate(
+                    id = id,
+                    thumbnailUrl = "",
+                    coverLastModified = System.currentTimeMillis(),
+                ),
+            )
+            updateProgress(index + 1, total, context.stringResource(TDMR.strings.library_clear_clearing_covers))
+        }
+        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_covers, total))
+    }
+
+    private suspend fun clearDescriptions(mangaIds: LongArray) {
+        val updates = mangaIds.map { MangaUpdate(id = it, description = "") }
+        updateManga.awaitAll(updates)
+        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_descriptions, mangaIds.size))
+    }
+
+    private suspend fun clearTags(mangaIds: LongArray) {
+        val updates = mangaIds.map { MangaUpdate(id = it, genre = emptyList()) }
+        updateManga.awaitAll(updates)
+        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_tags, mangaIds.size))
+    }
+
+    private suspend fun clearChapters(mangaIds: LongArray) {
+        val total = mangaIds.size
+        mangaIds.forEachIndexed { index, id ->
+            val chapters = getChaptersByMangaId.await(id)
+            if (chapters.isNotEmpty()) {
+                removeChapters.await(chapters)
+            }
+            updateProgress(index + 1, total, context.stringResource(TDMR.strings.library_clear_clearing_chapters))
+        }
+        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_chapters, total))
+    }
+
+    private fun updateProgress(current: Int, total: Int, title: String) {
+        val notification = context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
+            setSmallIcon(android.R.drawable.ic_menu_delete)
+            setContentTitle(title)
+            setContentText("$current / $total")
+            setProgress(total, current, false)
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+        }.build()
+        context.notify(Notifications.ID_LIBRARY_CLEAR_PROGRESS, notification)
+    }
+
+    private fun showComplete(message: String) {
+        context.cancelNotification(Notifications.ID_LIBRARY_CLEAR_PROGRESS)
+        val notification = context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
+            setSmallIcon(android.R.drawable.ic_menu_delete)
+            setContentTitle(context.stringResource(TDMR.strings.library_clear_complete_title))
+            setContentText(message)
+            setAutoCancel(true)
+        }.build()
+        context.notify(Notifications.ID_LIBRARY_CLEAR_COMPLETE, notification)
+    }
+
+    private fun loadMangaIds(): LongArray? {
+        inputData.getLongArray(KEY_MANGA_IDS)?.let { return it }
+        val filePath = inputData.getString(KEY_IDS_FILE) ?: return null
+        return try {
+            val file = File(filePath)
+            val ids = file.readText().split(",").mapNotNull { it.trim().toLongOrNull() }.toLongArray()
+            file.delete()
+            ids
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read manga IDs from file: $filePath" }
+            null
+        }
+    }
+
+    companion object {
+        private const val TAG = "LibraryClearJob"
+        private const val KEY_MANGA_IDS = "manga_ids"
+        private const val KEY_IDS_FILE = "ids_file"
+        private const val KEY_OPERATION = "operation"
+        private const val MAX_DIRECT_IDS = 500
+        const val OP_CLEAR_COVERS = "clear_covers"
+        const val OP_CLEAR_DESCRIPTIONS = "clear_descriptions"
+        const val OP_CLEAR_TAGS = "clear_tags"
+        const val OP_CLEAR_CHAPTERS = "clear_chapters"
+
+        fun start(context: Context, mangaIds: List<Long>, operation: String) {
+            val inputDataBuilder = workDataOf(KEY_OPERATION to operation).let {
+                androidx.work.Data.Builder().putAll(it)
+            }
+
+            if (mangaIds.size <= MAX_DIRECT_IDS) {
+                inputDataBuilder.putLongArray(KEY_MANGA_IDS, mangaIds.toLongArray())
+            } else {
+                val idsFile = File(context.cacheDir, "clear_job_ids_${System.currentTimeMillis()}.txt")
+                idsFile.writeText(mangaIds.joinToString(","))
+                inputDataBuilder.putString(KEY_IDS_FILE, idsFile.absolutePath)
+            }
+
+            val workRequest = OneTimeWorkRequestBuilder<LibraryClearJob>()
+                .addTag(TAG)
+                .setInputData(inputDataBuilder.build())
+                .build()
+            context.workManager.enqueueUniqueWork(
+                "${TAG}_$operation",
+                ExistingWorkPolicy.REPLACE,
+                workRequest,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -111,6 +111,7 @@ object Notifications {
     const val CHANNEL_LIBRARY_CLEAR = "library_clear_channel"
     const val ID_LIBRARY_CLEAR_PROGRESS = -801
     const val ID_LIBRARY_CLEAR_COMPLETE = -802
+    /**
      * Notification channel and ids used by database maintenance.
      */
     const val CHANNEL_DB_MAINTENANCE = "db_maintenance_channel"
@@ -226,6 +227,7 @@ object Notifications {
                 },
                 buildNotificationChannel(CHANNEL_LIBRARY_CLEAR, IMPORTANCE_LOW) {
                     setName(context.stringResource(TDMR.strings.channel_library_clear))
+                },
                 buildNotificationChannel(CHANNEL_DB_MAINTENANCE, IMPORTANCE_LOW) {
                     setName(context.stringResource(TDMR.strings.channel_db_maintenance))
                     setShowBadge(false)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -105,6 +105,13 @@ object Notifications {
     const val ID_LIBRARY_EXPORT_PROGRESS = -703
     const val ID_LIBRARY_EXPORT_COMPLETE = -704
 
+    /**
+     * Notification channel and ids used by library clear operations.
+     */
+    const val CHANNEL_LIBRARY_CLEAR = "library_clear_channel"
+    const val ID_LIBRARY_CLEAR_PROGRESS = -801
+    const val ID_LIBRARY_CLEAR_COMPLETE = -802
+
     private val deprecatedChannels = listOf(
         "downloader_channel",
         "downloader_complete_channel",
@@ -210,6 +217,10 @@ object Notifications {
                 },
                 buildNotificationChannel(CHANNEL_LIBRARY_EXPORT, IMPORTANCE_LOW) {
                     setName("Library Export")
+                    setShowBadge(false)
+                },
+                buildNotificationChannel(CHANNEL_LIBRARY_CLEAR, IMPORTANCE_LOW) {
+                    setName(context.stringResource(TDMR.strings.channel_library_clear))
                     setShowBadge(false)
                 },
             ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -25,6 +25,7 @@ import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.epub.EpubExportJob
+import eu.kanade.tachiyomi.data.library.LibraryClearJob
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.translation.TranslationJob
@@ -840,6 +841,9 @@ class LibraryScreenModel(
         deleteChapters: Boolean,
         clearChaptersFromDb: Boolean = false,
         deleteTranslations: Boolean = false,
+        clearCovers: Boolean = false,
+        clearDescriptions: Boolean = false,
+        clearTags: Boolean = false,
     ) {
         screenModelScope.launchNonCancellable {
             if (deleteFromLibrary) {
@@ -874,9 +878,22 @@ class LibraryScreenModel(
                 }
             }
 
+            // Delegate clear operations to LibraryClearJob (runs as background WorkManager job)
+            val mangaIds = mangas.map { it.id }
+            val context = Injekt.get<android.app.Application>()
+            if (clearCovers) {
+                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_COVERS)
+            }
+            if (clearDescriptions) {
+                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
+            }
+            if (clearTags) {
+                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_TAGS)
+            }
+
             // Refresh library UI after modifications
             if (deleteFromLibrary) {
-            } else if (deleteChapters || clearChaptersFromDb || deleteTranslations) {
+            } else if (deleteChapters || clearChaptersFromDb || deleteTranslations || clearCovers || clearDescriptions || clearTags) {
                 getLibraryManga.notifyChanged()
             }
         }
@@ -889,26 +906,8 @@ class LibraryScreenModel(
         val mangas = state.value.selectedManga
         if (mangas.isEmpty()) return
 
-        screenModelScope.launchNonCancellable {
-            mangas.forEach { manga ->
-                if (!manga.isLocal()) {
-                    coverCache.deleteFromCache(manga, true)
-                }
-            }
-            val updates = mangas.map {
-                MangaUpdate(
-                    id = it.id,
-                    thumbnailUrl = "",
-                    coverLastModified = System.currentTimeMillis(),
-                )
-            }
-            updateManga.awaitAll(updates)
-
-            snackbarHostState.showSnackbar(
-                message = "Cleared covers for ${mangas.size} entries",
-                duration = SnackbarDuration.Short,
-            )
-        }
+        val context = Injekt.get<android.app.Application>()
+        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_COVERS)
         clearSelection()
     }
 
@@ -919,17 +918,8 @@ class LibraryScreenModel(
         val mangas = state.value.selectedManga
         if (mangas.isEmpty()) return
 
-        screenModelScope.launchNonCancellable {
-            val updates = mangas.map {
-                MangaUpdate(id = it.id, description = "")
-            }
-            updateManga.awaitAll(updates)
-
-            snackbarHostState.showSnackbar(
-                message = "Cleared descriptions for ${mangas.size} entries",
-                duration = SnackbarDuration.Short,
-            )
-        }
+        val context = Injekt.get<android.app.Application>()
+        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
         clearSelection()
     }
 
@@ -940,17 +930,8 @@ class LibraryScreenModel(
         val mangas = state.value.selectedManga
         if (mangas.isEmpty()) return
 
-        screenModelScope.launchNonCancellable {
-            val updates = mangas.map {
-                MangaUpdate(id = it.id, genre = emptyList())
-            }
-            updateManga.awaitAll(updates)
-
-            snackbarHostState.showSnackbar(
-                message = "Cleared tags for ${mangas.size} entries",
-                duration = SnackbarDuration.Short,
-            )
-        }
+        val context = Injekt.get<android.app.Application>()
+        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_TAGS)
         clearSelection()
     }
 
@@ -1189,12 +1170,8 @@ class LibraryScreenModel(
     }
 
     fun removeChaptersFromSelectedManga(mangaList: List<Manga>) {
-        screenModelScope.launchNonCancellable {
-            mangaList.forEach { manga ->
-                val chapters = getChaptersByMangaId.await(manga.id)
-                removeChapters.await(chapters)
-            }
-        }
+        val context = Injekt.get<android.app.Application>()
+        LibraryClearJob.start(context, mangaList.map { it.id }, LibraryClearJob.OP_CLEAR_CHAPTERS)
         clearSelection()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -181,9 +181,6 @@ data object LibraryTab : Tab {
                         screenModel.clearSelection()
                     },
                     onTranslateClicked = screenModel::translateSelectedNovels,
-                    onClearCoversClicked = screenModel::clearCoversForSelection,
-                    onClearDescriptionsClicked = screenModel::clearDescriptionsForSelection,
-                    onClearTagsClicked = screenModel::clearTagsForSelection,
                 )
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -290,8 +287,11 @@ data object LibraryTab : Tab {
                 DeleteLibraryMangaDialog(
                     containsLocalManga = dialog.manga.any(Manga::isLocal),
                     onDismissRequest = onDismissRequest,
-                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations ->
-                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations)
+                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations, clearCovers, clearDescriptions, clearTags ->
+                        screenModel.removeMangas(
+                            dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations,
+                            clearCovers, clearDescriptions, clearTags,
+                        )
                         screenModel.clearSelection()
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -289,8 +289,14 @@ data object LibraryTab : Tab {
                     onDismissRequest = onDismissRequest,
                     onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations, clearCovers, clearDescriptions, clearTags ->
                         screenModel.removeMangas(
-                            dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations,
-                            clearCovers, clearDescriptions, clearTags,
+                            dialog.manga,
+                            deleteManga,
+                            deleteChapter,
+                            clearChaptersFromDb,
+                            deleteTranslations,
+                            clearCovers,
+                            clearDescriptions,
+                            clearTags,
                         )
                         screenModel.clearSelection()
                     },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
@@ -311,8 +311,14 @@ data object NovelsTab : Tab {
                     onDismissRequest = onDismissRequest,
                     onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations, clearCovers, clearDescriptions, clearTags ->
                         screenModel.removeMangas(
-                            dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations,
-                            clearCovers, clearDescriptions, clearTags,
+                            dialog.manga,
+                            deleteManga,
+                            deleteChapter,
+                            clearChaptersFromDb,
+                            deleteTranslations,
+                            clearCovers,
+                            clearDescriptions,
+                            clearTags,
                         )
                         screenModel.clearSelection()
                     },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
@@ -203,9 +203,6 @@ data object NovelsTab : Tab {
                     },
                     onRemoveChaptersClicked = screenModel::openRemoveChaptersDialog,
                     onExportEpubClicked = screenModel::openExportEpubDialog,
-                    onClearCoversClicked = screenModel::clearCoversForSelection,
-                    onClearDescriptionsClicked = screenModel::clearDescriptionsForSelection,
-                    onClearTagsClicked = screenModel::clearTagsForSelection,
                 )
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -312,8 +309,11 @@ data object NovelsTab : Tab {
                 DeleteLibraryMangaDialog(
                     containsLocalManga = dialog.manga.any(Manga::isLocal),
                     onDismissRequest = onDismissRequest,
-                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations ->
-                        screenModel.removeMangas(dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations)
+                    onConfirm = { deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations, clearCovers, clearDescriptions, clearTags ->
+                        screenModel.removeMangas(
+                            dialog.manga, deleteManga, deleteChapter, clearChaptersFromDb, deleteTranslations,
+                            clearCovers, clearDescriptions, clearTags,
+                        )
                         screenModel.clearSelection()
                     },
                 )

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -642,4 +642,17 @@
     <string name="skip_update_days">Skip if updated in last %d day(s)</string>
     <string name="novel_ext_repos_js_header">JS Plugin Repos</string>
     <string name="novel_ext_repos_kt_header">Kotlin Extension Repos</string>
+
+    <!-- Library clear notifications -->
+    <string name="channel_library_clear">Library Clear</string>
+    <string name="library_clear_clearing_covers">Clearing covers</string>
+    <string name="library_clear_clearing_descriptions">Clearing descriptions</string>
+    <string name="library_clear_clearing_tags">Clearing tags</string>
+    <string name="library_clear_clearing_chapters">Clearing chapters</string>
+    <string name="library_clear_clearing">Clearing</string>
+    <string name="library_clear_complete_title">Clear Complete</string>
+    <string name="library_clear_cleared_covers">Cleared covers for %d entries</string>
+    <string name="library_clear_cleared_descriptions">Cleared descriptions for %d entries</string>
+    <string name="library_clear_cleared_tags">Cleared tags for %d entries</string>
+    <string name="library_clear_cleared_chapters">Cleared chapters for %d entries</string>
 </resources>


### PR DESCRIPTION
…MR strings

- LibraryClearJob: CoroutineWorker for covers/descriptions/tags/chapters clearing
- DeleteLibraryMangaDialog: cascading checkboxes for clear options
- MangaBottomActionMenu: remove redundant clear actions from overflow menu
- LibraryScreenModel: delegate clear operations to LibraryClearJob
- Notifications: add LIBRARY_CLEAR channel and IDs
- TDMR strings for all notification texts

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
