### PR TITLE
Add option to hide manga options in appearance screen, reorganize some settings and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Improved novel reader settings UI [@Rojikku](https://github.com/Rojikku) [#49](https://github.com/tsundoku-otaku/tsundoku/pull/49)
 
 ### Added
+- Toggle under settings > Appearance that hides most manga UI elements[@mrissaoussamau](https://github.com/mrissaoussama) [#48](https://github.com/tsundoku-otaku/tsundoku/pull/48)
 - Toggle under settings > Advanced that hides source name under manga details (For screenshots/bug reporting) [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
 - Customizable novel reader bottom toolbar [@Rojikku](https://github.com/Rojikku) [#45](https://github.com/tsundoku-otaku/tsundoku/pull/45)
 - Support lnreader repo add link [@mrissaoussamau](https://github.com/mrissaoussama) [#47](https://github.com/tsundoku-otaku/tsundoku/pull/47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Hid Quick migration, removed from unnecessary places, added category option (For migrating between KT and JS of same source) [@mrissaoussamau](https://github.com/mrissaoussama) [#43](https://github.com/tsundoku-otaku/tsundoku/pull/43)
 
 ### Added
+- Toggle under settings > Appearance that hides most manga UI elements[@mrissaoussamau](https://github.com/mrissaoussama) [#48](https://github.com/tsundoku-otaku/tsundoku/pull/48)
 - Toggle under settings > Advanced that hides source name under manga details (For screenshots/bug reporting) [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
 - Customizable novel reader bottom toolbar [@Rojikku](https://github.com/Rojikku) [#45](https://github.com/tsundoku-otaku/tsundoku/pull/45)
 

--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -23,6 +23,8 @@ class BasePreferences(
 
     fun shownOnboardingFlow() = preferenceStore.getBoolean(Preference.appStateKey("onboarding_complete"), false)
 
+    fun hideMangaUi() = preferenceStore.getBoolean(Preference.appStateKey("pref_hide_manga_ui"), false)
+
     enum class ExtensionInstaller(val titleRes: StringResource, val requiresSystemPermission: Boolean) {
         LEGACY(MR.strings.ext_installer_legacy, true),
         PACKAGEINSTALLER(MR.strings.ext_installer_packageinstaller, true),

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -54,6 +54,7 @@ fun HistoryScreen(
     onFilterSelected: (HistoryFilter) -> Unit,
     onGroupByNovelChanged: (Boolean) -> Unit,
     onLoadNextPage: () -> Unit,
+    showMangaFilter: Boolean = true,
 ) {
     Scaffold(
         topBar = { scrollBehavior ->
@@ -99,11 +100,13 @@ fun HistoryScreen(
                     onClick = { onFilterSelected(HistoryFilter.ALL) },
                     label = { Text(stringResource(MR.strings.all)) },
                 )
-                FilterChip(
-                    selected = state.filter == HistoryFilter.MANGA,
-                    onClick = { onFilterSelected(HistoryFilter.MANGA) },
-                    label = { Text(stringResource(TDMR.strings.label_manga)) },
-                )
+                if (showMangaFilter) {
+                    FilterChip(
+                        selected = state.filter == HistoryFilter.MANGA,
+                        onClick = { onFilterSelected(HistoryFilter.MANGA) },
+                        label = { Text(stringResource(TDMR.strings.label_manga)) },
+                    )
+                }
                 FilterChip(
                     selected = state.filter == HistoryFilter.NOVELS,
                     onClick = { onFilterSelected(HistoryFilter.NOVELS) },
@@ -209,6 +212,7 @@ internal fun HistoryScreenPreviews(
             onFilterSelected = {},
             onGroupByNovelChanged = {},
             onLoadNextPage = {},
+            showMangaFilter = true,
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -46,6 +46,7 @@ import java.time.LocalDate
 fun HistoryScreen(
     state: HistoryScreenModel.State,
     snackbarHostState: SnackbarHostState,
+    showFilterChips: Boolean = true,
     onSearchQueryChange: (String?) -> Unit,
     onClickCover: (mangaId: Long) -> Unit,
     onClickResume: (mangaId: Long, chapterId: Long) -> Unit,
@@ -89,32 +90,33 @@ fun HistoryScreen(
         Column(
             modifier = Modifier.padding(contentPadding),
         ) {
-            // Always show filter chips
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (showAllFilter) {
+            if (showFilterChips) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (showAllFilter) {
                     FilterChip(
                         selected = state.filter == HistoryFilter.ALL,
                         onClick = { onFilterSelected(HistoryFilter.ALL) },
                         label = { Text(stringResource(MR.strings.all)) },
                     )
-                }
-                if (showMangaFilter) {
+                    }
+                    if (showMangaFilter) {
                     FilterChip(
                         selected = state.filter == HistoryFilter.MANGA,
                         onClick = { onFilterSelected(HistoryFilter.MANGA) },
                         label = { Text(stringResource(TDMR.strings.label_manga)) },
                     )
+                    }
+                    FilterChip(
+                        selected = state.filter == HistoryFilter.NOVELS,
+                        onClick = { onFilterSelected(HistoryFilter.NOVELS) },
+                        label = { Text(stringResource(TDMR.strings.label_novels)) },
+                    )
                 }
-                FilterChip(
-                    selected = state.filter == HistoryFilter.NOVELS,
-                    onClick = { onFilterSelected(HistoryFilter.NOVELS) },
-                    label = { Text(stringResource(TDMR.strings.label_novels)) },
-                )
             }
 
             state.list.let {

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -54,6 +54,7 @@ fun HistoryScreen(
     onFilterSelected: (HistoryFilter) -> Unit,
     onGroupByNovelChanged: (Boolean) -> Unit,
     onLoadNextPage: () -> Unit,
+    showAllFilter: Boolean = true,
     showMangaFilter: Boolean = true,
 ) {
     Scaffold(
@@ -95,11 +96,13 @@ fun HistoryScreen(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                FilterChip(
-                    selected = state.filter == HistoryFilter.ALL,
-                    onClick = { onFilterSelected(HistoryFilter.ALL) },
-                    label = { Text(stringResource(MR.strings.all)) },
-                )
+                if (showAllFilter) {
+                    FilterChip(
+                        selected = state.filter == HistoryFilter.ALL,
+                        onClick = { onFilterSelected(HistoryFilter.ALL) },
+                        label = { Text(stringResource(MR.strings.all)) },
+                    )
+                }
                 if (showMangaFilter) {
                     FilterChip(
                         selected = state.filter == HistoryFilter.MANGA,

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -1,6 +1,7 @@
 package eu.kanade.presentation.library
 
 import android.content.res.Configuration
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -20,7 +21,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
@@ -53,6 +56,7 @@ import eu.kanade.presentation.components.TabbedDialogPaddings
 import eu.kanade.tachiyomi.ui.library.LibrarySettingsScreenModel
 import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.model.LibraryDisplayMode
@@ -739,21 +743,71 @@ private fun ColumnScope.ExtensionsPage(
     val excludedExtensions by screenModel.libraryPreferences.excludedExtensions().collectAsState()
     val availableExtensions by screenModel.extensionsFlow.collectAsState()
     val isLoading by screenModel.isLoading.collectAsState()
+    var showRefreshCompleted by remember { mutableStateOf(false) }
+    var refreshTriggered by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            showRefreshCompleted = false
+        } else if (refreshTriggered) {
+            refreshTriggered = false
+            showRefreshCompleted = true
+            delay(900)
+            showRefreshCompleted = false
+        }
+    }
 
     // Extensions are now auto-loaded in the ScreenModel's init block
     // No need for LaunchedEffect here
 
     HeadingItem(MR.strings.label_extensions)
 
-    // Refresh button
+    // Compact action row: refresh/check/uncheck
     Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.End,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        TextButton(onClick = { screenModel.refreshExtensions(forceRefresh = true) }) {
-            Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+        TextButton(
+            onClick = {
+                refreshTriggered = true
+                screenModel.refreshExtensions(forceRefresh = true)
+            },
+            enabled = !isLoading,
+            modifier = Modifier.weight(1f),
+        ) {
+            Crossfade(targetState = when {
+                isLoading -> "loading"
+                showRefreshCompleted -> "done"
+                else -> "idle"
+            }) { state ->
+                when (state) {
+                    "loading" -> CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    "done" -> Icon(Icons.Default.Done, contentDescription = "Refreshed")
+                    else -> Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+                }
+            }
             Spacer(Modifier.width(4.dp))
-            Text("Refresh List")
+            Text(if (showRefreshCompleted) "Refreshed" else "Refresh")
+        }
+
+        TextButton(
+            onClick = { screenModel.checkAllExtensions() },
+            modifier = Modifier.weight(1f),
+        ) {
+            Icon(Icons.Default.Check, contentDescription = "Check all")
+            Spacer(Modifier.width(4.dp))
+            Text("Check All")
+        }
+
+        TextButton(
+            onClick = { screenModel.uncheckAllExtensions() },
+            modifier = Modifier.weight(1f),
+        ) {
+            Icon(Icons.Default.Clear, contentDescription = "Uncheck all")
+            Spacer(Modifier.width(4.dp))
+            Text("Uncheck All")
         }
     }
 
@@ -773,27 +827,6 @@ private fun ColumnScope.ExtensionsPage(
             Text("Loading extensions...")
         }
     } else {
-        // Check All / Uncheck All buttons
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            TextButton(
-                onClick = { screenModel.checkAllExtensions() },
-                modifier = Modifier.weight(1f),
-            ) {
-                Text("Check All")
-            }
-            TextButton(
-                onClick = { screenModel.uncheckAllExtensions() },
-                modifier = Modifier.weight(1f),
-            ) {
-                Text("Uncheck All")
-            }
-        }
-
         // Show count of missing sources
         val stubCount = availableExtensions.count { it.isStub }
         if (stubCount > 0) {

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -1,6 +1,7 @@
 package eu.kanade.presentation.library
 
 import android.content.res.Configuration
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -20,7 +21,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
@@ -50,10 +53,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
-import eu.kanade.presentation.components.toTabTitles
 import eu.kanade.tachiyomi.ui.library.LibrarySettingsScreenModel
 import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.model.LibraryDisplayMode
@@ -86,7 +89,7 @@ fun LibrarySettingsDialog(
             stringResource(MR.strings.action_display),
             "Tags",
             "Extensions",
-        ).toTabTitles(),
+        ),
     ) { page ->
         if (page == 3) {
             Column(
@@ -285,6 +288,7 @@ private fun ColumnScope.SortPage(
             MR.strings.action_sort_latest_chapter to LibrarySort.Type.LatestChapter,
             MR.strings.action_sort_chapter_fetch_date to LibrarySort.Type.ChapterFetchDate,
             MR.strings.action_sort_date_added to LibrarySort.Type.DateAdded,
+            TDMR.strings.action_sort_source_name to LibrarySort.Type.SourceName,
             trackerMeanPair,
             MR.strings.action_sort_random to LibrarySort.Type.Random,
         )
@@ -739,11 +743,75 @@ private fun ColumnScope.ExtensionsPage(
     val excludedExtensions by screenModel.libraryPreferences.excludedExtensions().collectAsState()
     val availableExtensions by screenModel.extensionsFlow.collectAsState()
     val isLoading by screenModel.isLoading.collectAsState()
+    var showRefreshCompleted by remember { mutableStateOf(false) }
+    var refreshTriggered by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            showRefreshCompleted = false
+        } else if (refreshTriggered) {
+            refreshTriggered = false
+            showRefreshCompleted = true
+            delay(900)
+            showRefreshCompleted = false
+        }
+    }
 
     // Extensions are now auto-loaded in the ScreenModel's init block
     // No need for LaunchedEffect here
 
     HeadingItem(MR.strings.label_extensions)
+
+    // Compact action row: refresh/check/uncheck
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TextButton(
+            onClick = {
+                refreshTriggered = true
+                screenModel.refreshExtensions(forceRefresh = true)
+            },
+            enabled = !isLoading,
+            modifier = Modifier.weight(1f),
+        ) {
+            Crossfade(
+                targetState = when {
+                    isLoading -> "loading"
+                    showRefreshCompleted -> "done"
+                    else -> "idle"
+                },
+            ) { state ->
+                when (state) {
+                    "loading" -> CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    "done" -> Icon(Icons.Default.Done, contentDescription = "Refreshed")
+                    else -> Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+                }
+            }
+            Spacer(Modifier.width(4.dp))
+            Text(if (showRefreshCompleted) "Refreshed" else "Refresh")
+        }
+
+        TextButton(
+            onClick = { screenModel.checkAllExtensions() },
+            modifier = Modifier.weight(1f),
+        ) {
+            Icon(Icons.Default.Check, contentDescription = "Check all")
+            Spacer(Modifier.width(4.dp))
+            Text("Check All")
+        }
+
+        TextButton(
+            onClick = { screenModel.uncheckAllExtensions() },
+            modifier = Modifier.weight(1f),
+        ) {
+            Icon(Icons.Default.Clear, contentDescription = "Uncheck all")
+            Spacer(Modifier.width(4.dp))
+            Text("Uncheck All")
+        }
+    }
 
     if (availableExtensions.isEmpty() && !isLoading) {
         Text(
@@ -761,35 +829,6 @@ private fun ColumnScope.ExtensionsPage(
             Text("Loading extensions...")
         }
     } else {
-        // Refresh / Check All / Uncheck All buttons in one row
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            TextButton(
-                onClick = { screenModel.refreshExtensions(forceRefresh = true) },
-                modifier = Modifier.weight(1f),
-            ) {
-                Icon(Icons.Default.Refresh, contentDescription = "Refresh")
-                Spacer(Modifier.width(4.dp))
-                Text("Refresh")
-            }
-            TextButton(
-                onClick = { screenModel.checkAllExtensions() },
-                modifier = Modifier.weight(1f),
-            ) {
-                Text("Check All")
-            }
-            TextButton(
-                onClick = { screenModel.uncheckAllExtensions() },
-                modifier = Modifier.weight(1f),
-            ) {
-                Text("Uncheck All")
-            }
-        }
-
         // Show count of missing sources
         val stubCount = availableExtensions.count { it.isStub }
         if (stubCount > 0) {

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -285,7 +285,6 @@ private fun ColumnScope.SortPage(
             MR.strings.action_sort_latest_chapter to LibrarySort.Type.LatestChapter,
             MR.strings.action_sort_chapter_fetch_date to LibrarySort.Type.ChapterFetchDate,
             MR.strings.action_sort_date_added to LibrarySort.Type.DateAdded,
-            TDMR.strings.action_sort_source_name to LibrarySort.Type.SourceName,
             trackerMeanPair,
             MR.strings.action_sort_random to LibrarySort.Type.Random,
         )
@@ -746,18 +745,6 @@ private fun ColumnScope.ExtensionsPage(
 
     HeadingItem(MR.strings.label_extensions)
 
-    // Refresh button
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.End,
-    ) {
-        TextButton(onClick = { screenModel.refreshExtensions(forceRefresh = true) }) {
-            Icon(Icons.Default.Refresh, contentDescription = "Refresh")
-            Spacer(Modifier.width(4.dp))
-            Text("Refresh List")
-        }
-    }
-
     if (availableExtensions.isEmpty() && !isLoading) {
         Text(
             text = "No extensions with library entries",
@@ -774,13 +761,21 @@ private fun ColumnScope.ExtensionsPage(
             Text("Loading extensions...")
         }
     } else {
-        // Check All / Uncheck All buttons
+        // Refresh / Check All / Uncheck All buttons in one row
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            TextButton(
+                onClick = { screenModel.refreshExtensions(forceRefresh = true) },
+                modifier = Modifier.weight(1f),
+            ) {
+                Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+                Spacer(Modifier.width(4.dp))
+                Text("Refresh")
+            }
             TextButton(
                 onClick = { screenModel.checkAllExtensions() },
                 modifier = Modifier.weight(1f),

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
+import eu.kanade.presentation.components.toTabTitles
 import eu.kanade.tachiyomi.ui.library.LibrarySettingsScreenModel
 import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import kotlinx.collections.immutable.persistentListOf
@@ -89,7 +90,7 @@ fun LibrarySettingsDialog(
             stringResource(MR.strings.action_display),
             "Tags",
             "Extensions",
-        ),
+        ).toTabTitles(),
     ) { page ->
         if (page == 3) {
             Column(

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
@@ -1,12 +1,25 @@
 package eu.kanade.presentation.more.onboarding
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.presentation.more.settings.widget.AppThemeModePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidget
+import tachiyomi.i18n.novel.TDMR
+import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -27,6 +40,9 @@ internal class ThemeStep : OnboardingStep {
 
         val amoledPref = uiPreferences.themeDarkAmoled()
         val amoled by amoledPref.collectAsState()
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUiPref = basePreferences.hideMangaUi()
+        val hideMangaUi by hideMangaUiPref.collectAsState()
 
         Column {
             AppThemeModePreferenceWidget(
@@ -42,6 +58,23 @@ internal class ThemeStep : OnboardingStep {
                 amoled = amoled,
                 onItemClick = { appThemePref.set(it) },
             )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { hideMangaUiPref.set(!hideMangaUi) }
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Checkbox(
+                    checked = hideMangaUi,
+                    onCheckedChange = { hideMangaUiPref.set(it) },
+                )
+                Text(
+                    text = stringResource(TDMR.strings.pref_hide_manga_ui),
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
@@ -1,12 +1,25 @@
 package eu.kanade.presentation.more.onboarding
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.presentation.more.settings.widget.AppThemeModePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidget
+import tachiyomi.i18n.novel.TDMR
+import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -27,6 +40,9 @@ internal class ThemeStep : OnboardingStep {
 
         val amoledPref = uiPreferences.themeDarkAmoled()
         val amoled by amoledPref.collectAsState()
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUiPref = basePreferences.hideMangaUi()
+        val hideMangaUi by hideMangaUiPref.collectAsState()
 
         Column {
             AppThemeModePreferenceWidget(
@@ -42,6 +58,23 @@ internal class ThemeStep : OnboardingStep {
                 amoled = amoled,
                 onItemClick = { appThemePref.set(it) },
             )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { hideMangaUiPref.set(!hideMangaUi) }
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Checkbox(
+                    checked = hideMangaUi,
+                    onCheckedChange = { hideMangaUiPref.set(it) },
+                )
+                Text(
+                    text = stringResource(TDMR.strings.pref_hide_manga_ui),
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
@@ -162,6 +163,7 @@ object SettingsAppearanceScreen : SearchableSettings {
         libraryPreferences: tachiyomi.domain.library.service.LibraryPreferences,
     ): Preference.PreferenceGroup {
         val context = LocalContext.current
+        val basePreferences = remember { Injekt.get<eu.kanade.domain.base.BasePreferences>() }
         return Preference.PreferenceGroup(
             title = "Library layout",
             preferenceItems = persistentListOf(
@@ -169,6 +171,15 @@ object SettingsAppearanceScreen : SearchableSettings {
                     preference = libraryPreferences.joinedLibrary(),
                     title = "Combined library",
                     subtitle = "Merge Novels and Manga into a single Library tab",
+                    onValueChanged = {
+                        context.toast(MR.strings.requires_app_restart)
+                        true
+                    },
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = basePreferences.hideMangaUi(),
+                    title = stringResource(TDMR.strings.pref_hide_manga_ui),
+                    subtitle = stringResource(TDMR.strings.pref_hide_manga_ui_summary),
                     onValueChanged = {
                         context.toast(MR.strings.requires_app_restart)
                         true

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.util.fastMap
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.category.visualName
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.widget.TriStateListDialog
@@ -48,6 +49,8 @@ object SettingsDownloadScreen : SearchableSettings {
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
 
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
         val parallelSourceLimit by downloadPreferences.parallelSourceLimit().collectAsState()
         val parallelPageLimit by downloadPreferences.parallelPageLimit().collectAsState()
         return listOf(
@@ -55,28 +58,30 @@ object SettingsDownloadScreen : SearchableSettings {
                 preference = downloadPreferences.downloadOnlyOverWifi(),
                 title = stringResource(MR.strings.connected_to_wifi),
             ),
-            Preference.PreferenceItem.SwitchPreference(
-                preference = downloadPreferences.saveChaptersAsCBZ(),
-                title = stringResource(MR.strings.save_chapter_as_cbz),
-            ),
-            Preference.PreferenceItem.SwitchPreference(
-                preference = downloadPreferences.splitTallImages(),
-                title = stringResource(MR.strings.split_tall_images),
-                subtitle = stringResource(MR.strings.split_tall_images_summary),
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = parallelSourceLimit,
-                valueRange = 1..15,
-                title = stringResource(MR.strings.pref_download_concurrent_sources),
-                onValueChanged = { downloadPreferences.parallelSourceLimit().set(it) },
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = parallelPageLimit,
-                valueRange = 1..15,
-                title = stringResource(MR.strings.pref_download_concurrent_pages),
-                subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
-                onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
-            ),
+            *listOfNotNull(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = downloadPreferences.saveChaptersAsCBZ(),
+                    title = stringResource(MR.strings.save_chapter_as_cbz),
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = downloadPreferences.splitTallImages(),
+                    title = stringResource(MR.strings.split_tall_images),
+                    subtitle = stringResource(MR.strings.split_tall_images_summary),
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SliderPreference(
+                    value = parallelSourceLimit,
+                    valueRange = 1..15,
+                    title = stringResource(MR.strings.pref_download_concurrent_sources),
+                    onValueChanged = { downloadPreferences.parallelSourceLimit().set(it) },
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SliderPreference(
+                    value = parallelPageLimit,
+                    valueRange = 1..15,
+                    title = stringResource(MR.strings.pref_download_concurrent_pages),
+                    subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
+                    onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
+                ).takeUnless { hideMangaUi },
+            ).toTypedArray(),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,
                 categories = allCategories,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.util.fastMap
 import eu.kanade.presentation.category.visualName
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.widget.TriStateListDialog
+import eu.kanade.domain.base.BasePreferences
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -48,51 +49,39 @@ object SettingsDownloadScreen : SearchableSettings {
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
 
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
         val parallelSourceLimit by downloadPreferences.parallelSourceLimit().collectAsState()
         val parallelPageLimit by downloadPreferences.parallelPageLimit().collectAsState()
-        val epubCompressionLevel by downloadPreferences.epubCompressionLevel().collectAsState()
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.downloadOnlyOverWifi(),
                 title = stringResource(MR.strings.connected_to_wifi),
             ),
-            Preference.PreferenceItem.SwitchPreference(
-                preference = downloadPreferences.saveChaptersAsCBZ(),
-                title = stringResource(MR.strings.save_chapter_as_cbz),
-            ),
-            Preference.PreferenceItem.SwitchPreference(
-                preference = downloadPreferences.splitTallImages(),
-                title = stringResource(MR.strings.split_tall_images),
-                subtitle = stringResource(MR.strings.split_tall_images_summary),
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = parallelSourceLimit,
-                valueRange = 1..15,
-                title = stringResource(MR.strings.pref_download_concurrent_sources),
-                onValueChanged = { downloadPreferences.parallelSourceLimit().set(it) },
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = parallelPageLimit,
-                valueRange = 1..15,
-                title = stringResource(MR.strings.pref_download_concurrent_pages),
-                subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
-                onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = epubCompressionLevel + 1, // shift -1..9 to 0..10 for slider
-                valueRange = 0..10,
-                title = stringResource(MR.strings.pref_epub_compression_level),
-                subtitle = when (epubCompressionLevel) {
-                    -1 -> stringResource(MR.strings.pref_epub_compression_default)
-                    0 -> stringResource(MR.strings.pref_epub_compression_none)
-                    in 1..3 -> stringResource(MR.strings.pref_epub_compression_low)
-                    in 4..6 -> stringResource(MR.strings.pref_epub_compression_medium)
-                    in 7..9 -> stringResource(MR.strings.pref_epub_compression_high)
-                    else -> stringResource(MR.strings.pref_epub_compression_level_label, epubCompressionLevel)
-                },
-                valueString = if (epubCompressionLevel == -1) stringResource(MR.strings.pref_epub_compression_default_label) else "$epubCompressionLevel",
-                onValueChanged = { downloadPreferences.epubCompressionLevel().set(it - 1) },
-            ),
+            *listOfNotNull(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = downloadPreferences.saveChaptersAsCBZ(),
+                    title = stringResource(MR.strings.save_chapter_as_cbz),
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = downloadPreferences.splitTallImages(),
+                    title = stringResource(MR.strings.split_tall_images),
+                    subtitle = stringResource(MR.strings.split_tall_images_summary),
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SliderPreference(
+                    value = parallelSourceLimit,
+                    valueRange = 1..15,
+                    title = stringResource(MR.strings.pref_download_concurrent_sources),
+                    onValueChanged = { downloadPreferences.parallelSourceLimit().set(it) },
+                ).takeUnless { hideMangaUi },
+                Preference.PreferenceItem.SliderPreference(
+                    value = parallelPageLimit,
+                    valueRange = 1..15,
+                    title = stringResource(MR.strings.pref_download_concurrent_pages),
+                    subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
+                    onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
+                ).takeUnless { hideMangaUi },
+            ).toTypedArray(),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,
                 categories = allCategories,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -50,7 +50,6 @@ object SettingsDownloadScreen : SearchableSettings {
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
         val parallelSourceLimit by downloadPreferences.parallelSourceLimit().collectAsState()
         val parallelPageLimit by downloadPreferences.parallelPageLimit().collectAsState()
-        val epubCompressionLevel by downloadPreferences.epubCompressionLevel().collectAsState()
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.downloadOnlyOverWifi(),
@@ -77,21 +76,6 @@ object SettingsDownloadScreen : SearchableSettings {
                 title = stringResource(MR.strings.pref_download_concurrent_pages),
                 subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
                 onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
-            ),
-            Preference.PreferenceItem.SliderPreference(
-                value = epubCompressionLevel + 1, // shift -1..9 to 0..10 for slider
-                valueRange = 0..10,
-                title = stringResource(MR.strings.pref_epub_compression_level),
-                subtitle = when (epubCompressionLevel) {
-                    -1 -> stringResource(MR.strings.pref_epub_compression_default)
-                    0 -> stringResource(MR.strings.pref_epub_compression_none)
-                    in 1..3 -> stringResource(MR.strings.pref_epub_compression_low)
-                    in 4..6 -> stringResource(MR.strings.pref_epub_compression_medium)
-                    in 7..9 -> stringResource(MR.strings.pref_epub_compression_high)
-                    else -> stringResource(MR.strings.pref_epub_compression_level_label, epubCompressionLevel)
-                },
-                valueString = if (epubCompressionLevel == -1) stringResource(MR.strings.pref_epub_compression_default_label) else "$epubCompressionLevel",
-                onValueChanged = { downloadPreferences.epubCompressionLevel().set(it - 1) },
             ),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.launch
 import tachiyomi.domain.category.interactor.GetCategories
@@ -58,11 +59,12 @@ object SettingsLibraryScreen : SearchableSettings {
         val getCategories = remember { Injekt.get<GetCategories>() }
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
+        val isJoined by libraryPreferences.joinedLibrary().changes().collectAsState(initial = libraryPreferences.joinedLibrary().get())
 
         return listOf(
             getCategoriesGroup(LocalNavigator.currentOrThrow, allCategories, libraryPreferences),
             getGlobalUpdateGroup(allCategories, libraryPreferences),
-            getBehaviorGroup(libraryPreferences),
+            getBehaviorGroup(libraryPreferences, isJoined),
         )
     }
 
@@ -232,10 +234,10 @@ object SettingsLibraryScreen : SearchableSettings {
     @Composable
     private fun getBehaviorGroup(
         libraryPreferences: LibraryPreferences,
+        isJoined: Boolean,
     ): Preference.PreferenceGroup {
-        return Preference.PreferenceGroup(
-            title = stringResource(MR.strings.pref_behavior),
-            preferenceItems = persistentListOf(
+        val preferenceItems = buildList {
+            add(
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.swipeToStartAction(),
                     entries = persistentMapOf(
@@ -250,6 +252,8 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     title = stringResource(MR.strings.pref_chapter_swipe_start),
                 ),
+            )
+            add(
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.swipeToEndAction(),
                     entries = persistentMapOf(
@@ -264,6 +268,8 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     title = stringResource(MR.strings.pref_chapter_swipe_end),
                 ),
+            )
+            add(
                 Preference.PreferenceItem.MultiSelectListPreference(
                     preference = libraryPreferences.markDuplicateReadChapterAsRead(),
                     entries = persistentMapOf(
@@ -274,26 +280,41 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     title = stringResource(MR.strings.pref_mark_duplicate_read_chapter_read),
                 ),
+            )
+            add(
                 Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.hideMissingChapters(),
                     title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
                 ),
+            )
+            add(
                 Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.sortMangaTags(),
                     title = "Sort novel tags alphabetically",
                     subtitle = "Sort tags on novel detail page by name instead of source order",
                 ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = libraryPreferences.mangaReadProgress100(),
-                    title = "Restore position in completed manga chapters",
-                    subtitle = "Resume manga chapters from where you left off even when already marked as read",
-                ),
+            )
+            if (!isJoined) {
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = libraryPreferences.mangaReadProgress100(),
+                        title = "Restore position in completed manga chapters",
+                        subtitle = "Resume manga chapters from where you left off even when already marked as read",
+                    ),
+                )
+            }
+            add(
                 Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.novelReadProgress100(),
                     title = "Restore position in completed novel chapters",
                     subtitle = "Resume novel chapters from where you left off even when already marked as read",
                 ),
-            ),
+            )
+        }
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_behavior),
+            preferenceItems = preferenceItems.toImmutableList(),
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -287,6 +287,15 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
                 ),
             )
+            if (!isJoined) {
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = libraryPreferences.showMangaSourceName(),
+                        title = stringResource(TDMR.strings.pref_show_manga_source_name),
+                        subtitle = stringResource(TDMR.strings.pref_show_manga_source_name_summary),
+                    ),
+                )
+            }
             add(
                 Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.sortMangaTags(),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +41,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.more.settings.screen.about.AboutScreen
@@ -50,6 +53,9 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import cafe.adriel.voyager.core.screen.Screen as VoyagerScreen
 
 object SettingsMainScreen : Screen() {
@@ -79,8 +85,13 @@ object SettingsMainScreen : Screen() {
     fun Content(twoPane: Boolean) {
         val navigator = LocalNavigator.currentOrThrow
         val backPress = LocalBackPress.currentOrThrow
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
         val containerColor = if (twoPane) getPalerSurface() else MaterialTheme.colorScheme.surface
         val topBarState = rememberTopAppBarState()
+        val visibleItems = remember(hideMangaUi) {
+            items.filterNot { hideMangaUi && it.isMangaOnly }
+        }
 
         Scaffold(
             topBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topBarState),
@@ -106,10 +117,12 @@ object SettingsMainScreen : Screen() {
             content = { contentPadding ->
                 val state = rememberLazyListState()
                 val indexSelected = if (twoPane) {
-                    items.indexOfFirst { it.screen::class == navigator.items.first()::class }
+                    visibleItems.indexOfFirst { it.screen::class == navigator.items.first()::class }
                         .also {
                             LaunchedEffect(Unit) {
-                                state.animateScrollToItem(it)
+                                if (it >= 0) {
+                                    state.animateScrollToItem(it)
+                                }
                                 if (it > 0) {
                                     // Lift scroll
                                     topBarState.contentOffset = topBarState.heightOffsetLimit
@@ -125,7 +138,7 @@ object SettingsMainScreen : Screen() {
                     contentPadding = contentPadding,
                 ) {
                     itemsIndexed(
-                        items = items,
+                        items = visibleItems,
                         key = { _, item -> item.hashCode() },
                     ) { index, item ->
                         val selected = indexSelected == index
@@ -171,6 +184,7 @@ object SettingsMainScreen : Screen() {
         val formatSubtitle: @Composable () -> String? = { subtitleRes?.let { stringResource(it) } },
         val icon: ImageVector,
         val screen: VoyagerScreen,
+        val isMangaOnly: Boolean = false,
     )
 
     private val items = listOf(
@@ -191,6 +205,7 @@ object SettingsMainScreen : Screen() {
             subtitleRes = TDMR.strings.pref_manga_reader_summary,
             icon = Icons.AutoMirrored.Outlined.ChromeReaderMode,
             screen = SettingsReaderScreen,
+            isMangaOnly = true,
         ),
         Item(
             titleRes = TDMR.strings.pref_category_novel_reader,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,6 +43,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.more.settings.screen.about.AboutScreen
 import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import eu.kanade.presentation.util.LocalBackPress
@@ -79,8 +82,13 @@ object SettingsMainScreen : Screen() {
     fun Content(twoPane: Boolean) {
         val navigator = LocalNavigator.currentOrThrow
         val backPress = LocalBackPress.currentOrThrow
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
         val containerColor = if (twoPane) getPalerSurface() else MaterialTheme.colorScheme.surface
         val topBarState = rememberTopAppBarState()
+        val visibleItems = remember(hideMangaUi) {
+            items.filterNot { hideMangaUi && it.isMangaOnly }
+        }
 
         Scaffold(
             topBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topBarState),
@@ -106,10 +114,12 @@ object SettingsMainScreen : Screen() {
             content = { contentPadding ->
                 val state = rememberLazyListState()
                 val indexSelected = if (twoPane) {
-                    items.indexOfFirst { it.screen::class == navigator.items.first()::class }
+                    visibleItems.indexOfFirst { it.screen::class == navigator.items.first()::class }
                         .also {
                             LaunchedEffect(Unit) {
-                                state.animateScrollToItem(it)
+                                if (it >= 0) {
+                                    state.animateScrollToItem(it)
+                                }
                                 if (it > 0) {
                                     // Lift scroll
                                     topBarState.contentOffset = topBarState.heightOffsetLimit
@@ -125,7 +135,7 @@ object SettingsMainScreen : Screen() {
                     contentPadding = contentPadding,
                 ) {
                     itemsIndexed(
-                        items = items,
+                        items = visibleItems,
                         key = { _, item -> item.hashCode() },
                     ) { index, item ->
                         val selected = indexSelected == index
@@ -171,6 +181,7 @@ object SettingsMainScreen : Screen() {
         val formatSubtitle: @Composable () -> String? = { subtitleRes?.let { stringResource(it) } },
         val icon: ImageVector,
         val screen: VoyagerScreen,
+        val isMangaOnly: Boolean = false,
     )
 
     private val items = listOf(
@@ -191,6 +202,7 @@ object SettingsMainScreen : Screen() {
             subtitleRes = TDMR.strings.pref_manga_reader_summary,
             icon = Icons.AutoMirrored.Outlined.ChromeReaderMode,
             screen = SettingsReaderScreen,
+            isMangaOnly = true,
         ),
         Item(
             titleRes = TDMR.strings.pref_category_novel_reader,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -53,6 +53,9 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import cafe.adriel.voyager.core.screen.Screen as VoyagerScreen
 
 object SettingsMainScreen : Screen() {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
@@ -40,6 +40,7 @@ import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.collections.immutable.persistentListOf
+import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences.Companion.SourceOverride
 import tachiyomi.domain.source.service.SourceManager
@@ -131,12 +132,14 @@ object SettingsNovelDownloadScreen : SearchableSettings {
     private fun getDownloadThrottlingGroup(
         prefs: NovelDownloadPreferences,
     ): Preference.PreferenceGroup {
+        val downloadPreferences = Injekt.get<DownloadPreferences>()
         val enabled = prefs.enableThrottling().collectAsState().value
         val downloadDelay = prefs.downloadDelay().collectAsState().value
         val randomDelayMin = prefs.randomDelayMin().collectAsState().value
         val randomDelay = prefs.randomDelayRange().collectAsState().value
         val parallelDownloads = prefs.parallelNovelDownloads().collectAsState().value
         val compressionLevel = prefs.zipCompressionLevel().collectAsState().value
+        val epubCompressionLevel = downloadPreferences.epubCompressionLevel().collectAsState().value
         val resumeOnNew = prefs.resumeQueueOnNewChapters().collectAsState().value
 
         val lowDelayWarning = if (downloadDelay < LOW_DELAY_THRESHOLD_MS && enabled) {
@@ -215,6 +218,25 @@ object SettingsNovelDownloadScreen : SearchableSettings {
                         stringResource(TDMR.strings.pref_novel_deflate_level, compressionLevel)
                     },
                     onValueChanged = { prefs.zipCompressionLevel().set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = epubCompressionLevel + 1,
+                    valueRange = 0..10,
+                    title = stringResource(MR.strings.pref_epub_compression_level),
+                    subtitle = when (epubCompressionLevel) {
+                        -1 -> stringResource(MR.strings.pref_epub_compression_default)
+                        0 -> stringResource(MR.strings.pref_epub_compression_none)
+                        in 1..3 -> stringResource(MR.strings.pref_epub_compression_low)
+                        in 4..6 -> stringResource(MR.strings.pref_epub_compression_medium)
+                        in 7..9 -> stringResource(MR.strings.pref_epub_compression_high)
+                        else -> stringResource(MR.strings.pref_epub_compression_level_label, epubCompressionLevel)
+                    },
+                    valueString = if (epubCompressionLevel == -1) {
+                        stringResource(MR.strings.pref_epub_compression_default_label)
+                    } else {
+                        "$epubCompressionLevel"
+                    },
+                    onValueChanged = { downloadPreferences.epubCompressionLevel().set(it - 1) },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
@@ -40,6 +40,7 @@ import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.collections.immutable.persistentListOf
+import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences.Companion.SourceOverride
 import tachiyomi.domain.source.service.SourceManager
@@ -80,6 +81,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
     @Composable
     override fun getPreferences(): List<Preference> {
         val novelDownloadPreferences = remember { Injekt.get<NovelDownloadPreferences>() }
+        val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
 
         // Dialog state for per-extension overrides
         var showOverridesDialog by remember { mutableStateOf(false) }
@@ -119,7 +121,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
         }
 
         return listOf(
-            getDownloadThrottlingGroup(novelDownloadPreferences),
+            getDownloadThrottlingGroup(novelDownloadPreferences, downloadPreferences),
             getImageEmbeddingGroup(novelDownloadPreferences),
             getUpdateThrottlingGroup(novelDownloadPreferences),
             getMassImportThrottlingGroup(novelDownloadPreferences),
@@ -130,6 +132,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
     @Composable
     private fun getDownloadThrottlingGroup(
         prefs: NovelDownloadPreferences,
+        downloadPreferences: DownloadPreferences,
     ): Preference.PreferenceGroup {
         val enabled = prefs.enableThrottling().collectAsState().value
         val downloadDelay = prefs.downloadDelay().collectAsState().value
@@ -137,6 +140,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
         val randomDelay = prefs.randomDelayRange().collectAsState().value
         val parallelDownloads = prefs.parallelNovelDownloads().collectAsState().value
         val compressionLevel = prefs.zipCompressionLevel().collectAsState().value
+        val epubCompressionLevel = downloadPreferences.epubCompressionLevel().collectAsState().value
         val resumeOnNew = prefs.resumeQueueOnNewChapters().collectAsState().value
 
         val lowDelayWarning = if (downloadDelay < LOW_DELAY_THRESHOLD_MS && enabled) {
@@ -215,6 +219,25 @@ object SettingsNovelDownloadScreen : SearchableSettings {
                         stringResource(TDMR.strings.pref_novel_deflate_level, compressionLevel)
                     },
                     onValueChanged = { prefs.zipCompressionLevel().set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = epubCompressionLevel + 1,
+                    valueRange = 0..10,
+                    title = stringResource(MR.strings.pref_epub_compression_level),
+                    subtitle = when (epubCompressionLevel) {
+                        -1 -> stringResource(MR.strings.pref_epub_compression_default)
+                        0 -> stringResource(MR.strings.pref_epub_compression_none)
+                        in 1..3 -> stringResource(MR.strings.pref_epub_compression_low)
+                        in 4..6 -> stringResource(MR.strings.pref_epub_compression_medium)
+                        in 7..9 -> stringResource(MR.strings.pref_epub_compression_high)
+                        else -> stringResource(MR.strings.pref_epub_compression_level_label, epubCompressionLevel)
+                    },
+                    valueString = if (epubCompressionLevel == -1) {
+                        stringResource(MR.strings.pref_epub_compression_default_label)
+                    } else {
+                        "$epubCompressionLevel"
+                    },
+                    onValueChanged = { downloadPreferences.epubCompressionLevel().set(it - 1) },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
@@ -134,6 +134,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
         prefs: NovelDownloadPreferences,
         downloadPreferences: DownloadPreferences,
     ): Preference.PreferenceGroup {
+        val downloadPreferences = Injekt.get<DownloadPreferences>()
         val enabled = prefs.enableThrottling().collectAsState().value
         val downloadDelay = prefs.downloadDelay().collectAsState().value
         val randomDelayMin = prefs.randomDelayMin().collectAsState().value

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
@@ -291,6 +291,8 @@ private val settingScreens = listOf(
     SettingsReaderScreen,
     SettingsNovelReaderScreen,
     SettingsDownloadScreen,
+    SettingsNovelDownloadScreen,
+    SettingsTranslationScreen,
     SettingsTrackingScreen,
     SettingsBrowseScreen,
     SettingsDataScreen,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
@@ -99,7 +99,6 @@ private fun ExtensionRepoListItem(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-
             IconButton(onClick = onOpenWebsite) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
@@ -128,9 +127,9 @@ private fun ExtensionRepoListItem(
 
             Row(
                 modifier = Modifier.padding(
-                top = MaterialTheme.padding.small,
-                end = MaterialTheme.padding.small,
-            ),
+                    top = MaterialTheme.padding.small,
+                    end = MaterialTheme.padding.small,
+                ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Switch(

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -75,6 +75,7 @@ fun UpdateScreen(
     onFilterSelected: (UpdatesFilter) -> Unit = {},
     onFilterClicked: () -> Unit,
     hasActiveFilters: Boolean,
+    showMangaFilter: Boolean = true,
     onToggleGroupByNovel: () -> Unit = {},
     onClickNovelGroup: (Long) -> Unit = {},
     onLoadMore: () -> Unit = {},
@@ -164,11 +165,13 @@ fun UpdateScreen(
                                     onClick = { onFilterSelected(UpdatesFilter.ALL) },
                                     label = { Text(stringResource(MR.strings.all)) },
                                 )
-                                FilterChip(
-                                    selected = state.filter == UpdatesFilter.MANGA,
-                                    onClick = { onFilterSelected(UpdatesFilter.MANGA) },
-                                    label = { Text(stringResource(TDMR.strings.label_manga)) },
-                                )
+                                if (showMangaFilter) {
+                                    FilterChip(
+                                        selected = state.filter == UpdatesFilter.MANGA,
+                                        onClick = { onFilterSelected(UpdatesFilter.MANGA) },
+                                        label = { Text(stringResource(TDMR.strings.label_manga)) },
+                                    )
+                                }
                                 FilterChip(
                                     selected = state.filter == UpdatesFilter.NOVELS,
                                     onClick = { onFilterSelected(UpdatesFilter.NOVELS) },

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -75,6 +75,7 @@ fun UpdateScreen(
     onFilterSelected: (UpdatesFilter) -> Unit = {},
     onFilterClicked: () -> Unit,
     hasActiveFilters: Boolean,
+    showAllFilter: Boolean = true,
     showMangaFilter: Boolean = true,
     onToggleGroupByNovel: () -> Unit = {},
     onClickNovelGroup: (Long) -> Unit = {},
@@ -160,11 +161,13 @@ fun UpdateScreen(
                                     .padding(horizontal = 16.dp, vertical = 8.dp),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
-                                FilterChip(
-                                    selected = state.filter == UpdatesFilter.ALL,
-                                    onClick = { onFilterSelected(UpdatesFilter.ALL) },
-                                    label = { Text(stringResource(MR.strings.all)) },
-                                )
+                                if (showAllFilter) {
+                                    FilterChip(
+                                        selected = state.filter == UpdatesFilter.ALL,
+                                        onClick = { onFilterSelected(UpdatesFilter.ALL) },
+                                        label = { Text(stringResource(MR.strings.all)) },
+                                    )
+                                }
                                 if (showMangaFilter) {
                                     FilterChip(
                                         selected = state.filter == UpdatesFilter.MANGA,

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -60,6 +60,7 @@ import kotlin.time.Duration.Companion.seconds
 fun UpdateScreen(
     state: UpdatesScreenModel.State,
     snackbarHostState: SnackbarHostState,
+    showFilterChips: Boolean = true,
     lastUpdated: Long,
     onClickCover: (UpdatesItem) -> Unit,
     onSelectAll: (Boolean) -> Unit,
@@ -153,33 +154,34 @@ fun UpdateScreen(
                         contentPadding = contentPadding,
                         state = lazyListState,
                     ) {
-                        // Filter chips row
-                        item(key = "filter_chips") {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                if (showAllFilter) {
+                        if (showFilterChips) {
+                            item(key = "filter_chips") {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    if (showAllFilter) {
                                     FilterChip(
                                         selected = state.filter == UpdatesFilter.ALL,
                                         onClick = { onFilterSelected(UpdatesFilter.ALL) },
                                         label = { Text(stringResource(MR.strings.all)) },
                                     )
-                                }
-                                if (showMangaFilter) {
+                                    }
+                                    if (showMangaFilter) {
                                     FilterChip(
                                         selected = state.filter == UpdatesFilter.MANGA,
                                         onClick = { onFilterSelected(UpdatesFilter.MANGA) },
                                         label = { Text(stringResource(TDMR.strings.label_manga)) },
                                     )
+                                    }
+                                    FilterChip(
+                                        selected = state.filter == UpdatesFilter.NOVELS,
+                                        onClick = { onFilterSelected(UpdatesFilter.NOVELS) },
+                                        label = { Text(stringResource(TDMR.strings.label_novels)) },
+                                    )
                                 }
-                                FilterChip(
-                                    selected = state.filter == UpdatesFilter.NOVELS,
-                                    onClick = { onFilterSelected(UpdatesFilter.NOVELS) },
-                                    label = { Text(stringResource(TDMR.strings.label_novels)) },
-                                )
                             }
                         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -437,7 +437,10 @@ class DownloadCache(
     }
 
     private fun getSources(): List<Source> {
-        return sourceManager.getOnlineSources() + sourceManager.getStubSources()
+        val catalogueSources = sourceManager.getCatalogueSources()
+        val catalogueSourceIds = catalogueSources.mapTo(mutableSetOf()) { it.id }
+        val offlineStubSources = sourceManager.getStubSources().filterNot { it.id in catalogueSourceIds }
+        return catalogueSources + offlineStubSources
     }
 
     private fun notifyChanges() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.Navigator
@@ -34,7 +35,10 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.domain.library.service.LibraryPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 data object BrowseTab : Tab {
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -15,6 +15,7 @@ import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import eu.kanade.presentation.components.TabbedScreen
 import eu.kanade.presentation.util.Tab
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.browse.extension.ExtensionsScreenModel
 import eu.kanade.tachiyomi.ui.browse.extension.NovelExtensionsScreenModel
@@ -33,6 +34,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.domain.library.service.LibraryPreferences
 
 data object BrowseTab : Tab {
 
@@ -61,6 +63,11 @@ data object BrowseTab : Tab {
     @Composable
     override fun Content() {
         val context = LocalContext.current
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
+        val isJoined by libraryPreferences.joinedLibrary().collectAsState()
+        val hideMangaBrowseTabs = hideMangaUi || isJoined
 
         // Hoisted for extensions tab's search bar
         val extensionsScreenModel = rememberScreenModel { ExtensionsScreenModel() }
@@ -69,14 +76,25 @@ data object BrowseTab : Tab {
         val novelExtensionsScreenModel = rememberScreenModel { NovelExtensionsScreenModel() }
         val novelExtensionsState by novelExtensionsScreenModel.state.collectAsState()
 
-        val tabs = persistentListOf(
-            novelSourcesTab(),
-            sourcesTab(),
-            novelExtensionsTab(novelExtensionsScreenModel),
-            extensionsTab(extensionsScreenModel),
-            novelMigrateSourceTab(),
-            migrateSourceTab(),
-        )
+        val tabs = if (hideMangaBrowseTabs) {
+            persistentListOf(
+                novelSourcesTab(),
+                novelExtensionsTab(novelExtensionsScreenModel),
+                novelMigrateSourceTab(),
+            )
+        } else {
+            persistentListOf(
+                novelSourcesTab(),
+                sourcesTab(),
+                novelExtensionsTab(novelExtensionsScreenModel),
+                extensionsTab(extensionsScreenModel),
+                novelMigrateSourceTab(),
+                migrateSourceTab(),
+            )
+        }
+
+        val novelExtensionsTabIndex = if (hideMangaBrowseTabs) 1 else 2
+        val mangaExtensionsTabIndex = if (hideMangaBrowseTabs) null else 3
 
         val state = rememberPagerState { tabs.size }
 
@@ -85,20 +103,22 @@ data object BrowseTab : Tab {
             tabs = tabs,
             state = state,
             searchQuery = when (state.currentPage) {
-                2 -> novelExtensionsState.searchQuery
-                3 -> extensionsState.searchQuery
+                novelExtensionsTabIndex -> novelExtensionsState.searchQuery
+                mangaExtensionsTabIndex -> extensionsState.searchQuery
                 else -> null
             },
             onChangeSearchQuery = { query ->
                 when (state.currentPage) {
-                    2 -> novelExtensionsScreenModel.search(query)
-                    3 -> extensionsScreenModel.search(query)
+                    novelExtensionsTabIndex -> novelExtensionsScreenModel.search(query)
+                    mangaExtensionsTabIndex -> extensionsScreenModel.search(query)
                 }
             },
         )
         LaunchedEffect(Unit) {
             switchToExtensionTabChannel.receiveAsFlow()
-                .collectLatest { state.scrollToPage(3) }
+                .collectLatest {
+                    state.scrollToPage(if (hideMangaBrowseTabs) novelExtensionsTabIndex else 3)
+                }
         }
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -8,11 +8,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.components.TabbedScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
@@ -31,8 +33,12 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 data object BrowseTab : Tab {
 
@@ -61,6 +67,11 @@ data object BrowseTab : Tab {
     @Composable
     override fun Content() {
         val context = LocalContext.current
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
+        val isJoined by libraryPreferences.joinedLibrary().collectAsState()
+        val hideMangaBrowseTabs = hideMangaUi || isJoined
 
         // Hoisted for extensions tab's search bar
         val extensionsScreenModel = rememberScreenModel { ExtensionsScreenModel() }
@@ -69,14 +80,25 @@ data object BrowseTab : Tab {
         val novelExtensionsScreenModel = rememberScreenModel { NovelExtensionsScreenModel() }
         val novelExtensionsState by novelExtensionsScreenModel.state.collectAsState()
 
-        val tabs = persistentListOf(
-            novelSourcesTab(),
-            sourcesTab(),
-            novelExtensionsTab(novelExtensionsScreenModel),
-            extensionsTab(extensionsScreenModel),
-            novelMigrateSourceTab(),
-            migrateSourceTab(),
-        )
+        val tabs = if (hideMangaBrowseTabs) {
+            persistentListOf(
+                novelSourcesTab(),
+                novelExtensionsTab(novelExtensionsScreenModel),
+                novelMigrateSourceTab(),
+            )
+        } else {
+            persistentListOf(
+                novelSourcesTab(),
+                sourcesTab(),
+                novelExtensionsTab(novelExtensionsScreenModel),
+                extensionsTab(extensionsScreenModel),
+                novelMigrateSourceTab(),
+                migrateSourceTab(),
+            )
+        }
+
+        val novelExtensionsTabIndex = if (hideMangaBrowseTabs) 1 else 2
+        val mangaExtensionsTabIndex = if (hideMangaBrowseTabs) null else 3
 
         val state = rememberPagerState { tabs.size }
 
@@ -85,20 +107,22 @@ data object BrowseTab : Tab {
             tabs = tabs,
             state = state,
             searchQuery = when (state.currentPage) {
-                2 -> novelExtensionsState.searchQuery
-                3 -> extensionsState.searchQuery
+                novelExtensionsTabIndex -> novelExtensionsState.searchQuery
+                mangaExtensionsTabIndex -> extensionsState.searchQuery
                 else -> null
             },
             onChangeSearchQuery = { query ->
                 when (state.currentPage) {
-                    2 -> novelExtensionsScreenModel.search(query)
-                    3 -> extensionsScreenModel.search(query)
+                    novelExtensionsTabIndex -> novelExtensionsScreenModel.search(query)
+                    mangaExtensionsTabIndex -> extensionsScreenModel.search(query)
                 }
             },
         )
         LaunchedEffect(Unit) {
             switchToExtensionTabChannel.receiveAsFlow()
-                .collectLatest { state.scrollToPage(3) }
+                .collectLatest {
+                    state.scrollToPage(if (hideMangaBrowseTabs) novelExtensionsTabIndex else 3)
+                }
         }
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
@@ -256,7 +256,6 @@ private fun NovelRepoListItem(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-
             IconButton(onClick = {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repo.url))
                 context.startActivity(intent)
@@ -287,9 +286,9 @@ private fun NovelRepoListItem(
 
             Row(
                 modifier = Modifier.padding(
-                top = MaterialTheme.padding.small,
-                end = MaterialTheme.padding.small,
-            ),
+                    top = MaterialTheme.padding.small,
+                    end = MaterialTheme.padding.small,
+                ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Switch(
@@ -413,7 +412,6 @@ private fun KotlinRepoListItem(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-
             IconButton(onClick = {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repo.baseUrl))
                 context.startActivity(intent)
@@ -444,9 +442,9 @@ private fun KotlinRepoListItem(
 
             Row(
                 modifier = Modifier.padding(
-                top = MaterialTheme.padding.small,
-                end = MaterialTheme.padding.small,
-            ),
+                    top = MaterialTheme.padding.small,
+                    end = MaterialTheme.padding.small,
+                ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Switch(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -171,6 +171,17 @@ class HistoryScreenModel(
         mutableState.update { it.copy(filter = filter, limit = HISTORY_PAGE_SIZE) }
     }
 
+    fun syncFilterWithHideManga(hideMangaUi: Boolean) {
+        if (!hideMangaUi) return
+        mutableState.update { state ->
+            val nextFilter = when (state.filter) {
+                HistoryFilter.MANGA, HistoryFilter.ALL -> HistoryFilter.NOVELS
+                HistoryFilter.NOVELS -> HistoryFilter.NOVELS
+            }
+            if (nextFilter == state.filter) state else state.copy(filter = nextFilter, limit = HISTORY_PAGE_SIZE)
+        }
+    }
+
     fun setGroupByNovel(groupByNovel: Boolean) {
         mutableState.update { it.copy(groupByNovel = groupByNovel, limit = HISTORY_PAGE_SIZE) }
         libraryPreferences.historyGroupByNovel().set(groupByNovel)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -174,11 +174,11 @@ class HistoryScreenModel(
     fun syncFilterWithHideManga(hideMangaUi: Boolean) {
         if (!hideMangaUi) return
         mutableState.update { state ->
-            val nextFilter = when (state.filter) {
-                HistoryFilter.MANGA, HistoryFilter.ALL -> HistoryFilter.NOVELS
-                HistoryFilter.NOVELS -> HistoryFilter.NOVELS
+            if (state.filter == HistoryFilter.ALL) {
+                state
+            } else {
+                state.copy(filter = HistoryFilter.ALL, limit = HISTORY_PAGE_SIZE)
             }
-            if (nextFilter == state.filter) state else state.copy(filter = nextFilter, limit = HISTORY_PAGE_SIZE)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import mihon.feature.migration.dialog.MigrateMangaDialog
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.chapter.model.Chapter
-import tachiyomi.domain.library.service.LibraryPreferences
+import eu.kanade.domain.base.BasePreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
@@ -68,9 +68,9 @@ data object HistoryTab : Tab {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val screenModel = rememberScreenModel { HistoryScreenModel() }
-        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
         val state by screenModel.state.collectAsState()
-        val isJoined by libraryPreferences.joinedLibrary().changes().collectAsState(initial = libraryPreferences.joinedLibrary().get())
+        val hideMangaUi by basePreferences.hideMangaUi().changes().collectAsState(initial = basePreferences.hideMangaUi().get())
 
         HistoryScreen(
             state = state,
@@ -83,8 +83,13 @@ data object HistoryTab : Tab {
             onFilterSelected = screenModel::setFilter,
             onGroupByNovelChanged = screenModel::setGroupByNovel,
             onLoadNextPage = screenModel::loadNextPage,
-            showMangaFilter = !isJoined,
+            showAllFilter = !hideMangaUi,
+            showMangaFilter = !hideMangaUi,
         )
+
+        LaunchedEffect(hideMangaUi) {
+            screenModel.syncFilterWithHideManga(hideMangaUi)
+        }
 
         val onDismissRequest = { screenModel.setDialog(null) }
         when (val dialog = state.dialog) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -33,10 +33,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import mihon.feature.migration.dialog.MigrateMangaDialog
-import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.domain.chapter.model.Chapter
 import eu.kanade.domain.base.BasePreferences
+import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.i18n.MR
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -72,9 +72,14 @@ data object HistoryTab : Tab {
         val state by screenModel.state.collectAsState()
         val hideMangaUi by basePreferences.hideMangaUi().changes().collectAsState(initial = basePreferences.hideMangaUi().get())
 
+        LaunchedEffect(hideMangaUi) {
+            screenModel.syncFilterWithHideManga(hideMangaUi)
+        }
+
         HistoryScreen(
             state = state,
             snackbarHostState = snackbarHostState,
+            showFilterChips = !hideMangaUi,
             onSearchQueryChange = screenModel::updateSearchQuery,
             onClickCover = { navigator.push(MangaScreen(it)) },
             onClickResume = screenModel::getNextChapterForManga,
@@ -86,10 +91,6 @@ data object HistoryTab : Tab {
             showAllFilter = !hideMangaUi,
             showMangaFilter = !hideMangaUi,
         )
-
-        LaunchedEffect(hideMangaUi) {
-            screenModel.syncFilterWithHideManga(hideMangaUi)
-        }
 
         val onDismissRequest = { screenModel.setDialog(null) }
         when (val dialog = state.dialog) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -34,8 +35,11 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import mihon.feature.migration.dialog.MigrateMangaDialog
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 data object HistoryTab : Tab {
 
@@ -64,7 +68,9 @@ data object HistoryTab : Tab {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val screenModel = rememberScreenModel { HistoryScreenModel() }
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
         val state by screenModel.state.collectAsState()
+        val isJoined by libraryPreferences.joinedLibrary().changes().collectAsState(initial = libraryPreferences.joinedLibrary().get())
 
         HistoryScreen(
             state = state,
@@ -77,6 +83,7 @@ data object HistoryTab : Tab {
             onFilterSelected = screenModel::setFilter,
             onGroupByNovelChanged = screenModel::setGroupByNovel,
             onLoadNextPage = screenModel::loadNextPage,
+            showMangaFilter = !isJoined,
         )
 
         val onDismissRequest = { screenModel.setDialog(null) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.TabNavigator
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.util.Screen
 import eu.kanade.presentation.util.isTabletUi
@@ -95,8 +96,10 @@ object HomeScreen : Screen() {
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val libraryPreferences = remember { Injekt.get<tachiyomi.domain.library.service.LibraryPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
         val isJoined by libraryPreferences.joinedLibrary().collectAsState()
-        val tabs = if (isJoined) JOINED_TABS else TABS
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
+        val tabs = if (isJoined || hideMangaUi) JOINED_TABS else TABS
         TabNavigator(
             tab = NovelsTab,
             key = TabNavigatorKey,
@@ -168,7 +171,7 @@ object HomeScreen : Screen() {
                 launch {
                     openTabEvent.receiveAsFlow().collectLatest {
                         tabNavigator.current = when (it) {
-                            is Tab.Library -> if (isJoined) NovelsTab else LibraryTab
+                            is Tab.Library -> if (isJoined || hideMangaUi) NovelsTab else LibraryTab
                             Tab.Updates -> UpdatesTab
                             Tab.History -> HistoryTab
                             is Tab.Browse -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -35,6 +35,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.TabNavigator
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.util.Screen
 import eu.kanade.presentation.util.isTabletUi
 import eu.kanade.tachiyomi.ui.browse.BrowseTab
@@ -95,8 +96,10 @@ object HomeScreen : Screen() {
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val libraryPreferences = remember { Injekt.get<tachiyomi.domain.library.service.LibraryPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
         val isJoined by libraryPreferences.joinedLibrary().collectAsState()
-        val tabs = if (isJoined) JOINED_TABS else TABS
+        val hideMangaUi by basePreferences.hideMangaUi().collectAsState()
+        val tabs = if (isJoined || hideMangaUi) JOINED_TABS else TABS
         TabNavigator(
             tab = NovelsTab,
             key = TabNavigatorKey,
@@ -168,7 +171,7 @@ object HomeScreen : Screen() {
                 launch {
                     openTabEvent.receiveAsFlow().collectLatest {
                         tabNavigator.current = when (it) {
-                            is Tab.Library -> if (isJoined) NovelsTab else LibraryTab
+                            is Tab.Library -> if (isJoined || hideMangaUi) NovelsTab else LibraryTab
                             Tab.Updates -> UpdatesTab
                             Tab.History -> HistoryTab
                             is Tab.Browse -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -620,6 +620,12 @@ class UpdatesScreenModel(
         currentLimit.value = GetUpdates.PAGE_SIZE
     }
 
+    fun syncFilterWithHideManga(hideMangaUi: Boolean) {
+        if (!hideMangaUi) return
+        if (state.value.filter == UpdatesFilter.NOVELS) return
+        setFilter(UpdatesFilter.NOVELS)
+    }
+
     sealed interface Dialog {
         data class DeleteConfirmation(val toDelete: List<UpdatesItem>) : Dialog
         data object FilterSheet : Dialog

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -621,9 +621,13 @@ class UpdatesScreenModel(
     }
 
     fun syncFilterWithHideManga(hideMangaUi: Boolean) {
-        if (!hideMangaUi) return
-        if (state.value.filter == UpdatesFilter.NOVELS) return
-        setFilter(UpdatesFilter.NOVELS)
+        if (!hideMangaUi || state.value.filter == UpdatesFilter.ALL) return
+
+        mutableState.update { it.copy(filter = UpdatesFilter.ALL) }
+        mutableState.update {
+            it.copy(items = latestUpdates.toUpdateItems().toPersistentList())
+        }
+        currentLimit.value = GetUpdates.PAGE_SIZE
     }
 
     sealed interface Dialog {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -64,9 +64,14 @@ data object UpdatesTab : Tab {
         val state by screenModel.state.collectAsState()
         val hideMangaUi by basePreferences.hideMangaUi().changes().collectAsState(initial = basePreferences.hideMangaUi().get())
 
+        LaunchedEffect(hideMangaUi) {
+            screenModel.syncFilterWithHideManga(hideMangaUi)
+        }
+
         UpdateScreen(
             state = state,
             snackbarHostState = screenModel.snackbarHostState,
+            showFilterChips = !hideMangaUi,
             lastUpdated = screenModel.lastUpdated,
             onClickCover = { item -> navigator.push(MangaScreen(item.update.mangaId)) },
             onSelectAll = screenModel::toggleAllSelection,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -27,10 +27,10 @@ import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel.Event
+import eu.kanade.domain.base.BasePreferences
 import kotlinx.coroutines.flow.collectLatest
 import mihon.feature.upcoming.UpcomingScreen
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
@@ -60,9 +60,9 @@ data object UpdatesTab : Tab {
         val navigator = LocalNavigator.currentOrThrow
         val screenModel = rememberScreenModel { UpdatesScreenModel() }
         val settingsScreenModel = rememberScreenModel { UpdatesSettingsScreenModel() }
-        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val basePreferences = remember { Injekt.get<BasePreferences>() }
         val state by screenModel.state.collectAsState()
-        val isJoined by libraryPreferences.joinedLibrary().changes().collectAsState(initial = libraryPreferences.joinedLibrary().get())
+        val hideMangaUi by basePreferences.hideMangaUi().changes().collectAsState(initial = basePreferences.hideMangaUi().get())
 
         UpdateScreen(
             state = state,
@@ -85,11 +85,16 @@ data object UpdatesTab : Tab {
             onFilterSelected = screenModel::setFilter,
             onFilterClicked = screenModel::showFilterDialog,
             hasActiveFilters = state.hasActiveFilters,
-            showMangaFilter = !isJoined,
+            showAllFilter = !hideMangaUi,
+            showMangaFilter = !hideMangaUi,
             onToggleGroupByNovel = screenModel::toggleGroupByNovel,
             onClickNovelGroup = { mangaId -> navigator.push(MangaScreen(mangaId)) },
             onLoadMore = screenModel::loadMore,
         )
+
+        LaunchedEffect(hideMangaUi) {
+            screenModel.syncFilterWithHideManga(hideMangaUi)
+        }
 
         val onDismissDialog = { screenModel.setDialog(null) }
         when (val dialog = state.dialog) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -29,8 +30,11 @@ import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel.Event
 import kotlinx.coroutines.flow.collectLatest
 import mihon.feature.upcoming.UpcomingScreen
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 data object UpdatesTab : Tab {
 
@@ -56,7 +60,9 @@ data object UpdatesTab : Tab {
         val navigator = LocalNavigator.currentOrThrow
         val screenModel = rememberScreenModel { UpdatesScreenModel() }
         val settingsScreenModel = rememberScreenModel { UpdatesSettingsScreenModel() }
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
         val state by screenModel.state.collectAsState()
+        val isJoined by libraryPreferences.joinedLibrary().changes().collectAsState(initial = libraryPreferences.joinedLibrary().get())
 
         UpdateScreen(
             state = state,
@@ -79,6 +85,7 @@ data object UpdatesTab : Tab {
             onFilterSelected = screenModel::setFilter,
             onFilterClicked = screenModel::showFilterDialog,
             hasActiveFilters = state.hasActiveFilters,
+            showMangaFilter = !isJoined,
             onToggleGroupByNovel = screenModel::toggleGroupByNovel,
             onClickNovelGroup = { mangaId -> navigator.push(MangaScreen(mangaId)) },
             onLoadMore = screenModel::loadMore,

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -327,6 +327,8 @@
     <string name="pref_font_size">Font size</string>
     <string name="pref_font_family">Font family</string>
     <string name="pref_novel_js_snippets">JavaScript Snippets</string>
+    <string name="pref_hide_manga_ui">Hide manga-related UI</string>
+    <string name="pref_hide_manga_ui_summary">Hide manga library tab, manga browse tabs, and manga settings.</string>
     <string name="novel_add_css_snippet">Add CSS snippet</string>
     <string name="novel_edit_css_snippet">Edit CSS snippet</string>
     <string name="novel_add_js_snippet">Add JavaScript snippet</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -328,6 +328,8 @@
     <string name="pref_font_size">Font size</string>
     <string name="pref_font_family">Font family</string>
     <string name="pref_novel_js_snippets">JavaScript Snippets</string>
+    <string name="pref_hide_manga_ui">Hide manga-related UI</string>
+    <string name="pref_hide_manga_ui_summary">Hide manga library tab, manga browse tabs, and manga settings.</string>
     <string name="novel_add_css_snippet">Add CSS snippet</string>
     <string name="novel_edit_css_snippet">Edit CSS snippet</string>
     <string name="novel_add_js_snippet">Add JavaScript snippet</string>


### PR DESCRIPTION
Add option to hide manga options in appearance screen
move epub compression to novel downloads screen
rearrange extensions tab filter