### PR TITLE
feat: add source name visibility toggle and sorting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Improved
+- New sorting option based on source name [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
+- Duplicate finder now has category filter [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
 
+### Added
+- Toggle under settings > Advanced that hides source name under manga details (For screenshots/bug reporting) [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
+
+### Fixed
+- Updates tab didn't show all items properly when showing one entry per novel [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
 
 ## [v0.1.1] - 2026-03-17
 ### Improved

--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -71,11 +71,11 @@ fun DeleteLibraryMangaDialog(
             if (!containsLocalManga) {
                 add(CheckboxItem(MR.strings.downloaded_chapters, deleteDownloads, { deleteDownloads = it }))
             }
-            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb, { clearChaptersFromDb = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb || removeFromLibrary, { clearChaptersFromDb = it }, enabled = !removeFromLibrary))
             add(CheckboxItem(TDMR.strings.translated_chapters, deleteTranslations, { deleteTranslations = it }))
-            add(CheckboxItem(TDMR.strings.action_clear_covers, clearCovers, { clearCovers = it }, enabled = !removeFromLibrary))
-            add(CheckboxItem(TDMR.strings.action_clear_descriptions, clearDescriptions, { clearDescriptions = it }, enabled = !removeFromLibrary))
-            add(CheckboxItem(TDMR.strings.action_clear_tags, clearTags, { clearTags = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.action_clear_covers, clearCovers || removeFromLibrary, { clearCovers = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.action_clear_descriptions, clearDescriptions || removeFromLibrary, { clearDescriptions = it }, enabled = !removeFromLibrary))
+            add(CheckboxItem(TDMR.strings.action_clear_tags, clearTags || removeFromLibrary, { clearTags = it }, enabled = !removeFromLibrary))
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -37,14 +37,15 @@ fun DeleteLibraryMangaDialog(
     var clearDescriptions by remember { mutableStateOf(false) }
     var clearTags by remember { mutableStateOf(false) }
 
-    // Cascading: "remove from library" auto-checks clear operations (but not downloads/translations)
+    // Keep destructive clear options disabled when removing from library.
+    // They are redundant because removing from library already clears associated data.
     fun onRemoveFromLibraryChanged(checked: Boolean) {
         removeFromLibrary = checked
         if (checked) {
-            clearChaptersFromDb = true
-            clearCovers = true
-            clearDescriptions = true
-            clearTags = true
+            clearChaptersFromDb = false
+            clearCovers = false
+            clearDescriptions = false
+            clearTags = false
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -284,6 +284,7 @@ private fun ColumnScope.SortPage(
             MR.strings.action_sort_latest_chapter to LibrarySort.Type.LatestChapter,
             MR.strings.action_sort_chapter_fetch_date to LibrarySort.Type.ChapterFetchDate,
             MR.strings.action_sort_date_added to LibrarySort.Type.DateAdded,
+            TDMR.strings.action_sort_source_name to LibrarySort.Type.SourceName,
             trackerMeanPair,
             MR.strings.action_sort_random to LibrarySort.Type.Random,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,6 +35,7 @@ fun LibraryContent(
     contentPadding: PaddingValues,
     currentPage: Int,
     hasActiveFilters: Boolean,
+    isQueryRunning: Boolean,
     showPageTabs: Boolean,
     onChangeCurrentPage: (Int) -> Unit,
     onClickManga: (Long) -> Unit,
@@ -114,6 +117,12 @@ fun LibraryContent(
                 onClickContinueReading = onContinueReadingClicked,
                 titleMaxLines = titleMaxLines,
                 showUrlInList = showUrlInList,
+            )
+        }
+
+        if (isQueryRunning && selection.isEmpty()) {
+            LinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -383,8 +383,6 @@ private fun MangaScreenSmallImpl(
                 onClickTranslate = onTranslateClicked,
                 onClickTranslateDownloaded = onTranslateDownloadedClicked,
                 onClickExportEpub = onExportEpubClicked,
-                showSourceName = showSourceName,
-                onToggleSourceNameVisibility = onToggleSourceNameVisibility,
                 onClickScrollToTop = {
                     scrollScope.launch { chapterListState.animateScrollToItem(0) }
                 },
@@ -695,8 +693,6 @@ fun MangaScreenLargeImpl(
                 onClickTranslate = onTranslateClicked,
                 onClickTranslateDownloaded = onTranslateDownloadedClicked,
                 onClickExportEpub = onExportEpubClicked,
-                showSourceName = showSourceName,
-                onToggleSourceNameVisibility = onToggleSourceNameVisibility,
                 onClickScrollToTop = {
                     scrollScope.launch { chapterListState.animateScrollToItem(0) }
                 },

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -128,6 +128,8 @@ fun MangaScreen(
     onTranslateClicked: (() -> Unit)? = null,
     onTranslateDownloadedClicked: (() -> Unit)? = null,
     onExportEpubClicked: (() -> Unit)? = null,
+    showSourceName: Boolean = true,
+    onToggleSourceNameVisibility: (() -> Unit)? = null,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -191,6 +193,8 @@ fun MangaScreen(
             onTranslateClicked = onTranslateClicked,
             onTranslateDownloadedClicked = onTranslateDownloadedClicked,
             onExportEpubClicked = onExportEpubClicked,
+            showSourceName = showSourceName,
+            onToggleSourceNameVisibility = onToggleSourceNameVisibility,
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
@@ -241,6 +245,8 @@ fun MangaScreen(
             onTranslateClicked = onTranslateClicked,
             onTranslateDownloadedClicked = onTranslateDownloadedClicked,
             onExportEpubClicked = onExportEpubClicked,
+            showSourceName = showSourceName,
+            onToggleSourceNameVisibility = onToggleSourceNameVisibility,
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
@@ -301,6 +307,8 @@ private fun MangaScreenSmallImpl(
     onTranslateClicked: (() -> Unit)?,
     onTranslateDownloadedClicked: (() -> Unit)?,
     onExportEpubClicked: (() -> Unit)?,
+    showSourceName: Boolean,
+    onToggleSourceNameVisibility: (() -> Unit)?,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -375,6 +383,8 @@ private fun MangaScreenSmallImpl(
                 onClickTranslate = onTranslateClicked,
                 onClickTranslateDownloaded = onTranslateDownloadedClicked,
                 onClickExportEpub = onExportEpubClicked,
+                showSourceName = showSourceName,
+                onToggleSourceNameVisibility = onToggleSourceNameVisibility,
                 onClickScrollToTop = {
                     scrollScope.launch { chapterListState.animateScrollToItem(0) }
                 },
@@ -487,7 +497,7 @@ private fun MangaScreenSmallImpl(
                             isTabletUi = false,
                             appBarPadding = topPadding,
                             manga = state.manga,
-                            sourceName = remember { state.source.getNameForMangaInfo() },
+                            sourceName = if (showSourceName) remember { state.source.getNameForMangaInfo() } else "",
                             isStubSource = remember { state.source is StubSource },
                             categories = state.categories,
                             onCoverClick = onCoverClicked,
@@ -616,6 +626,8 @@ fun MangaScreenLargeImpl(
     onTranslateClicked: (() -> Unit)?,
     onTranslateDownloadedClicked: (() -> Unit)?,
     onExportEpubClicked: (() -> Unit)?,
+    showSourceName: Boolean,
+    onToggleSourceNameVisibility: (() -> Unit)?,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -683,6 +695,8 @@ fun MangaScreenLargeImpl(
                 onClickTranslate = onTranslateClicked,
                 onClickTranslateDownloaded = onTranslateDownloadedClicked,
                 onClickExportEpub = onExportEpubClicked,
+                showSourceName = showSourceName,
+                onToggleSourceNameVisibility = onToggleSourceNameVisibility,
                 onClickScrollToTop = {
                     scrollScope.launch { chapterListState.animateScrollToItem(0) }
                 },
@@ -796,7 +810,7 @@ fun MangaScreenLargeImpl(
                             isTabletUi = true,
                             appBarPadding = contentPadding.calculateTopPadding(),
                             manga = state.manga,
-                            sourceName = remember { state.source.getNameForMangaInfo() },
+                            sourceName = if (showSourceName) remember { state.source.getNameForMangaInfo() } else "",
                             isStubSource = remember { state.source is StubSource },
                             categories = state.categories,
                             onCoverClick = onCoverClicked,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -52,8 +52,6 @@ fun MangaToolbar(
     onClickTranslate: (() -> Unit)? = null,
     onClickTranslateDownloaded: (() -> Unit)? = null,
     onClickExportEpub: (() -> Unit)? = null,
-    showSourceName: Boolean = true,
-    onToggleSourceNameVisibility: (() -> Unit)? = null,
     onClickScrollToTop: (() -> Unit)? = null,
     onClickScrollToLastRead: (() -> Unit)? = null,
     onClickScrollToBottom: (() -> Unit)? = null,
@@ -201,20 +199,6 @@ fun MangaToolbar(
                             AppBar.OverflowAction(
                                 title = stringResource(MR.strings.action_share),
                                 onClick = onClickShare,
-                            ),
-                        )
-                    }
-                    if (onToggleSourceNameVisibility != null) {
-                        add(
-                            AppBar.OverflowAction(
-                                title = stringResource(
-                                    if (showSourceName) {
-                                        TDMR.strings.action_hide_source_name
-                                    } else {
-                                        TDMR.strings.action_show_source_name
-                                    },
-                                ),
-                                onClick = onToggleSourceNameVisibility,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -52,6 +52,8 @@ fun MangaToolbar(
     onClickTranslate: (() -> Unit)? = null,
     onClickTranslateDownloaded: (() -> Unit)? = null,
     onClickExportEpub: (() -> Unit)? = null,
+    showSourceName: Boolean = true,
+    onToggleSourceNameVisibility: (() -> Unit)? = null,
     onClickScrollToTop: (() -> Unit)? = null,
     onClickScrollToLastRead: (() -> Unit)? = null,
     onClickScrollToBottom: (() -> Unit)? = null,
@@ -199,6 +201,20 @@ fun MangaToolbar(
                             AppBar.OverflowAction(
                                 title = stringResource(MR.strings.action_share),
                                 onClick = onClickShare,
+                            ),
+                        )
+                    }
+                    if (onToggleSourceNameVisibility != null) {
+                        add(
+                            AppBar.OverflowAction(
+                                title = stringResource(
+                                    if (showSourceName) {
+                                        TDMR.strings.action_hide_source_name
+                                    } else {
+                                        TDMR.strings.action_show_source_name
+                                    },
+                                ),
+                                onClick = onToggleSourceNameVisibility,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -146,6 +146,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     true
                 },
             ),
+            Preference.PreferenceItem.SwitchPreference(
+                preference = libraryPreferences.showMangaSourceName(),
+                title = stringResource(TDMR.strings.pref_show_manga_source_name),
+                subtitle = stringResource(TDMR.strings.pref_show_manga_source_name_summary),
+            ),
             Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.pref_debug_info),
                 onClick = { navigator.push(DebugInfoScreen()) },
@@ -1161,11 +1166,6 @@ object SettingsAdvancedScreen : SearchableSettings {
                     preference = libraryPreferences.disallowNonAsciiFilenames(),
                     title = stringResource(MR.strings.pref_disallow_non_ascii_filenames),
                     subtitle = stringResource(MR.strings.pref_disallow_non_ascii_filenames_details),
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = libraryPreferences.showMangaSourceName(),
-                    title = stringResource(TDMR.strings.pref_show_manga_source_name),
-                    subtitle = stringResource(TDMR.strings.pref_show_manga_source_name_summary),
                 ),
 
             ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -1162,6 +1162,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_disallow_non_ascii_filenames),
                     subtitle = stringResource(MR.strings.pref_disallow_non_ascii_filenames_details),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.showMangaSourceName(),
+                    title = stringResource(TDMR.strings.pref_show_manga_source_name),
+                    subtitle = stringResource(TDMR.strings.pref_show_manga_source_name_summary),
+                ),
 
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -131,7 +131,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
         libraryPreferences.lastUpdatedTimestamp().set(Instant.now().toEpochMilli())
 
-        val mangaIds = inputData.getLongArray(KEY_MANGA_IDS)
+        val mangaIds = loadMangaIds()
         forceFetchDetails = inputData.getBoolean(KEY_FETCH_DETAILS, false)
         skipChapterFetch = !inputData.getBoolean(KEY_FETCH_CHAPTERS, true)
         val ignoreSkip = inputData.getBoolean(KEY_IGNORE_SKIP, false)
@@ -589,6 +589,20 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         return File("")
     }
 
+    private fun loadMangaIds(): LongArray? {
+        inputData.getLongArray(KEY_MANGA_IDS)?.let { return it }
+        val filePath = inputData.getString(KEY_IDS_FILE) ?: return null
+        return try {
+            val file = java.io.File(filePath)
+            val ids = file.readText().split(",").mapNotNull { it.trim().toLongOrNull() }.toLongArray()
+            file.delete()
+            ids
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read manga IDs from file: $filePath" }
+            null
+        }
+    }
+
     companion object {
         private const val TAG = "LibraryUpdate"
         private const val WORK_NAME_AUTO = "LibraryUpdate-auto"
@@ -607,6 +621,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
          * Keys for "Update Selected" mode — specific manga IDs with options.
          */
         private const val KEY_MANGA_IDS = "manga_ids"
+        private const val KEY_IDS_FILE = "ids_file"
         private const val KEY_FETCH_DETAILS = "fetch_details"
         private const val KEY_FETCH_CHAPTERS = "fetch_chapters"
         private const val KEY_IGNORE_SKIP = "ignore_skip"
@@ -677,17 +692,27 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                 return false
             }
 
-            val inputData = workDataOf(
-                KEY_CATEGORY to category?.id,
-                KEY_MANGA_IDS to mangaIds,
-                KEY_FETCH_DETAILS to fetchDetails,
-                KEY_FETCH_CHAPTERS to fetchChapters,
-                KEY_IGNORE_SKIP to ignoreSkipRecentlyUpdated,
-            )
+            val inputDataBuilder = androidx.work.Data.Builder().apply {
+                if (category != null) putLong(KEY_CATEGORY, category.id)
+                putBoolean(KEY_FETCH_DETAILS, fetchDetails)
+                putBoolean(KEY_FETCH_CHAPTERS, fetchChapters)
+                putBoolean(KEY_IGNORE_SKIP, ignoreSkipRecentlyUpdated)
+
+                if (mangaIds != null) {
+                    if (mangaIds.size <= 500) {
+                        putLongArray(KEY_MANGA_IDS, mangaIds)
+                    } else {
+                        val idsFile = java.io.File(context.cacheDir, "update_job_ids_${System.currentTimeMillis()}.txt")
+                        idsFile.writeText(mangaIds.joinToString(","))
+                        putString(KEY_IDS_FILE, idsFile.absolutePath)
+                    }
+                }
+            }
+
             val request = OneTimeWorkRequestBuilder<LibraryUpdateJob>()
                 .addTag(TAG)
                 .addTag(WORK_NAME_MANUAL)
-                .setInputData(inputData)
+                .setInputData(inputDataBuilder.build())
                 .build()
             wm.enqueueUniqueWork(WORK_NAME_MANUAL, ExistingWorkPolicy.KEEP, request)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.ui.library
 
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
-import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
@@ -18,7 +17,6 @@ data class LibraryItem(
 
     companion object {
         private val sourceManager: SourceManager by lazy { Injekt.get() }
-        private val getChaptersByMangaId: GetChaptersByMangaId by lazy { Injekt.get() }
     }
 
     /**
@@ -55,6 +53,7 @@ data class LibraryItem(
         searchByUrl: Boolean = false,
         useRegex: Boolean = false,
     ): Boolean {
+        val regexCache = if (useRegex) HashMap<String, Regex?>(4) else null
         val sourceName by lazy { sourceManager.getOrStub(libraryManga.manga.source).getNameForMangaInfo() }
 
         // Special prefixes for searching specific fields
@@ -63,15 +62,15 @@ data class LibraryItem(
         }
         if (constraint.startsWith("title:", true)) {
             val query = constraint.substringAfter("title:").trim()
-            return matchString(libraryManga.manga.title, query, useRegex)
+            return matchString(libraryManga.manga.title, query, useRegex, regexCache)
         }
         if (constraint.startsWith("author:", true)) {
             val query = constraint.substringAfter("author:").trim()
-            return libraryManga.manga.author?.let { matchString(it, query, useRegex) } ?: false
+            return libraryManga.manga.author?.let { matchString(it, query, useRegex, regexCache) } ?: false
         }
         if (constraint.startsWith("artist:", true)) {
             val query = constraint.substringAfter("artist:").trim()
-            return libraryManga.manga.artist?.let { matchString(it, query, useRegex) } ?: false
+            return libraryManga.manga.artist?.let { matchString(it, query, useRegex, regexCache) } ?: false
         }
         if (constraint.startsWith("desc:", true) || constraint.startsWith("description:", true)) {
             val query = if (constraint.startsWith("desc:")) {
@@ -79,7 +78,7 @@ data class LibraryItem(
             } else {
                 constraint.substringAfter("description:").trim()
             }
-            return libraryManga.manga.description?.let { matchString(it, query, useRegex) } ?: false
+            return libraryManga.manga.description?.let { matchString(it, query, useRegex, regexCache) } ?: false
         }
         if (constraint.startsWith("tag:", true) || constraint.startsWith("genre:", true)) {
             val query = if (constraint.startsWith("tag:")) {
@@ -87,15 +86,15 @@ data class LibraryItem(
             } else {
                 constraint.substringAfter("genre:").trim()
             }
-            return libraryManga.manga.genre?.any { matchString(it, query, useRegex) } ?: false
+            return libraryManga.manga.genre?.any { matchString(it, query, useRegex, regexCache) } ?: false
         }
         if (constraint.startsWith("source:", true)) {
             val query = constraint.substringAfter("source:").trim()
-            return matchString(sourceName, query, useRegex)
+            return matchString(sourceName, query, useRegex, regexCache)
         }
         if (constraint.startsWith("url:", true)) {
             val query = constraint.substringAfter("url:").trim()
-            return matchString(libraryManga.manga.url, query, useRegex)
+            return matchString(libraryManga.manga.url, query, useRegex, regexCache)
         }
         // Search for chapter names explicitly
         if (constraint.startsWith("chapter:", true)) {
@@ -103,15 +102,15 @@ data class LibraryItem(
         }
 
         // Default: search title, author, artist, description, source, tags, URL (if enabled), and optionally chapters
-        val basicMatch = matchString(libraryManga.manga.title, constraint, useRegex) ||
-            (libraryManga.manga.author?.let { matchString(it, constraint, useRegex) } ?: false) ||
-            (libraryManga.manga.artist?.let { matchString(it, constraint, useRegex) } ?: false) ||
-            (libraryManga.manga.description?.let { matchString(it, constraint, useRegex) } ?: false) ||
-            (searchByUrl && matchString(libraryManga.manga.url, constraint, useRegex)) ||
+        val basicMatch = matchString(libraryManga.manga.title, constraint, useRegex, regexCache) ||
+            (libraryManga.manga.author?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
+            (libraryManga.manga.artist?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
+            (libraryManga.manga.description?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
+            (searchByUrl && matchString(libraryManga.manga.url, constraint, useRegex, regexCache)) ||
             constraint.split(",").map { it.trim() }.all { subconstraint ->
                 checkNegatableConstraint(subconstraint) {
-                    matchString(sourceName, it, useRegex) ||
-                        (libraryManga.manga.genre?.any { genre -> matchString(genre, it, useRegex) } ?: false)
+                    matchString(sourceName, it, useRegex, regexCache) ||
+                        (libraryManga.manga.genre?.any { genre -> matchString(genre, it, useRegex, regexCache) } ?: false)
                 }
             }
 
@@ -130,6 +129,26 @@ data class LibraryItem(
                 // Invalid regex, fall back to simple contains
                 text.contains(query, ignoreCase = true)
             }
+        } else {
+            text.contains(query, ignoreCase = true)
+        }
+    }
+
+    private fun matchString(
+        text: String,
+        query: String,
+        useRegex: Boolean,
+        regexCache: MutableMap<String, Regex?>?,
+    ): Boolean {
+        return if (useRegex) {
+            val cachedRegex = regexCache?.getOrPut(query) {
+                try {
+                    Regex(query, RegexOption.IGNORE_CASE)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+            cachedRegex?.containsMatchIn(text) ?: text.contains(query, ignoreCase = true)
         } else {
             text.contains(query, ignoreCase = true)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -225,6 +225,11 @@ class LibraryScreenModel(
                 .dropWhile { !it.libraryData.isInitialized }
                 .map { it.libraryData }
                 .distinctUntilChanged()
+                .onEach {
+                    mutableState.update { state ->
+                        if (state.isLoading) state else state.copy(isQueryRunning = true)
+                    }
+                }
                 .map { data ->
                     val favoritesById = HashMap<Long, LibraryItem>(data.favorites.size * 2)
                     for (item in data.favorites) {
@@ -238,6 +243,7 @@ class LibraryScreenModel(
                     mutableState.update { state ->
                         state.copy(
                             isLoading = false,
+                            isQueryRunning = false,
                             groupedFavorites = it,
                         )
                     }
@@ -454,6 +460,7 @@ class LibraryScreenModel(
         }
 
         val defaultTrackerScoreSortValue = -1.0
+        val sourceNameCache by lazy { HashMap<Long, String>() }
         val trackerScores by lazy {
             val trackerMap = trackerManager.getAll(loggedInTrackerIds).associateBy { e -> e.id }
             trackMap.mapValues { entry ->
@@ -504,6 +511,15 @@ class LibraryScreenModel(
                     val item1Score = trackerScores[manga1.id] ?: defaultTrackerScoreSortValue
                     val item2Score = trackerScores[manga2.id] ?: defaultTrackerScoreSortValue
                     item1Score.compareTo(item2Score)
+                }
+                LibrarySort.Type.SourceName -> {
+                    val sourceName1 = sourceNameCache.getOrPut(manga1.libraryManga.manga.source) {
+                        sourceManager.getOrStub(manga1.libraryManga.manga.source).name
+                    }
+                    val sourceName2 = sourceNameCache.getOrPut(manga2.libraryManga.manga.source) {
+                        sourceManager.getOrStub(manga2.libraryManga.manga.source).name
+                    }
+                    sourceName1.compareToWithCollator(sourceName2)
                 }
                 LibrarySort.Type.Random -> {
                     error("Why Are We Still Here? Just To Suffer?")
@@ -620,14 +636,15 @@ class LibraryScreenModel(
                     LibraryType.Novel -> if (!manga.manga.isNovel) continue
                 }
 
+                val dlCount = downloadManager.getDownloadCount(manga.manga).toLong()
+
                 val cached = itemCache[manga.id]
                 val cachedRef = itemCacheMangaRef[manga.id]
-                if (cached != null && cachedRef === manga) {
+                if (cached != null && cachedRef === manga && cached.downloadCount == dlCount) {
                     result.add(cached)
                     continue
                 }
 
-                val dlCount = downloadManager.getDownloadCount(manga.manga).toLong()
                 val item = LibraryItem(
                     libraryManga = manga,
                     downloadCount = dlCount,
@@ -872,16 +889,18 @@ class LibraryScreenModel(
             }
 
             // Delegate clear operations to LibraryClearJob (runs as background WorkManager job)
-            val mangaIds = mangas.map { it.id }
-            val context = Injekt.get<android.app.Application>()
-            if (clearCovers) {
-                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_COVERS)
-            }
-            if (clearDescriptions) {
-                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
-            }
-            if (clearTags) {
-                LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_TAGS)
+            if (!deleteFromLibrary) {
+                val mangaIds = mangas.map { it.id }
+                val context = Injekt.get<android.app.Application>()
+                if (clearCovers) {
+                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_COVERS)
+                }
+                if (clearDescriptions) {
+                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
+                }
+                if (clearTags) {
+                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_TAGS)
+                }
             }
 
             // Refresh library UI after modifications
@@ -1108,12 +1127,12 @@ class LibraryScreenModel(
 
     fun commitSearch(query: String) {
         // Commit the search, triggering filtering
-        mutableState.update { it.copy(searchQuery = query.ifBlank { null }) }
+        mutableState.update { it.copy(searchQuery = query.ifBlank { null }, isQueryRunning = true) }
     }
 
     fun clearSearch() {
         // Clear both toolbar and committed search
-        mutableState.update { it.copy(toolbarQuery = null, searchQuery = null) }
+        mutableState.update { it.copy(toolbarQuery = null, searchQuery = null, isQueryRunning = true) }
     }
 
     fun updateActiveCategoryIndex(index: Int) {
@@ -1709,6 +1728,7 @@ class LibraryScreenModel(
     data class State(
         val isInitialized: Boolean = false,
         val isLoading: Boolean = true,
+        val isQueryRunning: Boolean = false,
         val toolbarQuery: String? = null, // What's shown in the search box
         val searchQuery: String? = null, // Committed search (triggers filtering)
         val selection: Set</* Manga */ Long> = setOf(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -297,6 +297,8 @@ class LibrarySettingsScreenModel(
                 // Calculate tag counts, filtering by type
                 val tagCounts = mutableMapOf<String, Int>()
                 var noTagsCount = 0
+                val tagCache = mutableMapOf<String, String>()
+
                 genresList.forEach { (_, sourceId, genres) ->
                     // Filter by content type
                     val source = sourceManager.getOrStub(sourceId)
@@ -311,14 +313,26 @@ class LibrarySettingsScreenModel(
                         if (genres.isNullOrEmpty()) {
                             noTagsCount++
                         } else {
-                            genres.forEach { tag ->
-                                val normalizedTag = tag.trim()
-                                    .split(" ")
-                                    .joinToString(" ") { word ->
-                                        word.lowercase().replaceFirstChar { c ->
-                                            if (c.isLowerCase()) c.titlecase() else c.toString()
+                            genres.forEach { rawTag ->
+                                val tag = rawTag.trim()
+                                val normalizedTag = tagCache.getOrPut(tag) {
+                                    val lowered = tag.lowercase()
+                                    val result = java.lang.StringBuilder(lowered.length)
+                                    var capitalizeNext = true
+                                    for (i in lowered.indices) {
+                                        val c = lowered[i]
+                                        if (c.isWhitespace()) {
+                                            capitalizeNext = true
+                                            result.append(c)
+                                        } else if (capitalizeNext) {
+                                            result.append(c.titlecaseChar())
+                                            capitalizeNext = false
+                                        } else {
+                                            result.append(c)
                                         }
                                     }
+                                    result.toString()
+                                }
                                 if (normalizedTag.isNotBlank()) {
                                     tagCounts[normalizedTag] = (tagCounts[normalizedTag] ?: 0) + 1
                                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -211,6 +211,7 @@ data object LibraryTab : Tab {
                         contentPadding = contentPadding,
                         currentPage = state.coercedActiveCategoryIndex,
                         hasActiveFilters = state.hasActiveFilters,
+                        isQueryRunning = state.isQueryRunning,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/NovelsTab.kt
@@ -233,6 +233,7 @@ data object NovelsTab : Tab {
                         contentPadding = contentPadding,
                         currentPage = state.coercedActiveCategoryIndex,
                         hasActiveFilters = state.hasActiveFilters,
+                        isQueryRunning = state.isQueryRunning,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -439,6 +439,25 @@ class DuplicateDetectionScreen : Screen {
                                 modifier = Modifier.padding(start = 8.dp),
                             )
                         }
+
+                        // Require Group Match toggle
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { screenModel.setFilterByGroupCategory(!state.filterByGroupCategory) }
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                checked = state.filterByGroupCategory,
+                                onCheckedChange = { screenModel.setFilterByGroupCategory(it) },
+                            )
+                            Text(
+                                "Filter by group strictly (at least one valid item)",
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        }
                         // Sort mode selector
                         FlowRow(
                             modifier = Modifier

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
@@ -74,6 +74,7 @@ class DuplicateDetectionScreenModel(
         val selectedCategoryFilters: Set<Long> = emptySet(),
         val searchQuery: String = "",
         val excludedCategoryFilters: Set<Long> = emptySet(),
+        val filterByGroupCategory: Boolean = false,
         val sortMode: SortMode = SortMode.NAME,
         val mangaCategories: Map<Long, List<Category>> = emptyMap(),
         val showFullUrls: Boolean = false,
@@ -112,19 +113,36 @@ class DuplicateDetectionScreenModel(
                 val filtered = if (selectedCategoryFilters.isEmpty() && excludedCategoryFilters.isEmpty()) {
                     contentFiltered
                 } else {
-                    contentFiltered.mapValues { (_, novels) ->
-                        novels.filter { novel ->
-                            val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
-                            // Treat uncategorized manga as being in the default category (id=0)
-                            val categoryIds = novelCategories.map { it.id }.toSet()
-                                .ifEmpty { setOf(0L) }
-                            val passesInclude = selectedCategoryFilters.isEmpty() ||
-                                categoryIds.any { it in selectedCategoryFilters }
-                            val passesExclude = excludedCategoryFilters.isEmpty() ||
-                                categoryIds.none { it in excludedCategoryFilters }
-                            passesInclude && passesExclude
+                    if (filterByGroupCategory) {
+                        contentFiltered.filter { (_, novels) ->
+                            val groupMatches = novels.any { novel ->
+                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
+                                val categoryIds = novelCategories.map { it.id }.toSet().ifEmpty { setOf(0L) }
+                                val passesInclude = selectedCategoryFilters.isEmpty() || categoryIds.any { it in selectedCategoryFilters }
+                                passesInclude
+                            }
+                            val groupExcluded = excludedCategoryFilters.isNotEmpty() && novels.any { novel ->
+                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
+                                val categoryIds = novelCategories.map { it.id }.toSet().ifEmpty { setOf(0L) }
+                                categoryIds.any { it in excludedCategoryFilters }
+                            }
+                            groupMatches && !groupExcluded
                         }
-                    }.filter { it.value.size > 1 }
+                    } else {
+                        contentFiltered.mapValues { (_, novels) ->
+                            novels.filter { novel ->
+                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
+                                // Treat uncategorized manga as being in the default category (id=0)
+                                val categoryIds = novelCategories.map { it.id }.toSet()
+                                    .ifEmpty { setOf(0L) }
+                                val passesInclude = selectedCategoryFilters.isEmpty() ||
+                                    categoryIds.any { it in selectedCategoryFilters }
+                                val passesExclude = excludedCategoryFilters.isEmpty() ||
+                                    categoryIds.none { it in excludedCategoryFilters }
+                                passesInclude && passesExclude
+                            }
+                        }.filter { it.value.size > 1 }
+                    }
                 }
 
                 return when (sortMode) {
@@ -360,6 +378,10 @@ class DuplicateDetectionScreenModel(
 
     fun clearCategoryFilters() {
         mutableState.update { it.copy(selectedCategoryFilters = emptySet(), excludedCategoryFilters = emptySet()) }
+    }
+
+    fun setFilterByGroupCategory(filter: Boolean) {
+        mutableState.update { it.copy(filterByGroupCategory = filter) }
     }
 
     fun setSortMode(mode: SortMode) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -192,6 +192,8 @@ class MangaScreen(
             onTranslateClicked = screenModel::translateMangaDetails,
             onTranslateDownloadedClicked = screenModel::translateDownloadedChapters,
             onExportEpubClicked = screenModel::showExportEpubDialog.takeIf { successState.isNovel },
+            showSourceName = successState.showSourceName,
+            onToggleSourceNameVisibility = screenModel::toggleSourceNameVisibility,
             onMultiBookmarkClicked = screenModel::bookmarkChapters,
             onMultiMarkAsReadClicked = screenModel::markChaptersRead,
             onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -266,6 +266,7 @@ class MangaScreenModel(
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters().get(),
                     isNovel = manga.isNovel,
+                    showSourceName = libraryPreferences.showMangaSourceName().get(),
                 )
             }
 
@@ -289,6 +290,12 @@ class MangaScreenModel(
                 val categories = getCategories.await(manga.id)
                 updateSuccessState { it.copy(categories = categories) }
             }
+        }
+    }
+
+    fun toggleSourceNameVisibility() {
+        updateSuccessState {
+            it.copy(showSourceName = !it.showSourceName)
         }
     }
 
@@ -1599,6 +1606,7 @@ class MangaScreenModel(
             val isNovel: Boolean = false,
             val similarNovels: List<MangaWithChapterCount> = emptyList(),
             val categories: List<Category> = emptyList(),
+            val showSourceName: Boolean = true,
         ) : State {
             val processedChapters by lazy {
                 chapters.applyFilters(manga).toList()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -100,6 +100,10 @@ class UpdatesScreenModel(
     State(groupByNovel = Injekt.get<LibraryPreferences>().updatesGroupByNovel().get()),
 ) {
 
+    companion object {
+        private const val GROUPED_NOVEL_TARGET = 30
+    }
+
     @Volatile
     private var latestUpdates: List<UpdatesWithRelations> = emptyList()
 
@@ -163,6 +167,17 @@ class UpdatesScreenModel(
                     _events.send(Event.InternalError)
                 }
                 .collectLatest { (updateItems, hasMore) ->
+                    val shouldPrefetchForGroupedView =
+                        state.value.groupByNovel &&
+                            hasMore &&
+                            updateItems.groupBy { it.update.mangaId }.size < GROUPED_NOVEL_TARGET
+
+                    if (shouldPrefetchForGroupedView) {
+                        mutableState.update { it.copy(isLoadingMore = true) }
+                        currentLimit.value += GetUpdates.PAGE_SIZE
+                        return@collectLatest
+                    }
+
                     mutableState.update {
                         it.copy(
                             isLoading = false,

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
@@ -32,6 +32,7 @@ data class LibrarySort(
         data object DateAdded : Type(0b00011100)
         data object TrackerMean : Type(0b00100000)
         data object DownloadedChapters : Type(0b00100100)
+        data object SourceName : Type(0b00101000)
         data object Random : Type(0b00111100)
 
         companion object {
@@ -80,6 +81,7 @@ data class LibrarySort(
                 Type.DateAdded,
                 Type.TrackerMean,
                 Type.DownloadedChapters,
+                Type.SourceName,
                 Type.Random,
             )
         }
@@ -109,6 +111,7 @@ data class LibrarySort(
                     "DATE_ADDED" -> Type.DateAdded
                     "TRACKER_MEAN" -> Type.TrackerMean
                     "DOWNLOADED_CHAPTERS" -> Type.DownloadedChapters
+                    "SOURCE_NAME" -> Type.SourceName
                     "RANDOM" -> Type.Random
                     else -> Type.Alphabetical
                 }
@@ -132,6 +135,7 @@ data class LibrarySort(
             Type.DateAdded -> "DATE_ADDED"
             Type.TrackerMean -> "TRACKER_MEAN"
             Type.DownloadedChapters -> "DOWNLOADED_CHAPTERS"
+            Type.SourceName -> "SOURCE_NAME"
             Type.Random -> "RANDOM"
         }
         val direction = if (direction == Direction.Ascending) "ASCENDING" else "DESCENDING"

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -247,6 +247,8 @@ class LibraryPreferences(
 
     fun hideMissingChapters() = preferenceStore.getBoolean("pref_hide_missing_chapter_indicators", false)
 
+    fun showMangaSourceName() = preferenceStore.getBoolean("pref_show_manga_source_name", true)
+
     /**
      * Whether the library should auto-refresh when database changes occur.
      */

--- a/domain/src/test/java/tachiyomi/domain/library/model/LibraryFlagsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/library/model/LibraryFlagsTest.kt
@@ -12,7 +12,7 @@ class LibraryFlagsTest {
     @Test
     fun `Check the amount of flags`() {
         LibraryDisplayMode.values.size shouldBe 4
-        LibrarySort.types.size shouldBe 11
+        LibrarySort.types.size shouldBe 12
         LibrarySort.directions.size shouldBe 2
     }
 

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -668,4 +668,10 @@
     <string name="db_maintenance_failed">Maintenance failed: %s</string>
     <string name="db_maintenance_already_running">Database maintenance is already running</string>
     <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
+
+    <string name="action_sort_source_name">Source name</string>
+    <string name="pref_show_manga_source_name">Show source name in manga details</string>
+    <string name="pref_show_manga_source_name_summary">Display source name under status on manga details screen</string>
+    <string name="action_hide_source_name">Hide source name</string>
+    <string name="action_show_source_name">Show source name</string>
 </resources>


### PR DESCRIPTION
- Implemented a toggle for showing the manga source name in the manga details screen.
- Added a new sorting option for library items based on source name.
- Moved strings.xml changes to the TDMR namespace/file.
- Added UI elements to filter duplicates by group category in the duplicate detection screen.
- Fix updates tab not loading items properly when showing one entry per novel