### PR TITLE
fix: browse source paging isolation and filter preset icons

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.browse.components.BaseSourceItem
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel.Listing
 import eu.kanade.tachiyomi.util.system.LocaleHelper
@@ -81,6 +83,7 @@ fun SourcesScreen(
                         is SourceUiModel.Item -> SourceItem(
                             modifier = Modifier.animateItem(),
                             source = model.source,
+                            hasDefaultPreset = model.hasDefaultPreset,
                             onClickItem = onClickItem,
                             onLongClickItem = onLongClickItem,
                             onClickPin = onClickPin,
@@ -109,6 +112,7 @@ private fun SourceHeader(
 @Composable
 private fun SourceItem(
     source: Source,
+    hasDefaultPreset: Boolean,
     onClickItem: (Source, Listing) -> Unit,
     onLongClickItem: (Source) -> Unit,
     onClickPin: (Source) -> Unit,
@@ -120,6 +124,15 @@ private fun SourceItem(
         onClickItem = { onClickItem(source, Listing.Popular) },
         onLongClickItem = { onLongClickItem(source) },
         action = {
+            if (hasDefaultPreset) {
+                IconButton(onClick = { onClickItem(source, Listing.Search(query = null, filters = FilterList())) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.FilterList,
+                        tint = MaterialTheme.colorScheme.primary,
+                        contentDescription = stringResource(MR.strings.action_filter),
+                    )
+                }
+            }
             if (source.supportsLatest) {
                 TextButton(onClick = { onClickItem(source, Listing.Latest) }) {
                     Text(
@@ -199,6 +212,6 @@ fun SourceOptionsDialog(
 }
 
 sealed interface SourceUiModel {
-    data class Item(val source: Source) : SourceUiModel
+    data class Item(val source: Source, val hasDefaultPreset: Boolean = false) : SourceUiModel
     data class Header(val language: String) : SourceUiModel
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesScreenModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.source.interactor.GetEnabledNovelSources
+import eu.kanade.domain.source.interactor.ManageFilterPresets
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.presentation.browse.SourceUiModel
@@ -28,6 +29,7 @@ class NovelSourcesScreenModel(
     private val getEnabledNovelSources: GetEnabledNovelSources = Injekt.get(),
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
+    private val manageFilterPresets: ManageFilterPresets = Injekt.get(),
 ) : StateScreenModel<NovelSourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -79,7 +81,10 @@ class NovelSourcesScreenModel(
                         listOf(
                             SourceUiModel.Header(it.key),
                             *it.value.map { source ->
-                                SourceUiModel.Item(source)
+                                SourceUiModel.Item(
+                                    source = source,
+                                    hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
+                                )
                             }.toTypedArray(),
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.source.interactor.GetEnabledSources
+import eu.kanade.domain.source.interactor.ManageFilterPresets
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.presentation.browse.SourceUiModel
@@ -28,6 +29,7 @@ class SourcesScreenModel(
     private val getEnabledSources: GetEnabledSources = Injekt.get(),
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
+    private val manageFilterPresets: ManageFilterPresets = Injekt.get(),
 ) : StateScreenModel<SourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -73,7 +75,10 @@ class SourcesScreenModel(
                         listOf(
                             SourceUiModel.Header(it.key),
                             *it.value.map { source ->
-                                SourceUiModel.Item(source)
+                                SourceUiModel.Item(
+                                    source = source,
+                                    hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
+                                )
                             }.toTypedArray(),
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -298,6 +298,7 @@ class BrowseSourceScreenModel(
     fun setListing(listing: Listing) {
         // Reset initial page to 1 when listing changes (e.g., switching between Popular, Latest, Search)
         _initialPage.value = 1L
+        _targetEndPage.value = null
         mutableState.update { it.copy(listing = listing, toolbarQuery = null) }
     }
 
@@ -386,6 +387,7 @@ class BrowseSourceScreenModel(
 
         // Reset initial page to 1 when search/filters change
         _initialPage.value = 1L
+        _targetEndPage.value = null
 
         mutableState.update {
             it.copy(
@@ -432,6 +434,7 @@ class BrowseSourceScreenModel(
 
         // Reset initial page to 1 when genre search changes
         _initialPage.value = 1L
+        _targetEndPage.value = null
 
         mutableState.update {
             val listing = if (genreExists) {

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -16,6 +16,7 @@ import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.repository.SourcePagingSource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.concurrent.atomic.AtomicInteger
 
 class SourceSearchPagingSource(
     source: CatalogueSource,
@@ -50,6 +51,11 @@ abstract class BaseSourcePagingSource(
     // Track highest page loaded for UI display
     private var highestPageLoaded = 0
 
+    // Capture the generation at creation time — only update the shared counter
+    // if this instance's generation still matches (prevents stale paging sources
+    // from corrupting the counter after a listing switch).
+    private val myGeneration = _generation.get()
+
     abstract suspend fun requestNextPage(currentPage: Int): MangasPage
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, Manga> {
@@ -73,8 +79,8 @@ abstract class BaseSourcePagingSource(
             }
             lastLoadTime = System.currentTimeMillis()
 
-            // Update global page tracker when a new highest page is loaded
-            if (page.toInt() > highestPageLoaded) {
+            // Update global page tracker only if this paging source is still current
+            if (myGeneration == _generation.get() && page.toInt() > highestPageLoaded) {
                 highestPageLoaded = page.toInt()
                 _currentPage.value = highestPageLoaded
             }
@@ -105,6 +111,10 @@ abstract class BaseSourcePagingSource(
         // Page load delay in milliseconds (can be updated from UI preferences)
         var pageLoadDelayMs = 0L
 
+        // Generation counter — incremented on every pager reset so stale paging
+        // sources (from a previous listing/filter) don't update the shared counter.
+        private val _generation = AtomicInteger(0)
+
         // Global current page state for UI display
         private val _currentPage = MutableStateFlow(1)
         val currentPage: StateFlow<Int> = _currentPage.asStateFlow()
@@ -116,12 +126,14 @@ abstract class BaseSourcePagingSource(
         // Reset page counter (call when creating new pager)
         // Also resets the initial page override so future searches start from page 1
         fun resetPageCounter() {
+            _generation.incrementAndGet()
             _initialPageOverride = 1
             _currentPage.value = 1
         }
 
         // Set initial page for next pager creation
         fun setInitialPage(page: Int) {
+            _generation.incrementAndGet()
             _initialPageOverride = page
             _currentPage.value = page
         }


### PR DESCRIPTION
- SourcePagingSource: generation counter prevents stale page loads
- BrowseSourceScreenModel: clear targetEndPage on listing change
- SourcesScreenModel/NovelSourcesScreenModel: filter preset icon support
- SourcesScreen: display filter preset icon in UI if source has default filter preset

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
