### PR TITLE
perf: batch track queries in stats screen to fix N+1

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -103,12 +103,10 @@ class StatsScreenModel(
 
     private suspend fun getMangaTrackMap(libraryManga: List<LibraryManga>): Map<Long, List<Track>> {
         val loggedInTrackerIds = loggedInTrackers.map { it.id }.toHashSet()
-        return libraryManga.associate { manga ->
-            val tracks = getTracks.await(manga.id)
-                .fastFilter { it.trackerId in loggedInTrackerIds }
-
-            manga.id to tracks
-        }
+        val mangaIds = libraryManga.mapTo(HashSet()) { it.id }
+        return getTracks.awaitAll()
+            .fastFilter { it.mangaId in mangaIds && it.trackerId in loggedInTrackerIds }
+            .groupBy { it.mangaId }
     }
 
     private fun getScoredMangaTrackMap(mangaTrackMap: Map<Long, List<Track>>): Map<Long, List<Track>> {

--- a/data/src/main/java/tachiyomi/data/track/TrackRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/track/TrackRepositoryImpl.kt
@@ -20,6 +20,12 @@ class TrackRepositoryImpl(
         }
     }
 
+    override suspend fun getAllTracks(): List<Track> {
+        return handler.awaitList {
+            manga_syncQueries.getTracks(TrackMapper::mapTrack)
+        }
+    }
+
     override fun getTracksAsFlow(): Flow<List<Track>> {
         return handler.subscribeToDebouncedList(1.seconds) {
             manga_syncQueries.getTracks(TrackMapper::mapTrack)

--- a/domain/src/main/java/tachiyomi/domain/track/interactor/GetTracks.kt
+++ b/domain/src/main/java/tachiyomi/domain/track/interactor/GetTracks.kt
@@ -19,6 +19,15 @@ class GetTracks(
         }
     }
 
+    suspend fun awaitAll(): List<Track> {
+        return try {
+            trackRepository.getAllTracks()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            emptyList()
+        }
+    }
+
     suspend fun await(mangaId: Long): List<Track> {
         return try {
             trackRepository.getTracksByMangaId(mangaId)

--- a/domain/src/main/java/tachiyomi/domain/track/repository/TrackRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/track/repository/TrackRepository.kt
@@ -9,6 +9,8 @@ interface TrackRepository {
 
     suspend fun getTracksByMangaId(mangaId: Long): List<Track>
 
+    suspend fun getAllTracks(): List<Track>
+
     fun getTracksAsFlow(): Flow<List<Track>>
 
     fun getTracksByMangaIdAsFlow(mangaId: Long): Flow<List<Track>>


### PR DESCRIPTION
- GetTracks.awaitAll(): fetch all tracks in single query
- TrackRepository.getAllTracks(): new interface method
- StatsScreenModel: filter in-memory instead of per-manga queries

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
