### PR TITLE
feat: restore novel scroll position across chapter switches

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -280,6 +280,7 @@ object SettingsNovelReaderScreen : SearchableSettings {
     @Composable
     private fun getContentGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
         val autoLoadNextAt = readerPreferences.novelAutoLoadNextChapterAt().collectAsState().value
+        val markAsReadThreshold = readerPreferences.novelMarkAsReadThreshold().collectAsState().value
 
         return Preference.PreferenceGroup(
             title = "Content",
@@ -295,6 +296,13 @@ object SettingsNovelReaderScreen : SearchableSettings {
                     title = "Auto-load next chapter at",
                     valueString = "$autoLoadNextAt%",
                     onValueChanged = { readerPreferences.novelAutoLoadNextChapterAt().set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = markAsReadThreshold,
+                    valueRange = 50..100,
+                    title = "Mark chapter as read at",
+                    valueString = "$markAsReadThreshold%",
+                    onValueChanged = { readerPreferences.novelMarkAsReadThreshold().set(it) },
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.novelHideChapterTitle(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -117,7 +117,7 @@ class ReaderViewModel @JvmOverloads constructor(
 
     private val mutableState = MutableStateFlow(
         State(
-            isTranslating = translationPreferences.translationEnabled().get() ||
+            isTranslating = translationPreferences.translationEnabled().get() &&
                 translationPreferences.smartAutoTranslate().get(),
         ),
     )
@@ -154,6 +154,15 @@ class ReaderViewModel @JvmOverloads constructor(
      * The chapter loader for the loaded manga. It'll be null until [manga] is set.
      */
     private var loader: ChapterLoader? = null
+
+    /**
+     * Novel scroll progress (0-100%) via SavedState. Persists synchronously before process death,
+     */
+    private var novelScrollProgress = savedState.get<Int>("novel_scroll_progress") ?: -1
+        set(value) {
+            savedState["novel_scroll_progress"] = value
+            field = value
+        }
 
     /**
      * The time the chapter was started reading
@@ -272,7 +281,15 @@ class ReaderViewModel @JvmOverloads constructor(
                         currentChapter.requestedPage = currentChapter.chapter.last_page_read
                     }
                 }
+
                 chapterId = currentChapter.chapter.id!!
+
+                // For novels: override with SavedState progress if available (survives process death
+                // even when the mutex-serialized DB write hasn't completed yet)
+                if (novelScrollProgress > 0) {
+                    currentChapter.requestedPage = novelScrollProgress
+                    novelScrollProgress = -1
+                }
             }
             .launchIn(viewModelScope)
     }
@@ -342,8 +359,9 @@ class ReaderViewModel @JvmOverloads constructor(
     private suspend fun loadChapter(
         loader: ChapterLoader,
         chapter: ReaderChapter,
+        forceFromSource: Boolean = false,
     ): ViewerChapters {
-        loader.loadChapter(chapter)
+        loader.loadChapter(chapter, forceFromSource)
 
         val chapterPos = chapterList.indexOf(chapter)
         val newChapters = ViewerChapters(
@@ -563,10 +581,7 @@ class ReaderViewModel @JvmOverloads constructor(
                 // Reset chapter state to force reload
                 currChapter.state = ReaderChapter.State.Wait
 
-                // If reloading from source, we need to clear the downloaded flag temporarily
-                // This is handled in the loader based on chapter state
-
-                loadChapter(loader, currChapter)
+                loadChapter(loader, currChapter, forceFromSource = fromSource)
 
                 // Notify the viewer to refresh
                 withUIContext {
@@ -703,9 +718,10 @@ class ReaderViewModel @JvmOverloads constructor(
 
                 selectedChapter.chapter.last_page_read = clampedProgress
 
-                // Mark as read if at the end (95% or more)
+                // Mark as read if at the configured threshold or more
+                val markAsReadThreshold = readerPreferences.novelMarkAsReadThreshold().get()
                 val wasRead = selectedChapter.chapter.read
-                if (clampedProgress >= 95 && !wasRead) {
+                if (clampedProgress >= markAsReadThreshold && !wasRead) {
                     selectedChapter.chapter.read = true
                     updateTrackChapterRead(selectedChapter)
                     deleteChapterIfNeeded(selectedChapter)
@@ -744,7 +760,9 @@ class ReaderViewModel @JvmOverloads constructor(
      * Update the novel progress percentage in the state for UI display (e.g., slider).
      */
     fun updateNovelProgressPercent(progress: Int) {
-        mutableState.update { it.copy(novelProgressPercent = progress.coerceIn(0, 100)) }
+        val clamped = progress.coerceIn(0, 100)
+        mutableState.update { it.copy(novelProgressPercent = clamped) }
+        novelScrollProgress = clamped
     }
 
     private fun downloadNextChapters() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -41,16 +41,16 @@ class ChapterLoader(
      * Assigns the chapter's page loader and loads the its pages. Returns immediately if the chapter
      * is already loaded.
      */
-    suspend fun loadChapter(chapter: ReaderChapter) {
-        if (chapterIsReady(chapter)) {
+    suspend fun loadChapter(chapter: ReaderChapter, forceFromSource: Boolean = false) {
+        if (!forceFromSource && chapterIsReady(chapter)) {
             return
         }
 
         chapter.state = ReaderChapter.State.Loading
         withIOContext {
-            logcat { "Loading pages for ${chapter.chapter.name}" }
+            logcat { "Loading pages for ${chapter.chapter.name}${if (forceFromSource) " (from source)" else ""}" }
             try {
-                val loader = getPageLoader(chapter)
+                val loader = getPageLoader(chapter, forceFromSource)
                 chapter.pageLoader = loader
 
                 val pages = loader.getPages()
@@ -84,9 +84,9 @@ class ChapterLoader(
     /**
      * Returns the page loader to use for this [chapter].
      */
-    private suspend fun getPageLoader(chapter: ReaderChapter): PageLoader {
+    private suspend fun getPageLoader(chapter: ReaderChapter, forceFromSource: Boolean = false): PageLoader {
         val dbChapter = chapter.chapter
-        val isDownloaded = downloadManager.isChapterDownloaded(
+        val isDownloaded = !forceFromSource && downloadManager.isChapterDownloaded(
             dbChapter.name,
             dbChapter.scanlator,
             dbChapter.url,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -261,6 +261,9 @@ class ReaderPreferences(
     // Auto-load next chapter at percentage (legacy 0 may exist; treated as default)
     fun novelAutoLoadNextChapterAt() = preferenceStore.getInt("pref_novel_auto_load_next_at", 95)
 
+    // Mark chapter as read when progress reaches this percentage
+    fun novelMarkAsReadThreshold() = preferenceStore.getInt("pref_novel_mark_read_threshold", 95)
+
     // Show raw HTML (display HTML tags without parsing) - useful for debugging
     fun novelShowRawHtml() = preferenceStore.getBoolean("pref_novel_show_raw_html", false)
 


### PR DESCRIPTION
- ReaderViewModel: save/restore novelScrollProgress via SavedState
- ChapterLoader: pass scroll progress to chapter load
- ReaderPreferences: add novel scroll restore preference
- SettingsNovelReaderScreen: UI toggle for scroll position persistence

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
