### PR TITLE
fix certain screens not waiting for source registration after process restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fixed bottom bar resizing [@Rojikku](https://github.com/Rojikku) [#96](https://github.com/tsundoku-otaku/tsundoku/pull/96)
 - Fixed extension filter option formatting [@mrissaoussama](https://github.com/mrissaoussama) [#138](https://github.com/tsundoku-otaku/tsundoku/pull/138)
 - Refresh library when deleting a category [@Rojikku](https://github.com/Rojikku)  [#134](https://github.com/tsundoku-otaku/tsundoku/pull/134)
+- Rare issue with OS app killing and source detection [@mrissaoussama](https://github.com/mrissaoussama) [#144](https://github.com/tsundoku-otaku/tsundoku/pull/144)
 - Fixed ttf font importing [@Rojikku](https://github.com/Rojikku)  [#135](https://github.com/tsundoku-otaku/tsundoku/pull/135)
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import logcat.LogPriority
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.domain.source.repository.StubSourceRepository
 import tachiyomi.domain.source.service.SourceManager
@@ -62,9 +60,6 @@ class AndroidSourceManager(
                 customSourceManager.customSources,
                 jsPluginManager.jsSources,
             ) { extensions, customSources, jsSources ->
-                logcat(LogPriority.INFO) {
-                    "AndroidSourceManager: combine() triggered - extensions=${extensions.size}, customSources=${customSources.size}, jsSources=${jsSources.size}"
-                }
                 val mutableMap = ConcurrentHashMap<Long, Source>(
                     mapOf(
                         LocalSource.ID to LocalSource(
@@ -94,20 +89,10 @@ class AndroidSourceManager(
                 // Add JS plugin sources
                 jsSources.forEach { jsSource ->
                     mutableMap[jsSource.id] = jsSource
-                    // Store the full display name with "(JS)" marker for proper identification
-                    registerStubSource(StubSource.fromWithDisplayName(jsSource, "${jsSource.name} (JS)"))
-                    logcat(LogPriority.DEBUG) {
-                        "AndroidSourceManager: Added JsSource id=${jsSource.id}, name=${jsSource.name}"
-                    }
-                }
-                logcat(LogPriority.INFO) {
-                    "AndroidSourceManager: combine() returning map with ${mutableMap.size} sources"
+                    registerStubSource(StubSource.from(jsSource))
                 }
                 mutableMap
             }.collectLatest { sources ->
-                logcat(LogPriority.INFO) {
-                    "AndroidSourceManager: collectLatest() updating sourcesMapFlow with ${sources.size} sources"
-                }
                 sourcesMapFlow.value = sources
                 // Wait for extension manager to finish loading before marking initialized.
                 // Without this, the first combine emission (empty extensions) would set

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -123,9 +123,9 @@ class AndroidSourceManager(
         scope.launch {
             sourceRepository.subscribeAll()
                 .collectLatest { sources ->
-                    val mutableMap = stubSourcesMap.toMutableMap()
+                    stubSourcesMap.clear()
                     sources.forEach {
-                        mutableMap[it.id] = it
+                        stubSourcesMap[it.id] = it
                     }
                 }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceResolution.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceResolution.kt
@@ -1,0 +1,33 @@
+package eu.kanade.tachiyomi.source
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import tachiyomi.domain.source.service.SourceManager
+
+/**
+ * Tries to resolve a real source instance after process restore where source registration can lag.
+ * Returns null on timeout so callers can safely fall back to getOrStub().
+ */
+suspend fun SourceManager.awaitSource(
+    sourceId: Long,
+    timeoutMillis: Long = 5_000L,
+    pollIntervalMillis: Long = 100L,
+): Source? {
+    get(sourceId)?.let { return it }
+
+    return withTimeoutOrNull(timeoutMillis) {
+        if (!isInitialized.value) {
+            isInitialized.first { it }
+        }
+
+        var resolved: Source? = null
+        while (resolved == null) {
+            resolved = get(sourceId)
+            if (resolved == null) {
+                delay(pollIntervalMillis)
+            }
+        }
+        resolved
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -124,9 +124,10 @@ data class BrowseSourceScreen(
             navigateUp()
         }
 
-        if (screenModel.source is StubSource) {
+        val currentSource = screenModel.source
+        if (currentSource is StubSource) {
             MissingSourceScreen(
-                source = screenModel.source,
+                source = currentSource,
                 navigateUp = navigateUp,
             )
             return

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.paging.Pager
@@ -24,6 +25,8 @@ import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.awaitSource
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.util.removeCovers
@@ -74,7 +77,7 @@ import eu.kanade.tachiyomi.source.model.Filter as SourceModelFilter
 class BrowseSourceScreenModel(
     private val sourceId: Long,
     listingQuery: String?,
-    sourceManager: SourceManager = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
     private val sourcePreferences: SourcePreferences = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val coverCache: CoverCache = Injekt.get(),
@@ -99,7 +102,8 @@ class BrowseSourceScreenModel(
 
     val titleMaxLines by libraryPreferences.titleMaxLines.asState(screenModelScope)
 
-    val source = sourceManager.getOrStub(sourceId)
+    var source: Source by mutableStateOf(sourceManager.getOrStub(sourceId))
+        private set
 
     // Current page number from paging source
     val currentPage: StateFlow<Int> = tachiyomi.data.source.BaseSourcePagingSource.currentPage
@@ -175,9 +179,24 @@ class BrowseSourceScreenModel(
             }
         }
 
-        if (source is CatalogueSource) {
+        screenModelScope.launchIO {
+            sourceManager.awaitSource(sourceId)?.let { resolved ->
+                if (resolved !is tachiyomi.domain.source.model.StubSource && source is tachiyomi.domain.source.model.StubSource) {
+                    source = resolved
+                    initializeSourceState()
+                }
+            }
+        }
+
+        initializeSourceState()
+    }
+
+    private fun initializeSourceState() {
+        val currentSource = source
+
+        if (currentSource is CatalogueSource) {
             // Get initial filters from source
-            var initialFilters = source.getFilterList()
+            var initialFilters = currentSource.getFilterList()
 
             // Apply default preset synchronously if enabled
             if (manageFilterPresets.getAutoApplyEnabled()) {
@@ -206,8 +225,8 @@ class BrowseSourceScreenModel(
             }
         }
 
-        if (!getIncognitoState.await(source.id)) {
-            sourcePreferences.lastUsedSource.set(source.id)
+        if (!getIncognitoState.await(currentSource.id)) {
+            sourcePreferences.lastUsedSource.set(currentSource.id)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -296,10 +296,10 @@ class BrowseSourceScreenModel(
     }
 
     fun resetFilters() {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
 
         // Get fresh filter list from source
-        val freshFilters = source.getFilterList()
+        val freshFilters = catalogueSource.getFilterList()
 
         // Apply default preset if auto-apply is enabled
         if (manageFilterPresets.getAutoApplyEnabled()) {
@@ -336,9 +336,9 @@ class BrowseSourceScreenModel(
      * Creates a fresh FilterList with copied state to avoid reference sharing issues.
      */
     fun openFilterDialog() {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
         // Get fresh filters to avoid reference sharing
-        val freshFilters = source.getFilterList()
+        val freshFilters = catalogueSource.getFilterList()
         // Copy state from current filters to fresh filters
         copyFilterState(state.value.filters, freshFilters)
 
@@ -396,11 +396,11 @@ class BrowseSourceScreenModel(
     }
 
     fun search(query: String? = null, filters: FilterList? = null) {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
         logcat(LogPriority.DEBUG) { "search called: query='$query', filters=${filters?.hashCode()}" }
 
         val input = state.value.listing as? Listing.Search
-            ?: Listing.Search(query = null, filters = source.getFilterList())
+            ?: Listing.Search(query = null, filters = catalogueSource.getFilterList())
 
         val newFilters = filters ?: input.filters
 
@@ -421,9 +421,9 @@ class BrowseSourceScreenModel(
     }
 
     fun searchGenre(genreName: String) {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
 
-        val defaultFilters = source.getFilterList()
+        val defaultFilters = catalogueSource.getFilterList()
         var genreExists = false
 
         filter@ for (sourceFilter in defaultFilters) {
@@ -628,13 +628,13 @@ class BrowseSourceScreenModel(
     }
 
     fun loadFilterPreset(presetId: Long) {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
 
         logcat(LogPriority.DEBUG) { "BrowseSource: loadFilterPreset presetId=$presetId, sourceId=$sourceId" }
         val presetState = manageFilterPresets.loadPresetState(sourceId, presetId)
         if (presetState != null) {
             logcat(LogPriority.DEBUG) { "BrowseSource: Loaded preset state, applying..." }
-            val filters = source.getFilterList()
+            val filters = catalogueSource.getFilterList()
             ManageFilterPresets.applyPresetState(filters, presetState)
             // Update pendingFilters directly and open filter dialog
             mutableState.update {
@@ -675,14 +675,14 @@ class BrowseSourceScreenModel(
     }
 
     private fun applyDefaultPresetIfEnabled() {
-        if (source !is CatalogueSource) return
+        val catalogueSource = source as? CatalogueSource ?: return
         if (!manageFilterPresets.getAutoApplyEnabled()) return
 
         logcat(LogPriority.DEBUG) { "BrowseSource: applyDefaultPresetIfEnabled sourceId=$sourceId" }
         val presetState = manageFilterPresets.getDefaultPresetState(sourceId)
         if (presetState != null) {
             logcat(LogPriority.DEBUG) { "BrowseSource: Found default preset, applying..." }
-            val filters = source.getFilterList()
+            val filters = catalogueSource.getFilterList()
             ManageFilterPresets.applyPresetState(filters, presetState)
             mutableState.update { it.copy(filters = filters) }
             // Force a search with the new filters if we are in a search listing

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -55,6 +55,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -71,6 +72,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority
 import mihon.core.archive.archiveReader
 import tachiyomi.core.common.preference.toggle
@@ -349,7 +351,17 @@ class ReaderViewModel @JvmOverloads constructor(
                     if (chapterId == -1L) chapterId = initialChapterId
 
                     val context = Injekt.get<Application>()
-                    val source = sourceManager.getOrStub(manga.source)
+                    // On process restore, source registration can lag slightly behind initialization.
+                    val source = withTimeoutOrNull<Source>(5_000L) {
+                        var resolved: Source? = null
+                        while (resolved == null) {
+                            resolved = sourceManager.get(manga.source)
+                            if (resolved == null) {
+                                delay(100L)
+                            }
+                        }
+                        resolved
+                    } ?: sourceManager.getOrStub(manga.source)
                     loader = ChapterLoader(context, downloadManager, downloadProvider, manga, source)
 
                     loadChapter(loader!!, chapterList.first { chapterId == it.chapter.id })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -28,6 +28,7 @@ import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.saver.Location
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.awaitSource
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -55,7 +56,6 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -72,7 +72,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority
 import mihon.core.archive.archiveReader
 import tachiyomi.core.common.preference.toggle
@@ -351,17 +350,7 @@ class ReaderViewModel @JvmOverloads constructor(
                     if (chapterId == -1L) chapterId = initialChapterId
 
                     val context = Injekt.get<Application>()
-                    // On process restore, source registration can lag slightly behind initialization.
-                    val source = withTimeoutOrNull<Source>(5_000L) {
-                        var resolved: Source? = null
-                        while (resolved == null) {
-                            resolved = sourceManager.get(manga.source)
-                            if (resolved == null) {
-                                delay(100L)
-                            }
-                        }
-                        resolved
-                    } ?: sourceManager.getOrStub(manga.source)
+                    val source = sourceManager.awaitSource(manga.source) ?: sourceManager.getOrStub(manga.source)
                     loader = ChapterLoader(context, downloadManager, downloadProvider, manga, source)
 
                     loadChapter(loader!!, chapterList.first { chapterId == it.chapter.id })


### PR DESCRIPTION
this pr fixes issues where if the os kills the app while in browsesourcescreen or a reader screen, those screens will show a source not installed error