### PR TITLE
feat: expand HTML file detection and stabilize extension list keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 - Add Edit mode to edit chapters, fixes to images to make this work [@mrissaoussama](https://github.com/mrissaoussama) [#82](https://github.com/tsundoku-otaku/tsundoku/pull/82)
 
+### Fixed 
+- Improve HTML file detection which should fix some issues with downloaded content. [@mrissaoussama](https://github.com/mrissaoussama) [#133](https://github.com/tsundoku-otaku/tsundoku/pull/133)
+
 
 ## [v0.1.2] - 2026-03-22
 ### Changed

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
@@ -210,11 +210,19 @@ private fun ExtensionContent(
                 items = items,
                 contentType = { "item" },
                 key = { item ->
-                    when (item.extension) {
-                        is Extension.Untrusted -> "extension-untrusted-${item.hashCode()}"
-                        is Extension.Installed -> "extension-installed-${item.hashCode()}"
-                        is Extension.Available -> "extension-available-${item.hashCode()}"
-                        is Extension.JsPlugin -> "extension-js-${item.hashCode()}"
+                    when (val extension = item.extension) {
+                        is Extension.Untrusted -> {
+                            "extension-untrusted-${extension.pkgName}-${extension.versionCode}-${extension.signatureHash}"
+                        }
+                        is Extension.Installed -> {
+                            "extension-installed-${extension.pkgName}-${extension.versionCode}-${extension.hasUpdate}-${extension.isObsolete}"
+                        }
+                        is Extension.Available -> {
+                            "extension-available-${extension.pkgName}-${extension.versionCode}-${extension.repoUrl}"
+                        }
+                        is Extension.JsPlugin -> {
+                            "extension-js-${extension.pkgName}-${extension.versionCode}-${extension.repoUrl}-${extension.isInstalled}-${extension.hasUpdate}"
+                        }
                     }
                 },
             ) { item ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -182,13 +182,14 @@ class DownloadManager(
         val allFiles = chapterDir?.listFiles().orEmpty()
         logcat { "buildPageList: found ${allFiles.size} files in directory" }
         allFiles.forEach { file ->
-            logcat { "  - file: ${file.name}, isFile=${file.isFile}, isHtml=${file.name?.endsWith(".html")}" }
+            logcat { "  - file: ${file.name}, isFile=${file.isFile}, isHtml=${file.name.isHtmlContentFileName()}" }
         }
 
         val files = allFiles.filter { file ->
+            val fileName = file.name
             file.isFile && (
-                file.name?.endsWith(".html") == true ||
-                    ImageUtil.isImage(file.name) { file.openInputStream() }
+                fileName.isHtmlContentFileName() ||
+                    ImageUtil.isImage(fileName) { file.openInputStream() }
                 )
         }
         logcat { "buildPageList: filtered to ${files.size} files" }
@@ -201,6 +202,11 @@ class DownloadManager(
             .mapIndexed { i, file ->
                 Page(i, uri = file.uri).apply { status = Page.State.Ready }
             }
+    }
+
+    private fun String?.isHtmlContentFileName(): Boolean {
+        val name = this?.lowercase() ?: return false
+        return name.endsWith(".html") || name.endsWith(".htm") || name.endsWith(".xhtml")
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
@@ -16,13 +16,13 @@ internal class ArchivePageLoader(private val reader: ArchiveReader) : PageLoader
         entries
             .filter { entry ->
                 entry.isFile && (
-                    entry.name.endsWith(".html", ignoreCase = true) ||
+                    entry.name.isHtmlContentFileName() ||
                         ImageUtil.isImage(entry.name) { reader.getInputStream(entry.name)!! }
                     )
             }
             .sortedWith { f1, f2 -> f1.name.compareToCaseInsensitiveNaturalOrder(f2.name) }
             .mapIndexed { i, entry ->
-                val isHtml = entry.name.endsWith(".html", ignoreCase = true)
+                val isHtml = entry.name.isHtmlContentFileName()
                 val textContent = if (isHtml) {
                     reader.getInputStream(entry.name)?.use { it.bufferedReader().readText() }
                 } else {
@@ -49,5 +49,10 @@ internal class ArchivePageLoader(private val reader: ArchiveReader) : PageLoader
     override fun recycle() {
         super.recycle()
         reader.close()
+    }
+
+    private fun String.isHtmlContentFileName(): Boolean {
+        val normalized = lowercase()
+        return normalized.endsWith(".html") || normalized.endsWith(".htm") || normalized.endsWith(".xhtml")
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -78,7 +78,7 @@ internal class DownloadPageLoader(
             val uriString = page.uri?.toString() ?: ""
             logcat { "DownloadPageLoader: Processing page ${page.index}, uri=$uriString" }
 
-            var textContent = if (uriString.endsWith(".html")) {
+            var textContent = if (uriString.isHtmlContentPath()) {
                 logcat { "DownloadPageLoader: Reading HTML content from $uriString" }
                 context.contentResolver.openInputStream(page.uri!!)?.use {
                     it.bufferedReader().readText()
@@ -130,5 +130,10 @@ override suspend fun getPageDataStream(url: String): java.io.InputStream? {
 
     override suspend fun loadPage(page: ReaderPage) {
         archivePageLoader?.loadPage(page)
+    }
+
+    private fun String.isHtmlContentPath(): Boolean {
+        val normalized = lowercase()
+        return normalized.endsWith(".html") || normalized.endsWith(".htm") || normalized.endsWith(".xhtml")
     }
 }


### PR DESCRIPTION
- Support `.htm` and `.xhtml` file extensions in `ArchivePageLoader`, `DownloadPageLoader`, and `DownloadManager` by implementing helper functions for HTML content detection.
- Improve `ExtensionsScreen` list performance and stability by replacing unstable hash-based item keys with unique identifiers derived from extension metadata (package name, version, status, and repo URL).


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
