### PR TITLE
reader edit mode, text selection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 
+### Added
+- Add Edit mode to edit chapters, fixes to images to make this work [@mrissaoussama](https://github.com/mrissaoussama) [#82](https://github.com/tsundoku-otaku/tsundoku/pull/82)
+
+
 ## [v0.1.2] - 2026-03-22
 ### Changed
 - Decode HTML entities in JS manga title/descriptions `I&#x27;m` > `I'm` [@mrissaoussama](https://github.com/mrissaoussama) [#76](https://github.com/tsundoku-otaku/tsundoku/pull/76)

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/AppbarItemConfig.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/AppbarItemConfig.kt
@@ -19,6 +19,7 @@ enum class BottomBarItem(val id: String) {
     TTS("tts"),
     ORIENTATION("orientation"),
     SETTINGS("settings"),
+    EDIT("edit"),
 }
 
 data class BottomBarItemState(
@@ -35,6 +36,7 @@ val DefaultBottomBarItems = listOf(
     BottomBarItemState(BottomBarItem.TTS),
     BottomBarItemState(BottomBarItem.ORIENTATION),
     BottomBarItemState(BottomBarItem.SETTINGS),
+    BottomBarItemState(BottomBarItem.EDIT),
     BottomBarItemState(BottomBarItem.NEXT_CHAPTER),
 )
 

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material.icons.outlined.VerticalAlignTop
@@ -120,6 +121,9 @@ fun NovelReaderAppBars(
     isTtsPaused: Boolean,
     onToggleTts: () -> Unit,
     onLongPressTts: () -> Unit,
+
+    isEditing: Boolean = false,
+    onToggleEdit: () -> Unit = {},
 
     // Toolbar customization
     bottomBarItems: List<BottomBarItemState>,
@@ -206,6 +210,8 @@ fun NovelReaderAppBars(
                     isTtsPaused = isTtsPaused,
                     onToggleTts = onToggleTts,
                     onLongPressTts = onLongPressTts,
+                    isEditing = isEditing,
+                    onToggleEdit = onToggleEdit,
                 )
             }
         }
@@ -334,6 +340,8 @@ private fun NovelReaderBottomBar(
     isTtsPaused: Boolean,
     onToggleTts: () -> Unit,
     onLongPressTts: () -> Unit,
+    isEditing: Boolean,
+    onToggleEdit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showEditor by remember { mutableStateOf(false) }
@@ -447,6 +455,19 @@ private fun NovelReaderBottomBar(
                             contentDescription = stringResource(MR.strings.action_settings),
                         )
                     }
+
+                    // Edit
+                    BottomBarItem.EDIT -> IconButton(onClick = onToggleEdit) {
+                        Icon(
+                            Icons.Outlined.Edit,
+                            contentDescription = "Edit",
+                            tint = if (isEditing) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                    }
                 }
             }
     }
@@ -478,6 +499,7 @@ internal fun bottomBarItemInfo(
     BottomBarItem.TTS -> Icons.Outlined.RecordVoiceOver to stringResource(TDMR.strings.pref_novel_tts)
     BottomBarItem.ORIENTATION -> orientation.icon to stringResource(MR.strings.rotation_type)
     BottomBarItem.SETTINGS -> Icons.Outlined.Settings to stringResource(MR.strings.action_settings)
+    BottomBarItem.EDIT -> Icons.Outlined.Edit to "Edit" // Need to add translation later if required
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -124,10 +124,10 @@ fun NovelReaderAppBars(
 
     isEditing: Boolean = false,
     onToggleEdit: () -> Unit = {},
+    isWebView: Boolean = true,
 
     // Toolbar customization
     bottomBarItems: List<BottomBarItemState>,
-    onItemsChange: (List<BottomBarItemState>) -> Unit,
 ) {
     val backgroundColor = MaterialTheme.colorScheme
         .surfaceColorAtElevation(3.dp)
@@ -192,7 +192,6 @@ fun NovelReaderAppBars(
                         .fillMaxWidth()
                         .padding(horizontal = MaterialTheme.padding.small),
                     items = bottomBarItems,
-                    onItemsChange = onItemsChange,
                     onNextChapter = onNextChapter,
                     enabledNext = enabledNext,
                     onPreviousChapter = onPreviousChapter,
@@ -211,6 +210,7 @@ fun NovelReaderAppBars(
                     onToggleTts = onToggleTts,
                     onLongPressTts = onLongPressTts,
                     isEditing = isEditing,
+                    isWebView = isWebView,
                     onToggleEdit = onToggleEdit,
                 )
             }
@@ -322,7 +322,6 @@ private fun NovelReaderTopBar(
 @Composable
 private fun NovelReaderBottomBar(
     items: List<BottomBarItemState>,
-    onItemsChange: (List<BottomBarItemState>) -> Unit,
     onNextChapter: () -> Unit,
     enabledNext: Boolean,
     onPreviousChapter: () -> Unit,
@@ -341,11 +340,10 @@ private fun NovelReaderBottomBar(
     onToggleTts: () -> Unit,
     onLongPressTts: () -> Unit,
     isEditing: Boolean,
+    isWebView: Boolean,
     onToggleEdit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var showEditor by remember { mutableStateOf(false) }
-
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.SpaceEvenly,
@@ -353,7 +351,7 @@ private fun NovelReaderBottomBar(
     ) {
         // Previous chapter - left position, left arrow icon
         items
-            .filter { it.enabled }
+            .filter { it.enabled && (isWebView || it.item != BottomBarItem.EDIT) }
             .forEach { itemState ->
                 when (itemState.item) {
                     BottomBarItem.PREV_CHAPTER -> IconButton(
@@ -470,15 +468,6 @@ private fun NovelReaderBottomBar(
                     }
                 }
             }
-    }
-
-    if (showEditor) {
-        BottomBarEditorSheet(
-            items = items,
-            onItemsChange = onItemsChange,
-            onDismiss = { showEditor = false },
-            itemInfo = { item -> bottomBarItemInfo(item, orientation, isAutoScrolling, isTtsActive, isTtsPaused) },
-        )
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
@@ -383,23 +384,25 @@ private fun NovelReaderBottomBar(
                     }
 
                     // Translation toggle - tap for quick translate, long-press for language picker
-                    BottomBarItem.TRANSLATE -> Box(
-                        modifier = Modifier.combinedClickable(
-                            onClick = onToggleTranslation,
-                            onLongClick = onLongPressTranslation,
-                        ),
-                        contentAlignment = Alignment.Center,
+                    BottomBarItem.TRANSLATE -> androidx.compose.material3.Surface(
+                        modifier = Modifier.padding(4.dp),
+                        shape = MaterialTheme.shapes.small,
+                        color = if (isTranslating) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent
                     ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Translate,
-                            contentDescription = stringResource(TDMR.strings.action_translate),
-                            tint = if (isTranslating) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                            modifier = Modifier.size(48.dp).padding(12.dp),
-                        )
+                        Box(
+                            modifier = Modifier.combinedClickable(
+                                onClick = onToggleTranslation,
+                                onLongClick = onLongPressTranslation,
+                            ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Translate,
+                                contentDescription = stringResource(TDMR.strings.action_translate),
+                                tint = if (isTranslating) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(40.dp).padding(8.dp),
+                            )
+                        }
                     }
                     // Auto-scroll toggle
                     BottomBarItem.AUTO_SCROLL -> IconButton(onClick = onToggleAutoScroll) {
@@ -455,16 +458,19 @@ private fun NovelReaderBottomBar(
                     }
 
                     // Edit
-                    BottomBarItem.EDIT -> IconButton(onClick = onToggleEdit) {
-                        Icon(
-                            Icons.Outlined.Edit,
-                            contentDescription = "Edit",
-                            tint = if (isEditing) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                        )
+                    BottomBarItem.EDIT -> androidx.compose.material3.Surface(
+                        modifier = Modifier.padding(4.dp),
+                        shape = MaterialTheme.shapes.small,
+                        color = if (isEditing) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
+                        border = if (isEditing) BorderStroke(1.dp, MaterialTheme.colorScheme.primary) else null,
+                    ) {
+                        IconButton(onClick = onToggleEdit) {
+                            Icon(
+                                Icons.Outlined.Edit,
+                                contentDescription = "Edit",
+                                tint = if (isEditing) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -6,10 +6,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
@@ -32,12 +32,12 @@ import androidx.compose.material.icons.automirrored.outlined.NavigateBefore
 import androidx.compose.material.icons.automirrored.outlined.NavigateNext
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.RecordVoiceOver
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Settings
-import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material.icons.outlined.VerticalAlignTop
@@ -387,7 +387,7 @@ private fun NovelReaderBottomBar(
                     BottomBarItem.TRANSLATE -> androidx.compose.material3.Surface(
                         modifier = Modifier.padding(4.dp),
                         shape = MaterialTheme.shapes.small,
-                        color = if (isTranslating) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent
+                        color = if (isTranslating) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
                     ) {
                         Box(
                             modifier = Modifier.combinedClickable(

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -488,7 +488,7 @@ internal fun bottomBarItemInfo(
     BottomBarItem.TTS -> Icons.Outlined.RecordVoiceOver to stringResource(TDMR.strings.pref_novel_tts)
     BottomBarItem.ORIENTATION -> orientation.icon to stringResource(MR.strings.rotation_type)
     BottomBarItem.SETTINGS -> Icons.Outlined.Settings to stringResource(MR.strings.action_settings)
-    BottomBarItem.EDIT -> Icons.Outlined.Edit to "Edit" // Need to add translation later if required
+    BottomBarItem.EDIT -> Icons.Outlined.Edit to stringResource(MR.strings.action_edit)
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -664,7 +664,7 @@ class Downloader(
                     ?: (download.source as? HttpSource)?.baseUrl
                     ?: (download.source as? JsSource)?.baseUrl
                 val embedder = ChapterImageEmbedder()
-                embedder.processHtml(page.text!!, baseUrl)
+                embedder.processHtml(page.text!!, baseUrl, tmpDir)
             } else {
                 page.text!!
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -766,7 +766,7 @@ class ReaderActivity : BaseActivity() {
                         }) {
                             androidx.compose.material3.Text("Discard")
                         }
-                    }
+                    },
                 )
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -599,6 +599,7 @@ class ReaderActivity : BaseActivity() {
 
             val bottomBarItems by viewModel.bottomBarItems.collectAsState()
             var showBottomBarEditor by remember { mutableStateOf(false) }
+            var showEditSaveDialog by remember { mutableStateOf(false) }
             var isEditing by remember { mutableStateOf(false) }
 
             NovelReaderAppBars(
@@ -716,17 +717,58 @@ class ReaderActivity : BaseActivity() {
                         else -> {}
                     }
                 },
-                
+
                 isEditing = isEditing,
-                onToggleEdit = { 
-                    isEditing = !isEditing
+                onToggleEdit = {
                     val viewer = state.viewer
-                    if (viewer is NovelWebViewViewer) {
-                        viewer.toggleEditMode(isEditing)
+                    if (isEditing) {
+                        if (state.hasUnsavedChanges) {
+                            showEditSaveDialog = true
+                        } else {
+                            isEditing = false
+                            (viewer as? NovelWebViewViewer)?.toggleEditMode(isEditing = false, save = false)
+                        }
+                    } else {
+                        isEditing = true
+                        if (viewer is NovelWebViewViewer) {
+                            viewer.toggleEditMode(true)
+                        }
+                    }
+                },
 
                 isWebView = state.viewer is NovelWebViewViewer,
                 bottomBarItems = bottomBarItems,
             )
+
+            androidx.activity.compose.BackHandler(enabled = isEditing && state.hasUnsavedChanges) {
+                showEditSaveDialog = true
+            }
+
+            if (showEditSaveDialog) {
+                androidx.compose.material3.AlertDialog(
+                    onDismissRequest = { showEditSaveDialog = false },
+                    title = { androidx.compose.material3.Text("Save changes?") },
+                    text = { androidx.compose.material3.Text("Do you want to save your edits to this chapter?") },
+                    confirmButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            showEditSaveDialog = false
+                            isEditing = false
+                            (state.viewer as? NovelWebViewViewer)?.toggleEditMode(isEditing = false, save = true)
+                        }) {
+                            androidx.compose.material3.Text("Save")
+                        }
+                    },
+                    dismissButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            showEditSaveDialog = false
+                            isEditing = false
+                            (state.viewer as? NovelWebViewViewer)?.toggleEditMode(isEditing = false, save = false)
+                        }) {
+                            androidx.compose.material3.Text("Discard")
+                        }
+                    }
+                )
+            }
 
             if (showBottomBarEditor) {
                 BottomBarEditorSheet(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -745,17 +745,17 @@ class ReaderActivity : BaseActivity() {
             }
 
             if (showEditSaveDialog) {
-                androidx.compose.material3.AlertDialog(
+                AlertDialog(
                     onDismissRequest = { showEditSaveDialog = false },
-                    title = { androidx.compose.material3.Text("Save changes?") },
-                    text = { androidx.compose.material3.Text("Do you want to save your edits to this chapter?") },
+                    title = { Text(tachiyomi.presentation.core.i18n.stringResource(tachiyomi.i18n.novel.TDMR.strings.prompt_save_changes)) },
+                    text = { Text(tachiyomi.presentation.core.i18n.stringResource(tachiyomi.i18n.novel.TDMR.strings.prompt_save_changes_message)) },
                     confirmButton = {
                         androidx.compose.material3.TextButton(onClick = {
                             showEditSaveDialog = false
                             isEditing = false
                             (state.viewer as? NovelWebViewViewer)?.toggleEditMode(isEditing = false, save = true)
                         }) {
-                            androidx.compose.material3.Text("Save")
+                            Text(tachiyomi.presentation.core.i18n.stringResource(MR.strings.action_save))
                         }
                     },
                     dismissButton = {
@@ -764,7 +764,7 @@ class ReaderActivity : BaseActivity() {
                             isEditing = false
                             (state.viewer as? NovelWebViewViewer)?.toggleEditMode(isEditing = false, save = false)
                         }) {
-                            androidx.compose.material3.Text("Discard")
+                            Text(tachiyomi.presentation.core.i18n.stringResource(tachiyomi.i18n.novel.TDMR.strings.action_discard))
                         }
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -728,8 +728,8 @@ class ReaderActivity : BaseActivity() {
                     }
                 },
 
+                isWebView = state.viewer is NovelWebViewViewer,
                 bottomBarItems = bottomBarItems,
-                onItemsChange = { viewModel.saveBottomBarItems(it) },
             )
 
             if (showBottomBarEditor) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -723,10 +723,6 @@ class ReaderActivity : BaseActivity() {
                     val viewer = state.viewer
                     if (viewer is NovelWebViewViewer) {
                         viewer.toggleEditMode(isEditing)
-                    } else if (viewer is NovelViewer) {
-                        viewer.toggleEditMode(isEditing)
-                    }
-                },
 
                 isWebView = state.viewer is NovelWebViewViewer,
                 bottomBarItems = bottomBarItems,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -599,6 +599,7 @@ class ReaderActivity : BaseActivity() {
 
             val bottomBarItems by viewModel.bottomBarItems.collectAsState()
             var showBottomBarEditor by remember { mutableStateOf(false) }
+            var isEditing by remember { mutableStateOf(false) }
 
             NovelReaderAppBars(
                 visible = state.menuVisible,
@@ -715,6 +716,18 @@ class ReaderActivity : BaseActivity() {
                         else -> {}
                     }
                 },
+                
+                isEditing = isEditing,
+                onToggleEdit = { 
+                    isEditing = !isEditing
+                    val viewer = state.viewer
+                    if (viewer is NovelWebViewViewer) {
+                        viewer.toggleEditMode(isEditing)
+                    } else if (viewer is NovelViewer) {
+                        viewer.toggleEditMode(isEditing)
+                    }
+                },
+
                 bottomBarItems = bottomBarItems,
                 onItemsChange = { viewModel.saveBottomBarItems(it) },
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1399,6 +1399,7 @@ class ReaderViewModel @JvmOverloads constructor(
         val viewer: Viewer? = null,
         val dialog: Dialog? = null,
         val menuVisible: Boolean = false,
+        val hasUnsavedChanges: Boolean = false,
         @IntRange(from = -100, to = 100) val brightnessOverlayValue: Int = 0,
     ) {
         val currentChapter: ReaderChapter?
@@ -1418,8 +1419,86 @@ class ReaderViewModel @JvmOverloads constructor(
             initialValue = readerPreferences.novelBottomBarItems().get().deserializeBottomBarItems(),
         )
 
+    fun setHasUnsavedChanges(hasUnsaved: Boolean) {
+        mutableState.update { it.copy(hasUnsavedChanges = hasUnsaved) }
+    }
+
     fun saveBottomBarItems(items: List<BottomBarItemState>) {
         readerPreferences.novelBottomBarItems().set(items.serialize())
+    }
+
+    fun saveEditedChapterContent(json: String) {
+        viewModelScope.launchIO {
+            try {
+                val array = kotlinx.serialization.json.Json.decodeFromString<kotlinx.serialization.json.JsonArray>(json)
+                val m = manga ?: return@launchIO
+                val s = sourceManager.getOrStub(m.source)
+
+                for (item in array) {
+                    val jsonObj = item as? kotlinx.serialization.json.JsonObject ?: continue
+                    val idStr = (jsonObj["id"] as? kotlinx.serialization.json.JsonPrimitive)?.content
+                    if (idStr == "-1") continue
+                    val id = idStr?.toLongOrNull() ?: continue
+                    val htmlContent = (jsonObj["content"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: continue
+
+                    val chapter = chapterList.find { it.chapter.id == id }?.chapter?.toDomainChapter() ?: continue
+
+                    val isDownloaded = downloadManager.isChapterDownloaded(chapter.name, chapter.scanlator, chapter.url, m.title, m.source)
+                    var chapterDir: com.hippo.unifile.UniFile? = if (isDownloaded) {
+                        downloadProvider.findChapterDir(chapter.name, chapter.scanlator, chapter.url, m.title, s)
+                    } else {
+                        downloadProvider.getMangaDir(m.title, s).getOrNull()?.let { mangaDir ->
+                            val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
+                            if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                                mangaDir.createFile("$validName.cbz")
+                            } else {
+                                mangaDir.createDirectory(validName)
+                            }
+                        }
+                    }
+
+                    if (chapterDir != null) {
+                        try {
+                            val mangaDir = downloadProvider.getMangaDir(m.title, s).getOrNull()
+                            val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
+
+                            if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                                if (chapterDir.isDirectory) {
+                                    chapterDir.delete()
+                                    chapterDir = mangaDir?.createFile("$validName.cbz")
+                                }
+                                val targetFile = if (chapterDir?.name?.endsWith(".cbz") == true) chapterDir else mangaDir?.createFile("$validName.cbz")
+                                targetFile?.openOutputStream()?.let { os ->
+                                    java.util.zip.ZipOutputStream(os).use { zos ->
+                                        zos.putNextEntry(java.util.zip.ZipEntry("001.html"))
+                                        zos.write(htmlContent.toByteArray())
+                                        zos.closeEntry()
+                                    }
+                                }
+                            } else {
+                                if (chapterDir.isFile) {
+                                    chapterDir.delete()
+                                    chapterDir = mangaDir?.createDirectory(validName)
+                                }
+                                val targetDir = if (chapterDir?.isDirectory == true) chapterDir else mangaDir?.createDirectory(validName)
+                                val targetFile = targetDir?.findFile("001.html") ?: targetDir?.createFile("001.html")
+                                targetFile?.openOutputStream()?.bufferedWriter()?.use { it.write(htmlContent) }
+                            }
+
+                            if (!isDownloaded && mangaDir != null) {
+                                val dlCache: eu.kanade.tachiyomi.data.download.DownloadCache = uy.kohesive.injekt.Injekt.get()
+                                dlCache.addChapter(validName, mangaDir, m)
+                            }
+                        } catch (e: Exception) {
+                            logcat(logcat.LogPriority.ERROR, e) { "Failed to save edited chapter" }
+                        }
+                    }
+                }
+                setHasUnsavedChanges(false)
+            } catch (e: Exception) {
+                logcat(logcat.LogPriority.ERROR, e) { "Failed to decode edited content json" }
+            }
+        }
     }
 
     sealed interface Dialog {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -29,6 +29,7 @@ import eu.kanade.tachiyomi.data.saver.Location
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
 import eu.kanade.tachiyomi.ui.reader.loader.DownloadPageLoader
@@ -74,8 +75,10 @@ import tachiyomi.core.common.util.lang.launchNonCancellable
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
+import eu.kanade.tachiyomi.util.system.toast
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.Chapter as DomainChapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.download.service.DownloadPreferences
@@ -1442,61 +1445,78 @@ class ReaderViewModel @JvmOverloads constructor(
                     val htmlContent = (jsonObj["content"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: continue
 
                     val chapter = chapterList.find { it.chapter.id == id }?.chapter?.toDomainChapter() ?: continue
-
-                    val isDownloaded = downloadManager.isChapterDownloaded(chapter.name, chapter.scanlator, chapter.url, m.title, m.source)
-                    var chapterDir: com.hippo.unifile.UniFile? = if (isDownloaded) {
-                        downloadProvider.findChapterDir(chapter.name, chapter.scanlator, chapter.url, m.title, s)
-                    } else {
-                        downloadProvider.getMangaDir(m.title, s).getOrNull()?.let { mangaDir ->
-                            val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
-                            if (downloadPreferences.saveChaptersAsCBZ().get()) {
-                                mangaDir.createFile("$validName.cbz")
-                            } else {
-                                mangaDir.createDirectory(validName)
-                            }
-                        }
-                    }
-
-                    if (chapterDir != null) {
-                        try {
-                            val mangaDir = downloadProvider.getMangaDir(m.title, s).getOrNull()
-                            val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
-
-                            if (downloadPreferences.saveChaptersAsCBZ().get()) {
-                                if (chapterDir.isDirectory) {
-                                    chapterDir.delete()
-                                    chapterDir = mangaDir?.createFile("$validName.cbz")
-                                }
-                                val targetFile = if (chapterDir?.name?.endsWith(".cbz") == true) chapterDir else mangaDir?.createFile("$validName.cbz")
-                                targetFile?.openOutputStream()?.let { os ->
-                                    java.util.zip.ZipOutputStream(os).use { zos ->
-                                        zos.putNextEntry(java.util.zip.ZipEntry("001.html"))
-                                        zos.write(htmlContent.toByteArray())
-                                        zos.closeEntry()
-                                    }
-                                }
-                            } else {
-                                if (chapterDir.isFile) {
-                                    chapterDir.delete()
-                                    chapterDir = mangaDir?.createDirectory(validName)
-                                }
-                                val targetDir = if (chapterDir?.isDirectory == true) chapterDir else mangaDir?.createDirectory(validName)
-                                val targetFile = targetDir?.findFile("001.html") ?: targetDir?.createFile("001.html")
-                                targetFile?.openOutputStream()?.bufferedWriter()?.use { it.write(htmlContent) }
-                            }
-
-                            if (!isDownloaded && mangaDir != null) {
-                                val dlCache: eu.kanade.tachiyomi.data.download.DownloadCache = uy.kohesive.injekt.Injekt.get()
-                                dlCache.addChapter(validName, mangaDir, m)
-                            }
-                        } catch (e: Exception) {
-                            logcat(logcat.LogPriority.ERROR, e) { "Failed to save edited chapter" }
-                        }
-                    }
+                    saveSingleChapterEdits(m, chapter, s, htmlContent)
                 }
                 setHasUnsavedChanges(false)
             } catch (e: Exception) {
-                logcat(logcat.LogPriority.ERROR, e) { "Failed to decode edited content json" }
+                logcat(LogPriority.ERROR, e) { "Failed to decode edited content json" }
+                Injekt.get<Application>().let { app ->
+                    app.toast(tachiyomi.i18n.novel.TDMR.strings.error_decoding_edits)
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces the local downloaded file for a given chapter with the specified edited [htmlContent].
+     * Supports both plain directory (.html) and CBZ packed (.cbz) chapter formats.
+     */
+    private suspend fun saveSingleChapterEdits(
+        m: Manga,
+        chapter: DomainChapter,
+        s: Source,
+        htmlContent: String,
+    ) {
+        val isDownloaded = downloadManager.isChapterDownloaded(chapter.name, chapter.scanlator, chapter.url, m.title, m.source)
+        val mangaDir = downloadProvider.getMangaDir(m.title, s).getOrNull() ?: return
+        val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
+
+        try {
+            var chapterDir: com.hippo.unifile.UniFile? = if (isDownloaded) {
+                downloadProvider.findChapterDir(chapter.name, chapter.scanlator, chapter.url, m.title, s)
+            } else {
+                if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                    mangaDir.createFile("$validName.cbz")
+                } else {
+                    mangaDir.createDirectory(validName)
+                }
+            }
+
+            if (chapterDir != null) {
+                if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                    if (chapterDir!!.isDirectory) {
+                        chapterDir!!.delete()
+                        chapterDir = mangaDir.createFile("$validName.cbz")
+                    }
+                    val targetFile = if (chapterDir!!.name?.endsWith(".cbz") == true) chapterDir!! else mangaDir.createFile("$validName.cbz")
+
+                    targetFile?.openOutputStream()?.let { os ->
+                        java.util.zip.ZipOutputStream(os).use { zos ->
+                            zos.putNextEntry(java.util.zip.ZipEntry("001.html"))
+                            zos.write(htmlContent.toByteArray())
+                            zos.closeEntry()
+                        }
+                    }
+                } else {
+                    if (chapterDir!!.isFile) {
+                        chapterDir!!.delete()
+                        chapterDir = mangaDir.createDirectory(validName)
+                    }
+                    val targetDir = if (chapterDir!!.isDirectory) chapterDir else mangaDir.createDirectory(validName)
+                    val targetFile = targetDir?.findFile("001.html") ?: targetDir?.createFile("001.html")
+                    targetFile?.openOutputStream()?.bufferedWriter()?.use { it.write(htmlContent) }
+                }
+
+                // If it wasn't downloaded before, notify the DownloadCache that it exists now
+                if (!isDownloaded) {
+                    val dlCache: eu.kanade.tachiyomi.data.download.DownloadCache = Injekt.get()
+                    dlCache.addChapter(validName, mangaDir, m)
+                }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to save edited chapter" }
+            Injekt.get<Application>().let { app ->
+                app.toast(tachiyomi.i18n.novel.TDMR.strings.error_saving_edits)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1,5 +1,8 @@
 package eu.kanade.tachiyomi.ui.reader
 
+import mihon.core.archive.archiveReader
+import mihon.core.archive.archiveReader
+
 import android.app.Application
 import android.net.Uri
 import androidx.annotation.IntRange
@@ -1451,7 +1454,9 @@ class ReaderViewModel @JvmOverloads constructor(
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR, e) { "Failed to decode edited content json" }
                 Injekt.get<Application>().let { app ->
-                    app.toast(tachiyomi.i18n.novel.TDMR.strings.error_decoding_edits)
+                    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                        app.toast(tachiyomi.i18n.novel.TDMR.strings.error_decoding_edits)
+                    }
                 }
             }
         }
@@ -1472,51 +1477,76 @@ class ReaderViewModel @JvmOverloads constructor(
         val validName = downloadProvider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).first()
 
         try {
-            var chapterDir: com.hippo.unifile.UniFile? = if (isDownloaded) {
-                downloadProvider.findChapterDir(chapter.name, chapter.scanlator, chapter.url, m.title, s)
-            } else {
-                if (downloadPreferences.saveChaptersAsCBZ().get()) {
-                    mangaDir.createFile("$validName.cbz")
-                } else {
-                    mangaDir.createDirectory(validName)
+            val tmpDir = mangaDir.createDirectory(validName + "_tmp") ?: return
+            val existingDir = if (isDownloaded) downloadProvider.findChapterDir(chapter.name, chapter.scanlator, chapter.url, m.title, s) else null
+            val context: android.app.Application = uy.kohesive.injekt.Injekt.get()
+
+            if (existingDir != null) {
+                if (existingDir.isFile) {
+                    existingDir.archiveReader(context).use { archiveReader ->
+                        archiveReader.useEntries { entries ->
+                            entries.filter { it.isFile && it.name?.endsWith(".html") == false }.forEach { entry ->
+                                tmpDir.createFile(entry.name)?.openOutputStream()?.use { os ->
+                                    archiveReader.getInputStream(entry.name)?.use { it.copyTo(os) }
+                                }
+                            }
+                        }
+                    }
+                } else if (existingDir.isDirectory) {
+                    existingDir.listFiles()?.filter { it.isFile && it.name?.endsWith(".html") == false }?.forEach { file ->
+                        tmpDir.createFile(file.name!!)?.openOutputStream()?.use { os ->
+                            file.openInputStream().use { it.copyTo(os) }
+                        }
+                    }
                 }
             }
 
-            if (chapterDir != null) {
-                if (downloadPreferences.saveChaptersAsCBZ().get()) {
-                    if (chapterDir!!.isDirectory) {
-                        chapterDir!!.delete()
-                        chapterDir = mangaDir.createFile("$validName.cbz")
-                    }
-                    val targetFile = if (chapterDir!!.name?.endsWith(".cbz") == true) chapterDir!! else mangaDir.createFile("$validName.cbz")
+            // Process HTML to include images
+            val embedder = eu.kanade.tachiyomi.util.chapter.ChapterImageEmbedder()
+            val baseUrl = (s as? eu.kanade.tachiyomi.source.online.HttpSource)?.baseUrl ?: chapter.url.takeIf { it.startsWith("http") }
+            val processedHtml = embedder.processHtml(htmlContent, baseUrl, tmpDir)
 
-                    targetFile?.openOutputStream()?.let { os ->
-                        java.util.zip.ZipOutputStream(os).use { zos ->
-                            zos.putNextEntry(java.util.zip.ZipEntry("001.html"))
-                            zos.write(htmlContent.toByteArray())
-                            zos.closeEntry()
-                        }
-                    }
-                } else {
-                    if (chapterDir!!.isFile) {
-                        chapterDir!!.delete()
-                        chapterDir = mangaDir.createDirectory(validName)
-                    }
-                    val targetDir = if (chapterDir!!.isDirectory) chapterDir else mangaDir.createDirectory(validName)
-                    val targetFile = targetDir?.findFile("001.html") ?: targetDir?.createFile("001.html")
-                    targetFile?.openOutputStream()?.bufferedWriter()?.use { it.write(htmlContent) }
-                }
+            val targetFile = tmpDir.createFile("001.html") ?: return
+            targetFile.openOutputStream().bufferedWriter().use { it.write(processedHtml) }
 
-                // If it wasn't downloaded before, notify the DownloadCache that it exists now
-                if (!isDownloaded) {
-                    val dlCache: eu.kanade.tachiyomi.data.download.DownloadCache = Injekt.get()
-                    dlCache.addChapter(validName, mangaDir, m)
+            if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                val zip = mangaDir.createFile(validName + ".cbz.tmp")!!
+                val compressionLevel = if (m.isNovel) uy.kohesive.injekt.Injekt.get<tachiyomi.domain.download.service.NovelDownloadPreferences>().zipCompressionLevel().get() else 0
+                mihon.core.archive.ZipWriter(context, zip, compressionLevel).use { writer ->
+                    tmpDir.listFiles()?.forEach { file ->
+                        writer.write(file)
+                    }
                 }
+                
+                if (existingDir != null) {
+                    existingDir.delete()
+                }
+                
+                val currentCbz = mangaDir.findFile(validName + ".cbz")
+                currentCbz?.delete()
+                zip.renameTo(validName + ".cbz")
+                tmpDir.delete()
+            } else {
+                if (existingDir != null) {
+                    existingDir.delete()
+                }
+                val currentDir = mangaDir.findFile(validName)
+                if (currentDir != null && currentDir.isDirectory) {
+                    currentDir.delete()
+                }
+                tmpDir.renameTo(validName)
+            }
+
+            if (!isDownloaded) {
+                val dlCache: eu.kanade.tachiyomi.data.download.DownloadCache = uy.kohesive.injekt.Injekt.get()
+                dlCache.addChapter(validName, mangaDir, m)
             }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Failed to save edited chapter" }
             Injekt.get<Application>().let { app ->
-                app.toast(tachiyomi.i18n.novel.TDMR.strings.error_saving_edits)
+                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                    app.toast(tachiyomi.i18n.novel.TDMR.strings.error_saving_edits)
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
@@ -38,6 +38,10 @@ internal class ArchivePageLoader(private val reader: ArchiveReader) : PageLoader
             .toList()
     }
 
+    override suspend fun getPageDataStream(url: String): java.io.InputStream? {
+        return reader.getInputStream(url)?.readBytes()?.let { java.io.ByteArrayInputStream(it) }
+    }
+
     override suspend fun loadPage(page: ReaderPage) {
         check(!isRecycled)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -104,6 +104,30 @@ internal class DownloadPageLoader(
         }
     }
 
+override suspend fun getPageDataStream(url: String): java.io.InputStream? {
+        // 1. Try archive (for normal downloaded CBZ)
+        archivePageLoader?.getPageDataStream(url)?.let { return it }
+
+        // 2. Try directory (for normal downloaded directories)
+        val dbChapter = chapter.chapter
+        val chapterPath = downloadProvider.findChapterDir(
+            dbChapter.name,
+            dbChapter.scanlator,
+            dbChapter.url,
+            manga.title,
+            source,
+        )
+        if (chapterPath?.isDirectory == true) {
+            val file = chapterPath.findFile(url)
+            if (file != null && file.exists()) {
+                context.contentResolver.openInputStream(file.uri)?.let { return it }
+            }
+        }
+
+        // 3. Fallback to source (critical for edited EPUB chapters where the custom `.cbz` only contains 001.html)
+        return (source as? tachiyomi.source.local.LocalNovelSource)?.getChapterImage(dbChapter, url)
+    }
+
     override suspend fun loadPage(page: ReaderPage) {
         archivePageLoader?.loadPage(page)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/LocalNovelPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/LocalNovelPageLoader.kt
@@ -32,6 +32,11 @@ class LocalNovelPageLoader(
         }
     }
 
+    override suspend fun getPageDataStream(url: String): java.io.InputStream? { 
+        val sChapter = chapter.chapter
+        return (source as? tachiyomi.source.local.LocalNovelSource)?.getChapterImage(sChapter, url)
+    }
+
     override suspend fun loadPage(page: ReaderPage) = withIOContext {
         if (page.status == Page.State.Ready) return@withIOContext
 
@@ -39,7 +44,6 @@ class LocalNovelPageLoader(
         try {
             if (source is NovelSource) {
                 var text = source.fetchPageText(Page(page.index, page.url, page.imageUrl))
-
                 // Apply auto-split if enabled
                 if (readerPreferences.novelAutoSplitText().get()) {
                     val wordCount = readerPreferences.novelAutoSplitWordCount().get()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoader.kt
@@ -23,6 +23,12 @@ abstract class PageLoader {
     abstract suspend fun getPages(): List<ReaderPage>
 
     /**
+     * Reads a specific resource file synchronously from local storage.
+     * Useful for EPUB inner images parsed inside WebView clients.
+     */
+    open suspend fun getPageDataStream(url: String): java.io.InputStream? = null
+
+    /**
      * Loads the page. May also preload other pages.
      * Progress of the page loading should be followed via [page.statusFlow].
      * [loadPage] is not currently guaranteed to complete, so it should be launched asynchronously.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -2029,6 +2029,14 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
         return false
     }
 
+    fun toggleEditMode(isEditing: Boolean) {
+        if (isEditing) {
+            activity.runOnUiThread {
+                android.widget.Toast.makeText(activity, "Edit mode is only supported in WebView mode", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     override fun handleGenericMotionEvent(event: MotionEvent): Boolean {
         return false
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -142,6 +142,23 @@ private class CoilImageGetter(
 
     override fun getDrawable(source: String?): Drawable {
         val wrapper = DrawableWrapper()
+        
+        val contentWidth = textView.width - textView.paddingLeft - textView.paddingRight
+        val maxWidth = if (contentWidth > 0) {
+            contentWidth
+        } else {
+            activity.resources.displayMetrics.widthPixels
+        }
+
+        // Add a temporary loading placeholder taking full width to prevent inline stacking
+        val placeholder = android.graphics.drawable.ColorDrawable(android.graphics.Color.LTGRAY)
+        val placeholderHeight = (200 * activity.resources.displayMetrics.density).toInt()
+        
+        // Use maxWidth to force the placeholder onto its own line and prevent images stacking side-by-side
+        placeholder.setBounds(0, 0, maxWidth, placeholderHeight)
+        wrapper.innerDrawable = placeholder
+        wrapper.setBounds(0, 0, maxWidth, placeholderHeight)
+
         if (source.isNullOrBlank()) return wrapper
 
         // Handle base64 data URIs inline (EPUB downloads encode media as base64)
@@ -176,6 +193,60 @@ private class CoilImageGetter(
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.DEBUG) { "Failed to decode base64 image: ${e.message}" }
+            }
+            return wrapper
+        }
+
+        if (source.startsWith("tachiyomi-novel-image://")) {
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val imagePath = android.net.Uri.decode(source.removePrefix("tachiyomi-novel-image://"))
+                    val loader = activity.viewModel.state.value.viewerChapters?.currChapter?.pageLoader
+                    val stream = loader?.getPageDataStream(imagePath) ?: return@launch
+                    val bytes = stream.readBytes()
+                    val bitmap = android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                    if (bitmap != null) {
+                        val drawable = android.graphics.drawable.BitmapDrawable(activity.resources, bitmap)
+                        withContext(Dispatchers.Main) {
+                            val contentWidth = textView.width - textView.paddingLeft - textView.paddingRight
+                            val maxWidth = if (contentWidth > 0) {
+                                contentWidth
+                            } else {
+                                activity.resources.displayMetrics.widthPixels
+                            }
+                            val imgWidth = drawable.intrinsicWidth
+                            val imgHeight = drawable.intrinsicHeight
+
+                            if (imgWidth > 0 && imgHeight > 0) {
+                                val width = maxWidth.coerceAtLeast(1)
+                                val ratio = width.toFloat() / imgWidth.toFloat()
+                                val height = (imgHeight * ratio).toInt().coerceAtLeast(1)
+
+                                drawable.setBounds(0, 0, width, height)
+                                wrapper.innerDrawable = drawable
+                                wrapper.setBounds(0, 0, width, height)
+
+                                val text = textView.text
+                                if (text is android.text.Spannable) {
+                                    val spans = text.getSpans(0, text.length, android.text.style.ImageSpan::class.java)
+                                    val span = spans.firstOrNull { it.drawable === wrapper }
+                                    if (span != null) {
+                                        val start = text.getSpanStart(span)
+                                        val end = text.getSpanEnd(span)
+                                        val flags = text.getSpanFlags(span)
+                                        text.removeSpan(span)
+                                        text.setSpan(span, start, end, flags)
+                                    }
+                                }
+
+                                textView.invalidate()
+                                textView.requestLayout()
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    logcat(LogPriority.DEBUG) { "Failed to load custom novel image: ${e.message}" }
+                }
             }
             return wrapper
         }
@@ -218,9 +289,22 @@ private class CoilImageGetter(
                 wrapper.innerDrawable = drawable
                 wrapper.setBounds(0, 0, width, height)
 
+                // Trigger TextView layout update without destroying selection
+                // By removing and re-adding the span, we force the StaticLayout to re-calculate line heights
+                val text = textView.text
+                if (text is android.text.Spannable) {
+                    val spans = text.getSpans(0, text.length, android.text.style.ImageSpan::class.java)
+                    val span = spans.firstOrNull { it.drawable === wrapper }
+                    if (span != null) {
+                        val start = text.getSpanStart(span)
+                        val end = text.getSpanEnd(span)
+                        val flags = text.getSpanFlags(span)
+                        text.removeSpan(span)
+                        text.setSpan(span, start, end, flags)
+                    }
+                }
+
                 // Force TextView to re-layout with the loaded image
-                // Use invalidate() + requestLayout() instead of re-assigning text
-                // to avoid breaking text selection state
                 textView.invalidate()
                 textView.requestLayout()
             } catch (e: Exception) {
@@ -1706,6 +1790,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
             try {
                 val doc = org.jsoup.Jsoup.parse(cleanHtmlContent)
                 doc.select("style, script").remove()
+                // Force all images to be block-level by wrapping them in generic paragraphs
+                // This prevents `TextView` overlapping them if they appear inline without spaces
+                doc.select("img").forEach { img ->
+                    if (img.parent()?.tagName() != "p" && img.parent()?.tagName() != "div") {
+                        img.wrap("<p style=\"text-align:center;\"></p>")
+                    }
+                }
                 cleanHtmlContent = doc.body()?.html() ?: cleanHtmlContent
             } catch (_: Exception) {}
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -197,10 +197,10 @@ private class CoilImageGetter(
             return wrapper
         }
 
-        if (source.startsWith("tachiyomi-novel-image://")) {
+        if (source.startsWith("tsundoku-novel-image://")) {
             scope.launch(Dispatchers.IO) {
                 try {
-                    val imagePath = android.net.Uri.decode(source.removePrefix("tachiyomi-novel-image://"))
+                    val imagePath = android.net.Uri.decode(source.removePrefix("tsundoku-novel-image://"))
                     val loader = activity.viewModel.state.value.viewerChapters?.currChapter?.pageLoader
                     val stream = loader?.getPageDataStream(imagePath) ?: return@launch
                     val bytes = stream.readBytes()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -861,16 +861,6 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
                 }
         }
 
-        scope.launch {
-            preferences.novelTextSelectable().changes()
-                .drop(1)
-                .collectLatest {
-                    loadedChapters.forEach { loaded ->
-                        applyTextSelectionPreference(loaded.textView)
-                    }
-                }
-        }
-
         // Observe infinite scroll toggle - add/remove next chapter button
         scope.launch {
             preferences.novelInfiniteScroll().changes()
@@ -890,7 +880,6 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
                 }
         }
 
-        // In observePreferences(), add:
         scope.launch {
             preferences.novelTextSelectable().changes()
                 .drop(1)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -861,6 +861,16 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
                 }
         }
 
+        scope.launch {
+            preferences.novelTextSelectable().changes()
+                .drop(1)
+                .collectLatest {
+                    loadedChapters.forEach { loaded ->
+                        applyTextSelectionPreference(loaded.textView)
+                    }
+                }
+        }
+
         // Observe infinite scroll toggle - add/remove next chapter button
         scope.launch {
             preferences.novelInfiniteScroll().changes()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
@@ -55,22 +55,20 @@ object NovelViewerTextUtils {
 
     /**
      * Strips the chapter title from the beginning of the content.
-     * Searches within the first ~500 characters for chapter title or name matches.
+     * Searches within the first ~3000 characters for chapter title or name matches.
      */
     fun stripChapterTitle(content: String, chapterName: String): String {
         val normalizedChapterName = chapterName.trim().lowercase()
-        // Search within first 500 chars for title (to handle leading whitespace/tags)
-        val searchArea = content.take(500)
+        // Search within first 3000 chars for title (to handle leading whitespace/tags/extra prefixes)
+        val searchArea = content.take(3000)
 
-        // Try to remove first heading (H1-H6) anywhere in search area
+        // Try to remove first heading (H1-H6) anywhere in search area unconditionally first to match WebView behavior
         val headingRegex = """<h[1-6][^>]*>(.*?)</h[1-6]>""".toRegex(RegexOption.IGNORE_CASE)
         val headingMatch = headingRegex.find(searchArea)
         if (headingMatch != null) {
-            val headingText = headingMatch.groupValues[1].replace(Regex("<[^>]+>"), "").trim().lowercase()
-            if (isTitleMatch(headingText, normalizedChapterName)) {
-                return content.substring(0, headingMatch.range.first) +
-                    content.substring(headingMatch.range.last + 1)
-            }
+            // Unconditionally hide the first heading like in WebView
+            return content.substring(0, headingMatch.range.first) +
+                content.substring(headingMatch.range.last + 1)
         }
 
         // Try to remove first strong/b/em tag if it looks like a title

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
@@ -62,45 +62,24 @@ object NovelViewerTextUtils {
         // Search within first 3000 chars for title (to handle leading whitespace/tags/extra prefixes)
         val searchArea = content.take(3000)
 
-        // Try to remove first heading (H1-H6) anywhere in search area unconditionally first to match WebView behavior
-        val headingRegex = """<h[1-6][^>]*>(.*?)</h[1-6]>""".toRegex(RegexOption.IGNORE_CASE)
-        val headingMatch = headingRegex.find(searchArea)
-        if (headingMatch != null) {
-            // Unconditionally hide the first heading like in WebView
-            return content.substring(0, headingMatch.range.first) +
-                content.substring(headingMatch.range.last + 1)
-        }
+        // Try to remove first heading, or other elements if they match the chapter name.
+        // We unconditionally hide the first heading.
+        val extractPatterns = listOf(
+            """<h[1-6][^>]*>.*?</h[1-6]>""".toRegex(RegexOption.IGNORE_CASE) to true,
+            """<(strong|b|em)[^>]*>.*?</\1>""".toRegex(RegexOption.IGNORE_CASE) to false,
+            """<p[^>]*>.*?</p>""".toRegex(RegexOption.IGNORE_CASE) to false,
+            """<(div|span)[^>]*>.*?</\1>""".toRegex(RegexOption.IGNORE_CASE) to false,
+        )
 
-        // Try to remove first strong/b/em tag if it looks like a title
-        val strongRegex = """<(strong|b|em)[^>]*>(.*?)</\1>""".toRegex(RegexOption.IGNORE_CASE)
-        val strongMatch = strongRegex.find(searchArea)
-        if (strongMatch != null) {
-            val strongText = strongMatch.groupValues[2].replace(Regex("<[^>]+>"), "").trim().lowercase()
-            if (isTitleMatch(strongText, normalizedChapterName)) {
-                return content.substring(0, strongMatch.range.first) +
-                    content.substring(strongMatch.range.last + 1)
-            }
-        }
-
-        // Try to remove first paragraph if it matches chapter name
-        val paragraphRegex = """<p[^>]*>(.*?)</p>""".toRegex(RegexOption.IGNORE_CASE)
-        val pMatch = paragraphRegex.find(searchArea)
-        if (pMatch != null) {
-            val pText = pMatch.groupValues[1].replace(Regex("<[^>]+>"), "").trim().lowercase()
-            if (isTitleMatch(pText, normalizedChapterName)) {
-                return content.substring(0, pMatch.range.first) +
-                    content.substring(pMatch.range.last + 1)
-            }
-        }
-
-        // Try to remove first div or span if it matches chapter name
-        val divSpanRegex = """<(div|span)[^>]*>(.*?)</\1>""".toRegex(RegexOption.IGNORE_CASE)
-        val divMatch = divSpanRegex.find(searchArea)
-        if (divMatch != null) {
-            val divText = divMatch.groupValues[2].replace(Regex("<[^>]+>"), "").trim().lowercase()
-            if (isTitleMatch(divText, normalizedChapterName)) {
-                return content.substring(0, divMatch.range.first) +
-                    content.substring(divMatch.range.last + 1)
+        for ((regex, unconditional) in extractPatterns) {
+            val match = regex.find(searchArea)
+            if (match != null) {
+                // Strip tags from the entire matched HTML to get just the text
+                val matchText = match.value.replace(Regex("<[^>]+>"), "").trim().lowercase()
+                if (unconditional || isTitleMatch(matchText, normalizedChapterName)) {
+                    return content.substring(0, match.range.first) +
+                        content.substring(match.range.last + 1)
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -1563,11 +1563,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     fun toggleEditMode(isEditing: Boolean, save: Boolean = true) {
         if (!isEditing && !save) {
             this.isEditingMode = false
+            webView.evaluateJavascript("(function() { window.getSelection().removeAllRanges(); document.activeElement.blur(); })();", null)
             webView.clearFocus()
             val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
             imm?.hideSoftInputFromWindow(webView.windowToken, 0)
 
             // Reload chapter to discard edits
+            loadedChapterIds.clear()
+            loadedChapters.clear()
             activity.viewModel.reloadChapter(fromSource = false)
             return
         }
@@ -1588,6 +1591,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                 }, 120)
             }
         } else {
+            webView.evaluateJavascript("(function() { window.getSelection().removeAllRanges(); document.activeElement.blur(); })();", null)
             webView.clearFocus()
             val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
             imm?.hideSoftInputFromWindow(webView.windowToken, 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -77,6 +77,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private var currentChapterIndex = 0
     private var isLoadingNext = false
     private var isDestroyed = false
+    private var isEditingMode = false
 
     // Auto-scroll state
     private var isAutoScrolling = false
@@ -106,6 +107,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                 velocityX: Float,
                 velocityY: Float,
             ): Boolean {
+                if (isEditingMode) return false
                 if (!preferences.novelSwipeNavigation().get()) return false
                 if (e1 == null) return false
 
@@ -132,6 +134,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             }
 
             override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                if (isEditingMode) return false
+
                 val viewWidth = container.width.toFloat()
                 val viewHeight = container.height.toFloat()
                 val x = e.x
@@ -301,6 +305,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     restoreScrollPosition()
                     if (!preferences.novelInfiniteScroll().get()) {
                         injectNextChapterButton()
+                    }
+                    if (isEditingMode) {
+                        toggleEditMode(true)
                     }
                 }
             }
@@ -1527,8 +1534,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     }
 
     fun toggleEditMode(isEditing: Boolean) {
+        this.isEditingMode = isEditing
         val editable = if (isEditing) "true" else "false"
-        webView.evaluateJavascript("document.body.contentEditable = '$editable';", null)
+        val designMode = if (isEditing) "on" else "off"
+        
+        val script = """
+            if (document.body) {
+                document.body.contentEditable = '$editable';
+            }
+            document.designMode = '$designMode';
+        """.trimIndent()
+        
+        webView.evaluateJavascript(script, null)
     }
 
     override fun handleGenericMotionEvent(event: MotionEvent): Boolean = false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -537,30 +537,30 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     }
 
     private fun injectCustomScript() {
-        val variablesJs = """
-            window.TachiVariables = {
-                isEditMode: ${isEditingMode},
-                isInfScroll: ${preferences.novelInfiniteScroll().get()},
-                textSelectionBlocked: !${preferences.novelTextSelectable().get()},
-                forcedLowercase: ${preferences.novelForceTextLowercase().get()}
-            };
+        val chapter = currentChapters?.currChapter?.chapter
+            ?: loadedChapters.getOrNull(currentChapterIndex)?.chapter
+        val chapterTitle = (chapter?.name ?: "").jsEscape()
+        val chapterNumber = chapter?.chapter_number ?: -1f
+        val chapterUrl = (chapter?.url ?: "").jsEscape()
+        val novelUrl = (activity.viewModel.manga?.url ?: "").jsEscape()
+
+        val script = """
+        window.Tsundoku = {
+            chapterTitle: "$chapterTitle",
+            chapterNumber: $chapterNumber,
+            chapterUrl: "$chapterUrl",
+            novelUrl: "$novelUrl",
+            isEditMode: $isEditingMode,
+            isInfScroll: ${preferences.novelInfiniteScroll().get()},
+            textSelectionBlocked: ${!preferences.novelTextSelectable().get()},
+            forcedLowercase: ${preferences.novelForceTextLowercase().get()}
+        };
         """.trimIndent()
-        evaluateJavascriptSafe(variablesJs, null)
+        evaluateJavascriptSafe(script, null)
 
         val customJs = preferences.novelCustomJs().get()
         if (customJs.isNotBlank()) {
             evaluateJavascriptSafe(customJs, null)
-        }
-
-        // Inject enabled JS snippets
-        val jsSnippetsJson = preferences.novelCustomJsSnippets().get()
-        try {
-            val snippets = Json.decodeFromString<List<CodeSnippet>>(jsSnippetsJson)
-            snippets.filter { it.enabled }.forEach { snippet ->
-                evaluateJavascriptSafe(snippet.code, null)
-            }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Failed to parse JS snippets: ${e.message}" }
         }
     }
 
@@ -1387,7 +1387,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             window.__TSUNDOKU_CHAPTER_NUMBER = $chapterNumber;
             window.__TSUNDOKU_CHAPTER_URL = "$chapterUrl";
             window.__TSUNDOKU_NOVEL_URL = "$novelUrl";
-            window.__TSUNDOKU_IS_EDIT_MODE = ${isEditingMode};
+            window.__TSUNDOKU_IS_EDIT_MODE = $isEditingMode;
             window.__TSUNDOKU_IS_INF_SCROLL = ${preferences.novelInfiniteScroll().get()};
             window.__TSUNDOKU_TEXT_SELECTION_BLOCKED = ${!preferences.novelTextSelectable().get()};
             window.__TSUNDOKU_FORCED_LOWERCASE = ${preferences.novelForceTextLowercase().get()};
@@ -1586,13 +1586,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                 webView.postDelayed({
                     imm?.showSoftInput(webView, 0)
                 }, 120)
-
             }
         } else {
             webView.clearFocus()
             val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
             imm?.hideSoftInputFromWindow(webView.windowToken, 0)
-
         }
 
         val script = """

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -1539,16 +1539,34 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         val designMode = if (isEditing) "on" else "off"
         
         val script = """
-            if (document.body) {
-                document.body.contentEditable = '$editable';
-            }
-            document.designMode = '$designMode';
-        """.trimIndent()
-        
-        webView.evaluateJavascript(script, null)
-    }
+            (function() {
+                function enableEdit() {
+                    document.designMode = '$designMode';
+                    if (document.body) {
+                        document.body.contentEditable = '$editable';
+                    }
+                    var styleId = 'edit-mode-style';
+                    if ('$isEditing' === 'true') {
+                        if (!document.getElementById(styleId)) {
+                            var style = document.createElement('style');
+                            style.id = styleId;
+                            style.innerHTML = 'body, p, div { -webkit-user-select: text !important; user-select: text !important; pointer-events: auto !important; }';
+                            document.head.appendChild(style);
+                        }
+                    } else {
+                        var style = document.getElementById(styleId);
+                        if (style) {
+                            style.parentNode.removeChild(style);
+                        }
+                    }
+                }
 
-    override fun handleGenericMotionEvent(event: MotionEvent): Boolean = false
+                if (document.readyState === 'complete') {
+                    enableEdit();
+                } else {
+                    window.addEventListener('load', enableEdit);
+                }
+            })();
 
     /**
      * JavaScript interface for communication from WebView

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -300,8 +300,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             webViewClient = object : WebViewClient() {
                 override fun shouldInterceptRequest(view: WebView?, request: android.webkit.WebResourceRequest?): android.webkit.WebResourceResponse? {
                     val url = request?.url?.toString() ?: return null
-                    if (url.startsWith("tachiyomi-novel-image://")) {
-                        val imagePath = android.net.Uri.decode(url.removePrefix("tachiyomi-novel-image://"))
+                    if (url.startsWith("tsundoku-novel-image://")) {
+                        val imagePath = android.net.Uri.decode(url.removePrefix("tsundoku-novel-image://"))
                         val loader = activity.viewModel.state.value.viewerChapters?.currChapter?.pageLoader
                         if (loader != null) {
                             val stream = kotlinx.coroutines.runBlocking { loader.getPageDataStream(imagePath) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -298,6 +298,30 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             }
 
             webViewClient = object : WebViewClient() {
+                override fun shouldInterceptRequest(view: WebView?, request: android.webkit.WebResourceRequest?): android.webkit.WebResourceResponse? {
+                    val url = request?.url?.toString() ?: return null
+                    if (url.startsWith("tachiyomi-novel-image://")) {
+                        val imagePath = android.net.Uri.decode(url.removePrefix("tachiyomi-novel-image://"))
+                        val loader = activity.viewModel.state.value.viewerChapters?.currChapter?.pageLoader
+                        if (loader != null) {
+                            val stream = kotlinx.coroutines.runBlocking { loader.getPageDataStream(imagePath) }
+                            if (stream != null) {
+                                val mimeType = when (imagePath.substringAfterLast('.', "").lowercase()) {
+                                    "png" -> "image/png"
+                                    "jpg", "jpeg" -> "image/jpeg"
+                                    "gif" -> "image/gif"
+                                    "svg" -> "image/svg+xml"
+                                    "webp" -> "image/webp"
+                                    "avif" -> "image/avif"
+                                    else -> "image/jpeg"
+                                }
+                                return android.webkit.WebResourceResponse(mimeType, "UTF-8", stream)
+                            }
+                        }
+                    }
+                    return super.shouldInterceptRequest(view, request)
+                }
+
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
                     hideLoadingIndicator()
@@ -1338,6 +1362,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                         height: auto;
                         display: block;
                         margin: 8px auto;
+                        min-height: 100px;
+                        background: rgba(150, 150, 150, 0.2) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 50 50"><circle cx="25" cy="25" r="20" fill="none" stroke="%23888" stroke-width="5" stroke-dasharray="31.4 31.4"><animateTransform attributeName="transform" type="rotate" from="0 25 25" to="360 25 25" dur="1s" repeatCount="indefinite"/></circle></svg>') no-repeat center center;
                     }
                     video {
                         max-width: 100%;

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -1526,6 +1526,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         return false
     }
 
+    fun toggleEditMode(isEditing: Boolean) {
+        val editable = if (isEditing) "true" else "false"
+        webView.evaluateJavascript("document.body.contentEditable = '$editable';", null)
+    }
+
     override fun handleGenericMotionEvent(event: MotionEvent): Boolean = false
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.view.GestureDetector
@@ -8,6 +9,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -373,6 +375,17 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                 }
         }
 
+        scope.launch {
+            preferences.novelForceTextLowercase().changes()
+                .drop(1)
+                .collect {
+                    currentChapters?.let {
+                        // Reload the current chapter to reapply string transformations
+                        setChapters(it)
+                    }
+                }
+        }
+
         // Observe block media preference
         scope.launch {
             preferences.novelBlockMedia().changes()
@@ -502,10 +515,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
 
         val js = """
             (function() {
-                var style = document.getElementById('mihon-custom-style');
+                var style = document.getElementById('tsundoku-custom-style');
                 if (!style) {
                     style = document.createElement('style');
-                    style.id = 'mihon-custom-style';
+                    style.id = 'tsundoku-custom-style';
                     document.head.appendChild(style);
                 }
                 style.textContent = `$css`;
@@ -524,6 +537,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     }
 
     private fun injectCustomScript() {
+        val variablesJs = """
+            window.TachiVariables = {
+                isEditMode: ${isEditingMode},
+                isInfScroll: ${preferences.novelInfiniteScroll().get()},
+                textSelectionBlocked: !${preferences.novelTextSelectable().get()},
+                forcedLowercase: ${preferences.novelForceTextLowercase().get()}
+            };
+        """.trimIndent()
+        evaluateJavascriptSafe(variablesJs, null)
+
         val customJs = preferences.novelCustomJs().get()
         if (customJs.isNotBlank()) {
             evaluateJavascriptSafe(customJs, null)
@@ -585,21 +608,21 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         val effectiveThreshold = if (autoLoadThreshold > 0) autoLoadThreshold / 100.0 else 0.95
         val scrollTrackingScript = """
             (function() {
-                if (window.__mihonInfiniteScrollInstalled) {
+                if (window.__tsundokuInfiniteScrollInstalled) {
                     return;
                 }
-                window.__mihonInfiniteScrollInstalled = true;
+                window.__tsundokuInfiniteScrollInstalled = true;
 
                 var lastProgress = 0;
                 var saveTimeout = null;
-                window.__mihonLoadingNext = window.__mihonLoadingNext || false;
-                window.__mihonSetLoadingNext = function(v) { window.__mihonLoadingNext = !!v; };
+                window.__tsundokuLoadingNext = window.__tsundokuLoadingNext || false;
+                window.__tsundokuSetLoadingNext = function(v) { window.__tsundokuLoadingNext = !!v; };
                 var infiniteScrollEnabled = $infiniteScrollActuallyEnabled;
                 var loadThreshold = $effectiveThreshold;
 
                 // Track chapter boundaries for multi-chapter infinite scroll
                 window.chapterBoundaries = window.chapterBoundaries || [];
-                window.__mihonLastBoundaryUpdate = window.__mihonLastBoundaryUpdate || 0;
+                window.__tsundokuLastBoundaryUpdate = window.__tsundokuLastBoundaryUpdate || 0;
 
                 window.addEventListener('scroll', function() {
                     // Keep chapter boundaries in sync with actual DOM markers.
@@ -608,8 +631,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                         var dividers = document.querySelectorAll('.chapter-divider');
                         if (!window.chapterBoundaries || window.chapterBoundaries.length !== dividers.length) {
                             window.updateChapterBoundaries();
-                        } else if (Date.now() - window.__mihonLastBoundaryUpdate > 1000) {
-                            window.__mihonLastBoundaryUpdate = Date.now();
+                        } else if (Date.now() - window.__tsundokuLastBoundaryUpdate > 1000) {
+                            window.__tsundokuLastBoundaryUpdate = Date.now();
                             window.updateChapterBoundaries();
                         }
                     }
@@ -665,15 +688,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                             shouldLoadNext = progress >= loadThreshold;
                         }
                     }
-                    if (shouldLoadNext && !window.__mihonLoadingNext) {
+                    if (shouldLoadNext && !window.__tsundokuLoadingNext) {
                         console.log('Infinite scroll: Loading next chapter at progress ' + currentChapterProgress + ' (threshold: ' + loadThreshold + ')');
-                        window.__mihonLoadingNext = true;
+                        window.__tsundokuLoadingNext = true;
                         try {
                             Android.loadNextChapter();
                             console.log('Infinite scroll: Successfully called loadNextChapter()');
                         } catch(e) {
                             console.error('Infinite scroll: Error calling loadNextChapter:', e);
-                            window.__mihonLoadingNext = false; // Reset immediately on error
+                            window.__tsundokuLoadingNext = false; // Reset immediately on error
                         }
                     }
                 });
@@ -703,7 +726,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                         });
                     });
                     window.chapterBoundaries = boundaries;
-                    window.__mihonLastBoundaryUpdate = Date.now();
+                    window.__tsundokuLastBoundaryUpdate = Date.now();
                 };
 
                 // Initialize boundaries on first load.
@@ -1364,6 +1387,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             window.__TSUNDOKU_CHAPTER_NUMBER = $chapterNumber;
             window.__TSUNDOKU_CHAPTER_URL = "$chapterUrl";
             window.__TSUNDOKU_NOVEL_URL = "$novelUrl";
+            window.__TSUNDOKU_IS_EDIT_MODE = ${isEditingMode};
+            window.__TSUNDOKU_IS_INF_SCROLL = ${preferences.novelInfiniteScroll().get()};
+            window.__TSUNDOKU_TEXT_SELECTION_BLOCKED = ${!preferences.novelTextSelectable().get()};
+            window.__TSUNDOKU_FORCED_LOWERCASE = ${preferences.novelForceTextLowercase().get()};
         """.trimIndent()
     }
 
@@ -1533,30 +1560,102 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         return false
     }
 
-    fun toggleEditMode(isEditing: Boolean) {
+    fun toggleEditMode(isEditing: Boolean, save: Boolean = true) {
+        if (!isEditing && !save) {
+            this.isEditingMode = false
+            webView.clearFocus()
+            val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.hideSoftInputFromWindow(webView.windowToken, 0)
+
+            // Reload chapter to discard edits
+            activity.viewModel.reloadChapter(fromSource = false)
+            return
+        }
+
         this.isEditingMode = isEditing
-        val editable = if (isEditing) "true" else "false"
-        val designMode = if (isEditing) "on" else "off"
-        
+        injectCustomScript()
+        updateChapterMetaJs()
+
+        if (isEditing) {
+            webView.post {
+                activity.window.decorView.clearFocus()
+                webView.requestFocus()
+                webView.requestFocusFromTouch()
+                val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                imm?.showSoftInput(webView, 0)
+                webView.postDelayed({
+                    imm?.showSoftInput(webView, 0)
+                }, 120)
+
+            }
+        } else {
+            webView.clearFocus()
+            val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.hideSoftInputFromWindow(webView.windowToken, 0)
+
+        }
+
         val script = """
             (function() {
                 function enableEdit() {
-                    document.designMode = '$designMode';
-                    if (document.body) {
-                        document.body.contentEditable = '$editable';
-                    }
+                    document.designMode = 'off';
                     var styleId = 'edit-mode-style';
                     if ('$isEditing' === 'true') {
                         if (!document.getElementById(styleId)) {
                             var style = document.createElement('style');
                             style.id = styleId;
-                            style.innerHTML = 'body, p, div { -webkit-user-select: text !important; user-select: text !important; pointer-events: auto !important; }';
+                            style.innerHTML = '.chapter-content, [data-tsundoku-editable="1"], body { -webkit-user-select: text !important; user-select: text !important; pointer-events: auto !important; -webkit-tap-highlight-color: transparent; outline: none; }';
                             document.head.appendChild(style);
+                        }
+
+                        var editTargets = document.querySelectorAll('.chapter-content');
+                        if (editTargets.length === 0 && document.body) {
+                            document.body.setAttribute('contenteditable', 'true');
+                            document.body.setAttribute('data-tsundoku-editable', '1');
+                            document.body.setAttribute('tabindex', '0');
+                        } else {
+                            for (var i = 0; i < editTargets.length; i++) {
+                                editTargets[i].setAttribute('contenteditable', 'true');
+                                editTargets[i].setAttribute('data-tsundoku-editable', '1');
+                                editTargets[i].setAttribute('tabindex', '0');
+                            }
+                        }
+
+                        if (!window.__tsundokuEditInputBound) {
+                            window.__tsundokuEditInputBound = true;
+                            document.addEventListener('input', function(e) {
+                                if (window.Android && window.Android.onContentEdited) {
+                                    window.Android.onContentEdited();
+                                }
+                            });
                         }
                     } else {
                         var style = document.getElementById(styleId);
                         if (style) {
                             style.parentNode.removeChild(style);
+                        }
+
+                        var editableNodes = document.querySelectorAll('[data-tsundoku-editable="1"]');
+                        for (var j = 0; j < editableNodes.length; j++) {
+                            editableNodes[j].removeAttribute('contenteditable');
+                            editableNodes[j].removeAttribute('data-tsundoku-editable');
+                            editableNodes[j].removeAttribute('tabindex');
+                        }
+
+                        var contents = [];
+                        var nodes = document.querySelectorAll('.chapter-content');
+                        if (nodes.length > 0) {
+                            for (var i = 0; i < nodes.length; i++) {
+                                var html = nodes[i].innerHTML;
+                                var chapterId = nodes[i].getAttribute('data-chapter-id');
+                                contents.push({id: chapterId, content: html});
+                            }
+                        } else if (document.body) {
+                            var currentId = '${currentChapters?.currChapter?.chapter?.id ?: -1}';
+                            contents.push({id: currentId, content: document.body.innerHTML});
+                        }
+                        if (window.Android && window.Android.onSaveEditedContent) {
+                            window.Android.onSaveEditedContent(JSON.stringify(contents));
                         }
                     }
                 }
@@ -1567,12 +1666,29 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     window.addEventListener('load', enableEdit);
                 }
             })();
+        """.trimIndent()
+
+        webView.evaluateJavascript(script, null)
+    }
+
+    override fun handleGenericMotionEvent(event: MotionEvent): Boolean = false
 
     /**
      * JavaScript interface for communication from WebView
      */
     @Keep
     inner class WebViewInterface {
+        @JavascriptInterface
+        fun onContentEdited() {
+            activity.viewModel.setHasUnsavedChanges(true)
+        }
+
+        @JavascriptInterface
+        fun onSaveEditedContent(json: String) {
+            logcat(LogPriority.DEBUG) { "NovelWebViewViewer: onSaveEditedContent(length=${json.length})" }
+            activity.viewModel.saveEditedChapterContent(json)
+        }
+
         @JavascriptInterface
         fun onScrollProgress(progress: Float) {
             activity.runOnUiThread {
@@ -1646,7 +1762,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private fun setJsLoadingNext(isLoading: Boolean) {
         val flag = if (isLoading) "true" else "false"
         evaluateJavascriptSafe(
-            "(function(){ if (window.__mihonSetLoadingNext) window.__mihonSetLoadingNext($flag); })();",
+            "(function(){ if (window.__tsundokuSetLoadingNext) window.__tsundokuSetLoadingNext($flag); })();",
             null,
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -16,6 +16,7 @@ import uy.kohesive.injekt.api.get
 import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.util.regex.Pattern
+import coil3.imageLoader
 
 /**
  * Utility class for extracting image URLs from HTML and embedding them as base64.
@@ -51,7 +52,7 @@ class ChapterImageEmbedder(
      * @param baseUrl The base URL of the chapter for resolving relative URLs
      * @return Processed HTML with embedded images
      */
-    suspend fun processHtml(html: String, baseUrl: String?): String = withContext(Dispatchers.IO) {
+    suspend fun processHtml(html: String, baseUrl: String?, tmpDir: com.hippo.unifile.UniFile? = null): String = withContext(Dispatchers.IO) {
         if (!novelDownloadPreferences.downloadChapterImages().get()) {
             return@withContext html
         }
@@ -61,14 +62,43 @@ class ChapterImageEmbedder(
 
         logcat { "ChapterImageEmbedder: Found ${imageUrls.size} images to process" }
 
+        var imageCounter = 0
         for (imageUrl in imageUrls) {
+            // Already local or data URI, do not process
+            if (imageUrl.startsWith("tachiyomi-novel-image://") || imageUrl.startsWith("file://") || imageUrl.startsWith("data:")) {
+                continue
+            }
             try {
                 val absoluteUrl = resolveUrl(imageUrl, baseUrl)
-                val base64Data = downloadAndEncodeImage(absoluteUrl)
+                val imageResponse = downloadAndEncodeImage(absoluteUrl)
 
-                if (base64Data != null) {
-                    // Replace the URL with base64 data URI
-                    processedHtml = processedHtml.replace(imageUrl, base64Data)
+                if (imageResponse != null) {
+                    val (imageBytes, mimeType) = imageResponse
+                    val finalUrl = if (tmpDir != null) {
+                        // Save image to chapter's zip as a local file
+                        val extension = when (mimeType) {
+                            "image/png" -> "png"
+                            "image/gif" -> "gif"
+                            "image/webp" -> "webp"
+                            "image/svg+xml" -> "svg"
+                            "image/avif" -> "avif"
+                            else -> "jpg"
+                        }
+                        var filename: String
+                        do {
+                            filename = "image_${imageCounter++}.$extension"
+                        } while (tmpDir.findFile(filename) != null)
+                        
+                        tmpDir.createFile(filename)?.openOutputStream()?.use { it.write(imageBytes) }
+                        "tachiyomi-novel-image://$filename"
+                    } else {
+                        // Fallback to base64 if not actively zipping
+                        val base64 = Base64.encodeToString(imageBytes, Base64.NO_WRAP)
+                        "data:$mimeType;base64,$base64"
+                    }
+
+                    // Replace the URL with local path or base64
+                    processedHtml = processedHtml.replace(imageUrl, finalUrl)
                     logcat { "ChapterImageEmbedder: Embedded image $imageUrl" }
                 }
             } catch (e: Exception) {
@@ -149,48 +179,79 @@ class ChapterImageEmbedder(
     /**
      * Download an image and encode it as base64 data URI.
      */
-    private suspend fun downloadAndEncodeImage(url: String): String? = withContext(Dispatchers.IO) {
+    private suspend fun downloadAndEncodeImage(url: String): Pair<ByteArray, String>? = withContext(Dispatchers.IO) {
         try {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
-                .build()
+            var imageBytes: ByteArray? = null
+            var mimeType = "image/jpeg"
 
-            val response = client.newCall(request).execute()
-            response.use { resp ->
-                if (!resp.isSuccessful) {
-                    logcat(LogPriority.WARN) { "ChapterImageEmbedder: Failed to download $url - ${resp.code}" }
-                    return@withContext null
+            try {
+                val context = Injekt.get<android.app.Application>() as android.content.Context
+                val diskCache = context.imageLoader.diskCache
+                val snapshot = diskCache?.openSnapshot(url)
+                if (snapshot != null) {
+                    snapshot.use { snap ->
+                        val bytes = okio.FileSystem.SYSTEM.read(snap.data) { readByteArray() }
+                        imageBytes = bytes
+                        if (bytes.size > 12) {
+                            mimeType = when {
+                                bytes[0] == 0x89.toByte() && bytes[1] == 0x50.toByte() -> "image/png"
+                                bytes[0] == 0x47.toByte() && bytes[1] == 0x49.toByte() -> "image/gif"
+                                bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() -> "image/jpeg"
+                                bytes[0] == 0x52.toByte() && bytes[1] == 0x49.toByte() && bytes[8] == 0x57.toByte() && bytes[9] == 0x45.toByte() -> "image/webp"
+                                else -> "image/jpeg"
+                            }
+                        }
+                        logcat { "ChapterImageEmbedder: Loaded image from Coil cache: $url" }
+                    }
                 }
-
-                val contentType = resp.header("Content-Type") ?: "image/jpeg"
-                val mimeType = when {
-                    contentType.contains("png") -> "image/png"
-                    contentType.contains("gif") -> "image/gif"
-                    contentType.contains("webp") -> "image/webp"
-                    contentType.contains("svg") -> "image/svg+xml"
-                    else -> "image/jpeg"
-                }
-
-                val imageBytes = resp.body.bytes()
-
-                // Check if compression is needed
-                val maxSizeKb = novelDownloadPreferences.maxImageSizeKb().get()
-                val compressionQuality = novelDownloadPreferences.imageCompressionQuality().get()
-
-                val finalBytes = if (maxSizeKb > 0 && imageBytes.size > maxSizeKb * 1024 &&
-                    mimeType != "image/svg+xml"
-                ) {
-                    compressImage(imageBytes, compressionQuality, maxSizeKb)
-                } else {
-                    imageBytes
-                }
-
-                val base64 = Base64.encodeToString(finalBytes, Base64.NO_WRAP)
-                val finalMimeType = if (finalBytes !== imageBytes) "image/jpeg" else mimeType
-
-                "data:$finalMimeType;base64,$base64"
+            } catch(e: Exception) {
+                logcat(LogPriority.DEBUG) { "ChapterImageEmbedder: Not found in Coil cache or error reading, fetching from network..." }
             }
+
+            if (imageBytes == null) {
+                val request = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+                    .build()
+
+                val response = client.newCall(request).execute()
+                response.use { resp ->
+                    if (!resp.isSuccessful) {
+                        logcat(LogPriority.WARN) { "ChapterImageEmbedder: Failed to download $url - ${resp.code}" }
+                        return@withContext null
+                    }
+
+                    val contentType = resp.header("Content-Type") ?: "image/jpeg"
+                    mimeType = when {
+                        contentType.contains("png") -> "image/png"
+                        contentType.contains("gif") -> "image/gif"
+                        contentType.contains("webp") -> "image/webp"
+                        contentType.contains("svg") -> "image/svg+xml"
+                        contentType.contains("avif") -> "image/avif"
+                        else -> "image/jpeg"
+                    }
+
+                    imageBytes = resp.body.bytes()
+                }
+            }
+
+            val validImageBytes = imageBytes ?: return@withContext null
+
+            // Check if compression is needed
+            val maxSizeKb = novelDownloadPreferences.maxImageSizeKb().get()
+            val compressionQuality = novelDownloadPreferences.imageCompressionQuality().get()
+
+            val finalBytes = if (maxSizeKb > 0 && validImageBytes.size > maxSizeKb * 1024 &&
+                mimeType != "image/svg+xml"
+            ) {
+                compressImage(validImageBytes, compressionQuality, maxSizeKb)
+            } else {
+                validImageBytes
+            }
+
+            val finalMimeType = if (finalBytes !== validImageBytes) "image/jpeg" else mimeType
+
+            Pair(finalBytes, finalMimeType)
         } catch (e: Exception) {
             logcat(LogPriority.WARN, e) { "ChapterImageEmbedder: Error downloading image $url" }
             null

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -65,7 +65,7 @@ class ChapterImageEmbedder(
         var imageCounter = 0
         for (imageUrl in imageUrls) {
             // Already local or data URI, do not process
-            if (imageUrl.startsWith("tachiyomi-novel-image://") || imageUrl.startsWith("file://") || imageUrl.startsWith("data:")) {
+            if (imageUrl.startsWith("tsundoku-novel-image://") || imageUrl.startsWith("file://") || imageUrl.startsWith("data:")) {
                 continue
             }
             try {
@@ -90,7 +90,7 @@ class ChapterImageEmbedder(
                         } while (tmpDir.findFile(filename) != null)
                         
                         tmpDir.createFile(filename)?.openOutputStream()?.use { it.write(imageBytes) }
-                        "tachiyomi-novel-image://$filename"
+                        "tsundoku-novel-image://$filename"
                     } else {
                         // Fallback to base64 if not actively zipping
                         val base64 = Base64.encodeToString(imageBytes, Base64.NO_WRAP)

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -230,9 +230,9 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 val imageBasePath = getParentDirectory(entryPath)
                 document.select("img[src], image[xlink:href]").forEach { img ->
                     val src = if (img.hasAttr("src")) img.attr("src") else img.attr("xlink:href")
-                    if (!src.startsWith("http") && !src.startsWith("data:") && !src.startsWith("tachiyomi-novel-image://")) {
+                    if (!src.startsWith("http") && !src.startsWith("data:") && !src.startsWith("tsundoku-novel-image://")) {
                         val imagePath = resolveZipPath(imageBasePath, src)
-                        val novelUrl = "tachiyomi-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                        val novelUrl = "tsundoku-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
                         if (img.hasAttr("src")) {
                             img.attr("src", novelUrl)
                         } else {
@@ -370,12 +370,12 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 }
 
                 val src = rawSrc.substringBefore("#").trim()
-                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:") || src.startsWith("tachiyomi-novel-image://")) {
+                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:") || src.startsWith("tsundoku-novel-image://")) {
                     return@forEach
                 }
 
                 val imagePath = resolveZipPath(imageBasePath, src)
-                val novelUrl = "tachiyomi-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                val novelUrl = "tsundoku-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
                 when {
                     img.hasAttr("src") -> img.attr("src", novelUrl)
                     img.hasAttr("xlink:href") -> img.attr("xlink:href", novelUrl)

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -226,32 +226,17 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             getInputStream(entryPath)?.use { inputStream ->
                 val document = Jsoup.parse(inputStream, null, "")
 
-                // Inline images as Base64 to support NovelViewer
+                // Link images to standard schema to support NovelWebViewViewer
                 val imageBasePath = getParentDirectory(entryPath)
                 document.select("img[src], image[xlink:href]").forEach { img ->
                     val src = if (img.hasAttr("src")) img.attr("src") else img.attr("xlink:href")
-                    if (!src.startsWith("http") && !src.startsWith("data:")) {
+                    if (!src.startsWith("http") && !src.startsWith("data:") && !src.startsWith("tachiyomi-novel-image://")) {
                         val imagePath = resolveZipPath(imageBasePath, src)
-                        try {
-                            getInputStream(imagePath)?.use { imgStream ->
-                                val bytes = imgStream.readBytes()
-                                val base64 = java.util.Base64.getEncoder().encodeToString(bytes)
-                                val mimeType = when (imagePath.substringAfterLast('.', "").lowercase()) {
-                                    "png" -> "image/png"
-                                    "jpg", "jpeg" -> "image/jpeg"
-                                    "gif" -> "image/gif"
-                                    "svg" -> "image/svg+xml"
-                                    "webp" -> "image/webp"
-                                    else -> "image/jpeg"
-                                }
-                                if (img.hasAttr("src")) {
-                                    img.attr("src", "data:$mimeType;base64,$base64")
-                                } else {
-                                    img.attr("xlink:href", "data:$mimeType;base64,$base64")
-                                }
-                            }
-                        } catch (e: Exception) {
-                            // Ignore missing images
+                        val novelUrl = "tachiyomi-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                        if (img.hasAttr("src")) {
+                            img.attr("src", novelUrl)
+                        } else {
+                            img.attr("xlink:href", novelUrl)
                         }
                     }
                 }
@@ -385,34 +370,16 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 }
 
                 val src = rawSrc.substringBefore("#").trim()
-                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:")) {
+                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:") || src.startsWith("tachiyomi-novel-image://")) {
                     return@forEach
                 }
 
                 val imagePath = resolveZipPath(imageBasePath, src)
-                try {
-                    getInputStream(imagePath)?.use { imgStream ->
-                        val bytes = imgStream.readBytes()
-                        val base64 = java.util.Base64.getEncoder().encodeToString(bytes)
-                        val mimeType = when (imagePath.substringAfterLast('.', "").lowercase()) {
-                            "png" -> "image/png"
-                            "jpg", "jpeg" -> "image/jpeg"
-                            "gif" -> "image/gif"
-                            "svg" -> "image/svg+xml"
-                            "webp" -> "image/webp"
-                            "avif" -> "image/avif"
-                            else -> "application/octet-stream"
-                        }
-
-                        val dataUrl = "data:$mimeType;base64,$base64"
-                        when {
-                            img.hasAttr("src") -> img.attr("src", dataUrl)
-                            img.hasAttr("xlink:href") -> img.attr("xlink:href", dataUrl)
-                            else -> img.attr("href", dataUrl)
-                        }
-                    }
-                } catch (_: Exception) {
-                    // Ignore missing or unreadable image files.
+                val novelUrl = "tachiyomi-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                when {
+                    img.hasAttr("src") -> img.attr("src", novelUrl)
+                    img.hasAttr("xlink:href") -> img.attr("xlink:href", novelUrl)
+                    else -> img.attr("href", novelUrl)
                 }
             }
 

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -115,7 +115,7 @@
     <string name="translate_details_merge_genres">Add to existing genres (don\'t replace)</string>
     <string name="action_export_epub">Export as EPUB</string>
     <string name="action_export_epub_bulk">Export selected as EPUB</string>
-    <string name="export_epub_progress">Exporting %1$d of %2$d chaptersâ€¦</string>
+    <string name="export_epub_progress">Exporting %1$d of %2$d chapters…</string>
     <string name="export_epub_success">EPUB exported successfully</string>
     <string name="export_epub_started">EPUB export started</string>
     <string name="export_epub_error">Failed to export EPUB: %s</string>
@@ -219,7 +219,7 @@
     <string name="epub_import_error_count">%d failed</string>
     <string name="epub_create_dir_failed">Failed to create directory for: %s</string>
     <string name="epub_novels_export_count">%d novel(s) will be exported.</string>
-    <string name="epub_and_more">â€¦ and %d more</string>
+    <string name="epub_and_more">… and %d more</string>
     <string name="epub_content_options">Content Options</string>
     <string name="epub_downloaded_only">Downloaded chapters only</string>
     <string name="epub_prefer_translated">Prefer translated chapters</string>
@@ -274,7 +274,7 @@
     <string name="novel_sort_source">Source order</string>
     <string name="novel_sort_chapter">Chapter number</string>
     <string name="novel_auto_split">Auto-split long chapters</string>
-    <string name="novel_split_word_count">Split word count (Ã—50)</string>
+    <string name="novel_split_word_count">Split word count (×50)</string>
     <string name="novel_force_lowercase">Force text to lowercase</string>
     <string name="novel_engine_format">Engine #%d</string>
     <string name="novel_enabled">Enabled</string>
@@ -284,7 +284,7 @@
     <string name="novel_add_rule">Add rule</string>
     <string name="novel_tag_regex">regex</string>
     <string name="novel_tag_text">text</string>
-    <string name="novel_rule_format">/%1$s/ â†’ %2$s</string>
+    <string name="novel_rule_format">/%1$s/ → %2$s</string>
     <string name="novel_rule_remove">(remove)</string>
     <string name="novel_no_rules">No rules added. Rules apply to chapter content before rendering.</string>
     <string name="novel_edit_rule">Edit Rule</string>
@@ -352,7 +352,7 @@
     <string name="pref_novel_realtime_translation">Real-time translation while reading</string>
     <string name="pref_novel_translation_engine_label">Engine</string>
     <string name="pref_novel_translation_target_label">Target language</string>
-    <string name="pref_novel_translation_hint">Configure translation engines in Settings â†’ Novel â†’ Translation</string>
+    <string name="pref_novel_translation_hint">Configure translation engines in Settings → Novel → Translation</string>
     <string name="action_disable_translation">Disable translation</string>
     <string name="not_configured">Not configured</string>
 
@@ -496,11 +496,11 @@
 
     <!-- Custom Source - Test screen -->
     <string name="custom_source_test_title">Test Source</string>
-    <string name="custom_source_testing">Testing sourceâ€¦</string>
+    <string name="custom_source_testing">Testing source…</string>
     <string name="custom_source_run_test">Run Test</string>
     <string name="custom_source_test_again">Test Again</string>
-    <string name="custom_source_all_tests_passed">âœ“ All tests passed</string>
-    <string name="custom_source_some_tests_failed">âœ— Some tests failed</string>
+    <string name="custom_source_all_tests_passed">✓ All tests passed</string>
+    <string name="custom_source_some_tests_failed">✗ Some tests failed</string>
     <string name="custom_source_export_subject">Custom Source: %s</string>
 
     <!-- Custom Source - WebView Element Selector Wizard -->
@@ -680,4 +680,9 @@
     <string name="pref_show_manga_source_name_summary">Display source name under status on manga details screen</string>
     <string name="action_hide_source_name">Hide source name</string>
     <string name="action_show_source_name">Show source name</string>
+    <string name="prompt_save_changes">Save changes?</string>
+    <string name="prompt_save_changes_message">Do you want to save your edits to this chapter?</string>
+    <string name="action_discard">Discard</string>
+    <string name="error_saving_edits">Failed to save edited chapter</string>
+    <string name="error_decoding_edits">Failed to decode edited content</string>
 </resources>

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -415,6 +415,38 @@ actual class LocalNovelSource(
         }
     }
 
+    suspend fun getChapterImage(chapter: SChapter, imagePath: String): java.io.InputStream? = withIOContext {
+        try {
+            val urlParts = chapter.url.split("#", limit = 2)
+            val filePath = urlParts[0]
+            val (novelDirName, chapterName) = filePath.split('/', limit = 2)
+            val chapterFile = fileSystem.getBaseDirectory()
+                ?.findFile(novelDirName)
+                ?.findFile(chapterName)
+                ?: return@withIOContext null
+
+            when {
+                chapterFile.isDirectory -> {
+                    chapterFile.findFile(imagePath)?.openInputStream()?.readBytes()?.let { java.io.ByteArrayInputStream(it) }
+                }
+                chapterFile.extension.equals("epub", true) -> {
+                    chapterFile.epubReader(context).use { epub ->
+                        epub.getInputStream(imagePath)?.readBytes()?.let { java.io.ByteArrayInputStream(it) }
+                    }
+                }
+                isArchiveSupported(chapterFile) -> {
+                    chapterFile.archiveReader(context).use { reader ->
+                        reader.getInputStream(imagePath)?.readBytes()?.let { java.io.ByteArrayInputStream(it) }
+                    }
+                }
+                else -> null
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Error fetching image $imagePath for ${chapter.url}" }
+            null
+        }
+    }
+
     private fun isTextFile(file: UniFile): Boolean {
         val ext = file.extension?.lowercase() ?: return false
         return ext in TEXT_EXTENSIONS


### PR DESCRIPTION
This pull request introduces a new "Edit" mode for novel chapters in the reader, allowing users to edit and save chapter content directly from the reading interface. It also makes text selection configurable in the native text viewer and improves the handling and UI for bottom bar items. The most significant changes are grouped below:

**Edit Mode for Novel Chapters:**

* Added a new `EDIT` item to the bottom bar (`BottomBarItem`) and updated the default bottom bar items to include it. [[1]](diffhunk://#diff-9b20fb8c7f4bb9e50e052b50b4e8451d8fd7ab6299cf94c82322278fd2e2052bR22) [[2]](diffhunk://#diff-9b20fb8c7f4bb9e50e052b50b4e8451d8fd7ab6299cf94c82322278fd2e2052bR39)
* Implemented edit mode toggling in the reader UI, including a dialog for saving or discarding unsaved changes, and integrated logic to handle entering/exiting edit mode and saving edits to chapter files. [[1]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR602-R603) [[2]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR720-R772) [[3]](diffhunk://#diff-400127186c785ac7247d8b72668c4d76b2dbb8a573b9bf1ee3fc0673c3d75206R1402) [[4]](diffhunk://#diff-400127186c785ac7247d8b72668c4d76b2dbb8a573b9bf1ee3fc0673c3d75206R1422-R1503)
* Added visual and interactive support for the Edit button in the bottom bar, including proper theming and state indication. [[1]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR126-L126) [[2]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dL191) [[3]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR213-R215) [[4]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dL319) [[5]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR343-R355) [[6]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR459-L460) [[7]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR497)

**Bottom Bar and UI Improvements:**

* Updated the bottom bar to use Material3 surfaces for better visual feedback (for both Translate and Edit buttons), and improved the filtering logic to hide the Edit button when not in WebView mode. [[1]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dL380-R392) [[2]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dL390-R406) [[3]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR459-L460) [[4]](diffhunk://#diff-f5607f8631fb0c6c5e2605e20f4e47e5e74bab3e4301891698c4cfd40db0766dR343-R355)


**Text Selection Enhancements:**

* Made text selection configurable in the native text viewer, adding a preference and updating the UI to allow toggling this feature regardless of rendering mode.
* Implemented logic in `NovelViewer` to apply the text selection preference dynamically to all loaded chapters and refactored text view initialization to support this. [[1]](diffhunk://#diff-5b99fd812397bd1c99f57b3b6b91855d5be6913c8ba9749ff6a60ea58fc0093eR853-R862) [[2]](diffhunk://#diff-5b99fd812397bd1c99f57b3b6b91855d5be6913c8ba9749ff6a60ea58fc0093eL879-R901)

Fixed #58 