### PR TITLE
fix: Simplify URI normalization in document tree permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Telemetry [@Rojikku](https://github.com/Rojikku) [d4ec8df](https://github.com/tsundoku-otaku/tsundoku/commit/d4ec8dff90707ddabfb39a49be678e3ccc7e7ba2)
 - Updates tab didn't show all items properly when showing one entry per novel [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)
-- Improve storagemanager and directory creation to hopefully prevent issues with android 8 [@mrissaoussamau](https://github.com/mrissaoussama) [#44](https://github.com/tsundoku-otaku/tsundoku/pull/44)
+- Improve storagemanager and directory creation to hopefully prevent issues with android 8 [@mrissaoussamau](https://github.com/mrissaoussama) [#44](https://github.com/tsundoku-otaku/tsundoku/pull/44) [#56](https://github.com/tsundoku-otaku/tsundoku/pull/56)
 
 ### Other
 - Merged Mihon [2f9edb5](https://github.com/mihonapp/mihon/commit/2f9edb551fb2255c11ccd8452a080e87b9c963eb) [@Rojikku](https://github.com/Rojikku)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -131,16 +131,6 @@ object SettingsDataScreen : SearchableSettings {
             contract = ActivityResultContracts.OpenDocumentTree(),
         ) { uri ->
             if (uri != null) {
-                val normalizedUri = runCatching {
-                    val authority = uri.authority
-                    val treeId = DocumentsContract.getTreeDocumentId(uri)
-                    if (authority != null && treeId.isNotBlank()) {
-                        DocumentsContract.buildTreeDocumentUri(authority, treeId)
-                    } else {
-                        uri
-                    }
-                }.getOrDefault(uri)
-
                 val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
                     Intent.FLAG_GRANT_WRITE_URI_PERMISSION
 
@@ -150,14 +140,14 @@ object SettingsDataScreen : SearchableSettings {
                 // This also holds for some Samsung devices. Thus, we simply execute inside of a try-catch block and
                 // ignore the exception if it is thrown.
                 try {
-                    context.contentResolver.takePersistableUriPermission(normalizedUri, flags)
+                    context.contentResolver.takePersistableUriPermission(uri, flags)
                 } catch (e: SecurityException) {
                     logcat(LogPriority.ERROR, e)
                     context.toast(MR.strings.file_picker_uri_permission_unsupported)
                 }
 
-                UniFile.fromUri(context, normalizedUri)?.let {
-                    storageDirPref.set(normalizedUri.toString())
+                UniFile.fromUri(context, uri)?.let {
+                    storageDirPref.set(it.uri.toString())
                 }
             }
         }


### PR DESCRIPTION
hopefully fixes storage perms on some older android versions