### PR TITLE
feat(library): add visual feedback for tag and extension refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Improved
+- Visual feedback for tag/extension refreshes [@mrissaoussama](https://github.com/mrissaoussama) [#150](https://github.com/tsundoku-otaku/tsundoku/pull/150)
+
+
 ### Fixed
 - Fixed issue where some chapters wouldn't be marked read [@mrissaoussama](https://github.com/mrissaoussama) [#148](https://github.com/tsundoku-otaku/tsundoku/pull/148)
 - Fixed jsource library updates, links. Improved massimport and browse pagination. [@mrissaoussama](https://github.com/mrissaoussama) [#149](https://github.com/tsundoku-otaku/tsundoku/pull/149)

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -450,11 +450,25 @@ private fun ColumnScope.TagsPage(
 
     // Options expanded state
     val optionsExpanded by screenModel.tagOptionsExpanded.collectAsState()
+    var showRefreshCompleted by remember { mutableStateOf(false) }
+    var wasLoading by remember { mutableStateOf(false) }
 
     // Load data when first entering this page (only if empty)
     LaunchedEffect(Unit) {
         if (tags.isEmpty()) {
             screenModel.refreshTags()
+        }
+    }
+
+    LaunchedEffect(isLoading) {
+        if (isLoading) {
+            wasLoading = true
+            showRefreshCompleted = false
+        } else if (wasLoading) {
+            wasLoading = false
+            showRefreshCompleted = true
+            delay(900)
+            showRefreshCompleted = false
         }
     }
 
@@ -472,10 +486,25 @@ private fun ColumnScope.TagsPage(
             Spacer(Modifier.width(4.dp))
             Text("Options")
         }
-        TextButton(onClick = { screenModel.refreshTags(forceRefresh = true) }) {
-            Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+        TextButton(
+            onClick = { screenModel.refreshTags(forceRefresh = true) },
+            enabled = !isLoading,
+        ) {
+            Crossfade(
+                targetState = when {
+                    isLoading -> "loading"
+                    showRefreshCompleted -> "done"
+                    else -> "idle"
+                },
+            ) { state ->
+                when (state) {
+                    "loading" -> CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    "done" -> Icon(Icons.Default.Done, contentDescription = "Refreshed")
+                    else -> Icon(Icons.Default.Refresh, contentDescription = "Refresh")
+                }
+            }
             Spacer(Modifier.width(4.dp))
-            Text("Refresh")
+            Text(if (showRefreshCompleted) "Refreshed" else "Refresh")
         }
     }
 
@@ -746,13 +775,14 @@ private fun ColumnScope.ExtensionsPage(
     val availableExtensions by screenModel.extensionsFlow.collectAsState()
     val isLoading by screenModel.isLoading.collectAsState()
     var showRefreshCompleted by remember { mutableStateOf(false) }
-    var refreshTriggered by remember { mutableStateOf(false) }
+    var wasLoading by remember { mutableStateOf(false) }
 
     LaunchedEffect(isLoading) {
         if (isLoading) {
+            wasLoading = true
             showRefreshCompleted = false
-        } else if (refreshTriggered) {
-            refreshTriggered = false
+        } else if (wasLoading) {
+            wasLoading = false
             showRefreshCompleted = true
             delay(900)
             showRefreshCompleted = false
@@ -773,7 +803,6 @@ private fun ColumnScope.ExtensionsPage(
     ) {
         TextButton(
             onClick = {
-                refreshTriggered = true
                 screenModel.refreshExtensions(forceRefresh = true)
             },
             enabled = !isLoading,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -448,7 +448,6 @@ object SettingsDataScreen : SearchableSettings {
         }
 
         val context = LocalContext.current
-        val scope = rememberCoroutineScope()
 
         val saveFileLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.CreateDocument("text/csv"),

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -549,7 +549,9 @@ class JsSource(
                             val pageChapters = parsePageChapters(pageResult)
                             chapters.addAll(pageChapters)
                         } catch (e: Exception) {
-                            logcat(LogPriority.ERROR, e) { "JsSource[$pluginId]: Error fetching page $page of $maxPages" }
+                            logcat(LogPriority.ERROR, e) {
+                                "JsSource[$pluginId]: Error fetching page $page of $maxPages"
+                            }
                         }
                     }
                 }
@@ -725,13 +727,13 @@ class JsSource(
 
         try {
             val parsed = json.parseToJsonElement(jsonResult)
-            
+
             // Check if response is an array (simple case) or object with pagination metadata
             val (mangaArray, hasNextPageExplicit) = if (parsed is JsonArray) {
                 Pair(parsed, null)
             } else if (parsed is JsonObject) {
                 // Plugin can return { novels: [...], hasNextPage: true } or similar structure
-                val novels = parsed["novels"]?.jsonArray 
+                val novels = parsed["novels"]?.jsonArray
                     ?: parsed["results"]?.jsonArray
                     ?: return MangasPage(emptyList(), false)
                 val hasNext = parsed["hasNextPage"]?.jsonPrimitive?.content?.toBoolean()
@@ -760,7 +762,7 @@ class JsSource(
                     null
                 }
             }
-            
+
             // Use explicit hasNextPage if provided by plugin; otherwise use heuristic
             val hasNext = when {
                 hasNextPageExplicit != null -> hasNextPageExplicit


### PR DESCRIPTION
* Improve refresh button state in `LibrarySettingsDialog` by showing loading indicators and a "Refreshed" completion state.
* Clean up unused `CoroutineScope` in `SettingsDataScreen`.
* Format and lint `JsSource` for better readability.