### PR TITLE
epub import category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Hid Quick migration, removed from unnecessary places, added category option (For migrating between KT and JS of same source) [@mrissaoussamau](https://github.com/mrissaoussama) [#43](https://github.com/tsundoku-otaku/tsundoku/pull/43)
 - Add Enable/Disable for Extension Repos [@mrissaoussamau](https://github.com/mrissaoussama) [#50](https://github.com/tsundoku-otaku/tsundoku/pull/50)
 - Improved novel reader settings UI [@Rojikku](https://github.com/Rojikku) [#49](https://github.com/tsundoku-otaku/tsundoku/pull/49)
+- Fix Epub import to add to library (Not just inside source) and add specific category to import [@mrissaoussamau](https://github.com/mrissaoussama) [#70](https://github.com/tsundoku-otaku/tsundoku/pull/70)
 
 ### Added
 - Toggle under settings > Advanced that hides source name under manga details (For screenshots/bug reporting) [@mrissaoussamau](https://github.com/mrissaoussama) [#41](https://github.com/tsundoku-otaku/tsundoku/pull/41)

--- a/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -29,7 +28,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -55,8 +53,8 @@ import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
 import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository

--- a/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.hippo.unifile.UniFile
 import eu.kanade.presentation.category.visualName
+import eu.kanade.domain.manga.interactor.NetworkToLocalManga
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.coroutines.Dispatchers
@@ -50,13 +51,19 @@ import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import mihon.core.archive.EpubReader
 import mihon.core.archive.archiveReader
+import mihon.domain.manga.model.toDomainManga
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
+import tachiyomi.domain.manga.model.MangaUpdate
+import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.storage.service.StorageManager
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.source.local.LocalNovelSource
 import tachiyomi.source.local.metadata.fillMetadata
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -98,12 +105,28 @@ fun ImportEpubDialog(
     var selectedFiles = remember { mutableStateListOf<EpubFileInfo>() }
     var customTitle by remember { mutableStateOf("") }
     var combineAsOneNovel by remember { mutableStateOf(false) }
+    var autoAddToLibrary by remember { mutableStateOf(false) }
+    var selectedCategoryId by remember { mutableStateOf<Long?>(null) }
+    var categoryMenuExpanded by remember { mutableStateOf(false) }
+    var categories by remember { mutableStateOf<List<Category>>(emptyList()) }
 
     var importProgress by remember { mutableStateOf<ImportProgress?>(null) }
     var importResult by remember { mutableStateOf<ImportResult?>(null) }
     var isLoadingFiles by remember { mutableStateOf(false) }
 
     val storageManager = remember { Injekt.get<StorageManager>() }
+    val getCategories = remember { Injekt.get<GetCategories>() }
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        categories = withContext(Dispatchers.IO) {
+            getCategories.await().filter {
+                it.contentType == Category.CONTENT_TYPE_ALL || it.contentType == Category.CONTENT_TYPE_NOVEL
+            }
+        }
+        if (selectedCategoryId == null) {
+            selectedCategoryId = categories.firstOrNull()?.id
+        }
+    }
 
     // File picker for multiple EPUB files
     val filePickerLauncher = rememberLauncherForActivityResult(
@@ -291,6 +314,56 @@ fun ImportEpubDialog(
                                 }
                                 Spacer(Modifier.height(8.dp))
                             }
+
+                            // Optional: auto-add imported local novels to library and category
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { autoAddToLibrary = !autoAddToLibrary },
+                            ) {
+                                Checkbox(
+                                    checked = autoAddToLibrary,
+                                    onCheckedChange = { autoAddToLibrary = it },
+                                )
+                                Text(stringResource(TDMR.strings.epub_auto_add_to_category))
+                            }
+
+                            if (autoAddToLibrary) {
+                                val selectedCategory = categories.firstOrNull { it.id == selectedCategoryId }
+                                OutlinedButton(
+                                    onClick = { categoryMenuExpanded = true },
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Text(
+                                        text = selectedCategory?.visualName
+                                            ?: stringResource(TDMR.strings.epub_select_category),
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    Icon(Icons.Outlined.ArrowDropDown, contentDescription = null)
+                                }
+                                DropdownMenu(
+                                    expanded = categoryMenuExpanded,
+                                    onDismissRequest = { categoryMenuExpanded = false },
+                                ) {
+                                    categories.forEach { category ->
+                                        DropdownMenuItem(
+                                            text = { Text(category.visualName) },
+                                            onClick = {
+                                                selectedCategoryId = category.id
+                                                categoryMenuExpanded = false
+                                            },
+                                        )
+                                    }
+                                }
+                                Spacer(Modifier.height(8.dp))
+                            }
+
+                            Text(
+                                text = stringResource(TDMR.strings.epub_local_novels_note),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
                         }
                     }
                 }
@@ -317,7 +390,8 @@ fun ImportEpubDialog(
                                         files = selectedFiles.toList(),
                                         customTitle = customTitle.ifBlank { null },
                                         combineAsOne = combineAsOneNovel,
-                                        categoryId = null,
+                                        autoAddToLibrary = autoAddToLibrary,
+                                        categoryId = selectedCategoryId,
                                         storageManager = storageManager,
                                         onProgress = { current, total, fileName ->
                                             importProgress = ImportProgress(current, total, fileName, true)
@@ -417,12 +491,14 @@ private suspend fun importEpubFiles(
     files: List<EpubFileInfo>,
     customTitle: String?,
     combineAsOne: Boolean,
+    autoAddToLibrary: Boolean,
     categoryId: Long?,
     storageManager: StorageManager,
     onProgress: (current: Int, total: Int, fileName: String) -> Unit,
 ): ImportResult = withContext(Dispatchers.IO) {
     val errors = mutableListOf<String>()
     var successCount = 0
+    val importedNovelUrls = mutableListOf<String>()
 
     val localNovelsDir = storageManager.getLocalNovelSourceDirectory()
     if (localNovelsDir == null) {
@@ -442,6 +518,7 @@ private suspend fun importEpubFiles(
             if (novelDir == null) {
                 errors.add("Failed to create directory for: $novelTitle")
             } else {
+                importedNovelUrls.add(sanitizedTitle)
                 // Copy each file as a chapter
                 files.forEachIndexed { index, file ->
                     val chapterFileName = "Chapter ${index + 1} - ${file.fileName}"
@@ -499,6 +576,7 @@ private suspend fun importEpubFiles(
                 if (novelDir == null) {
                     errors.add("Failed to create directory for: ${file.fileName}")
                 } else {
+                    importedNovelUrls.add(sanitizedTitle)
                     // Copy the epub file
                     val destFile = novelDir.createFile(file.fileName)
                     if (destFile != null) {
@@ -537,7 +615,59 @@ private suspend fun importEpubFiles(
         }
     }
 
+    if (autoAddToLibrary) {
+        val registrationErrors = registerImportedLocalNovels(
+            importedNovelUrls = importedNovelUrls.distinct(),
+            categoryId = categoryId,
+        )
+        errors.addAll(registrationErrors)
+    }
+
     ImportResult(successCount, errors.size, errors)
+}
+
+private suspend fun registerImportedLocalNovels(
+    importedNovelUrls: List<String>,
+    categoryId: Long?,
+): List<String> {
+    if (importedNovelUrls.isEmpty()) return emptyList()
+
+    val networkToLocalManga = Injekt.get<NetworkToLocalManga>()
+    val getMangaByUrlAndSourceId = Injekt.get<GetMangaByUrlAndSourceId>()
+    val mangaRepository = Injekt.get<MangaRepository>()
+    val setMangaCategories = Injekt.get<SetMangaCategories>()
+
+    val errors = mutableListOf<String>()
+
+    importedNovelUrls.forEach { localUrl ->
+        try {
+            val existing = getMangaByUrlAndSourceId.await(localUrl, LocalNovelSource.ID)
+            val manga = existing ?: run {
+                val placeholder = SManga.create().apply {
+                    title = localUrl
+                    url = localUrl
+                }
+                networkToLocalManga(placeholder.toDomainManga(LocalNovelSource.ID, isNovel = true))
+            }
+
+            mangaRepository.update(
+                MangaUpdate(
+                    id = manga.id,
+                    favorite = true,
+                    dateAdded = System.currentTimeMillis(),
+                    isNovel = true,
+                ),
+            )
+
+            if (categoryId != null && categoryId != 0L) {
+                setMangaCategories.await(manga.id, listOf(categoryId))
+            }
+        } catch (e: Exception) {
+            errors.add("$localUrl: ${e.message}")
+        }
+    }
+
+    return errors
 }
 
 private fun sanitizeFileName(name: String): String {

--- a/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/ImportEpubDialog.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.hippo.unifile.UniFile
 import eu.kanade.presentation.category.visualName
-import eu.kanade.domain.manga.interactor.NetworkToLocalManga
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import kotlinx.coroutines.Dispatchers
@@ -57,6 +56,8 @@ import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
+import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.storage.service.StorageManager
@@ -231,6 +232,9 @@ fun ImportEpubDialog(
                 selectedFiles.addAll(fileInfos)
                 if (fileInfos.size == 1) {
                     customTitle = fileInfos.first().title
+                } else if (fileInfos.size > 1) {
+                    // For combine mode, default title to first selected epub filename (without extension).
+                    customTitle = fileInfos.first().fileName.substringBeforeLast('.', fileInfos.first().fileName)
                 }
                 isLoadingFiles = false
             }
@@ -304,11 +308,25 @@ fun ImportEpubDialog(
                                     verticalAlignment = Alignment.CenterVertically,
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .clickable { combineAsOneNovel = !combineAsOneNovel },
+                                        .clickable {
+                                            combineAsOneNovel = !combineAsOneNovel
+                                            if (combineAsOneNovel && customTitle.isBlank()) {
+                                                customTitle = selectedFiles.firstOrNull()?.fileName
+                                                    ?.substringBeforeLast('.', selectedFiles.first().fileName)
+                                                    .orEmpty()
+                                            }
+                                        },
                                 ) {
                                     Checkbox(
                                         checked = combineAsOneNovel,
-                                        onCheckedChange = { combineAsOneNovel = it },
+                                        onCheckedChange = {
+                                            combineAsOneNovel = it
+                                            if (it && customTitle.isBlank()) {
+                                                customTitle = selectedFiles.firstOrNull()?.fileName
+                                                    ?.substringBeforeLast('.', selectedFiles.first().fileName)
+                                                    .orEmpty()
+                                            }
+                                        },
                                     )
                                     Text(stringResource(TDMR.strings.epub_combine_files))
                                 }
@@ -510,7 +528,8 @@ private suspend fun importEpubFiles(
         onProgress(1, 1, customTitle ?: files.first().title)
 
         try {
-            val novelTitle = customTitle ?: files.first().title
+            val firstFileBaseName = files.first().fileName.substringBeforeLast('.', files.first().fileName)
+            val novelTitle = customTitle ?: firstFileBaseName
             val sanitizedTitle = sanitizeFileName(novelTitle)
 
             // Create novel folder
@@ -634,6 +653,7 @@ private suspend fun registerImportedLocalNovels(
 
     val networkToLocalManga = Injekt.get<NetworkToLocalManga>()
     val getMangaByUrlAndSourceId = Injekt.get<GetMangaByUrlAndSourceId>()
+    val getLibraryManga = Injekt.get<GetLibraryManga>()
     val mangaRepository = Injekt.get<MangaRepository>()
     val setMangaCategories = Injekt.get<SetMangaCategories>()
 
@@ -658,6 +678,9 @@ private suspend fun registerImportedLocalNovels(
                     isNovel = true,
                 ),
             )
+
+            // UI updates immediately.
+            getLibraryManga.addToLibrary(manga.id)
 
             if (categoryId != null && categoryId != 0L) {
                 setMangaCategories.await(manga.id, listOf(categoryId))

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -209,6 +209,9 @@
     <string name="epub_selected_files">Selected files:</string>
     <string name="epub_novel_title">Novel title</string>
     <string name="epub_combine_files">Combine all files into one novel</string>
+    <string name="epub_auto_add_to_category">Automatically add imported EPUBs to this category</string>
+    <string name="epub_select_category">Select category</string>
+    <string name="epub_local_novels_note">This novel will be under "Local novels" after import in Browse.</string>
     <string name="epub_importing_progress">Importing %1$d/%2$d</string>
     <string name="epub_import_complete">Import Complete</string>
     <string name="epub_import_success_count">%d imported successfully</string>


### PR DESCRIPTION

* Added a checkbox in the import dialog to allow users to automatically add imported EPUBs to the library and select a category for them. When enabled, a dropdown menu lets users pick the desired category.
* Improved default title handling when combining multiple EPUBs: the dialog now sets the default title to the first selected file's name (without extension) if the user hasn't provided one.