### PR TITLE
fix(reader): apply JS on inf scroll and improve paragraph split behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Visual feedback for tag/extension refreshes [@mrissaoussama](https://github.com/mrissaoussama) [#150](https://github.com/tsundoku-otaku/tsundoku/pull/150)
+- Paragraph auto-split [@mrissaoussama](https://github.com/mrissaoussama) [#162](https://github.com/tsundoku-otaku/tsundoku/pull/162)
 
 
 ### Fixed
 - Fixed issue where some chapters wouldn't be marked read [@mrissaoussama](https://github.com/mrissaoussama) [#148](https://github.com/tsundoku-otaku/tsundoku/pull/148)
 - JS Plugin entries now refresh with global updates [@mrissaoussama](https://github.com/mrissaoussama) [#151](https://github.com/tsundoku-otaku/tsundoku/pull/151)
+- JS when using infinite scroll now applies [@mrissaoussama](https://github.com/mrissaoussama) [#162](https://github.com/tsundoku-otaku/tsundoku/pull/162)
 - Fixed jsource library updates, links. Improved massimport and browse pagination. [@mrissaoussama](https://github.com/mrissaoussama) [#149](https://github.com/tsundoku-otaku/tsundoku/pull/149)
 
 

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -288,9 +288,9 @@ internal fun ColumnScope.NovelReadingTab(screenModel: ReaderSettingsScreenModel,
     if (autoSplitEnabled) {
         SliderItem(
             label = stringResource(TDMR.strings.novel_split_word_count),
-            value = autoSplitWordCount / 50,
-            valueRange = 1..40,
-            onChange = { screenModel.preferences.novelAutoSplitWordCount.set(it * 50) },
+            value = autoSplitWordCount.coerceAtLeast(20),
+            valueRange = 20..2000,
+            onChange = { screenModel.preferences.novelAutoSplitWordCount.set(it.coerceAtLeast(20)) },
         )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -88,7 +88,7 @@ internal class DownloadPageLoader(
             }
             // Apply auto-split if enabled
             if (textContent != null && readerPreferences.novelAutoSplitText.get()) {
-                val wordCount = readerPreferences.novelAutoSplitWordCount.get()
+                val wordCount = readerPreferences.novelAutoSplitWordCount.get().coerceAtLeast(20)
                 if (wordCount > 0) {
                     textContent = TextSplitter.splitText(textContent, wordCount)
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -207,7 +207,7 @@ internal class HttpPageLoader(
                 page.status = Page.State.LoadPage
                 var text = source.fetchNovelPageText(page)
                 if (readerPreferences.novelAutoSplitText.get()) {
-                    val wordCount = readerPreferences.novelAutoSplitWordCount.get()
+                    val wordCount = readerPreferences.novelAutoSplitWordCount.get().coerceAtLeast(20)
                     if (wordCount > 0) {
                         text = TextSplitter.splitText(text, wordCount)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/LocalNovelPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/LocalNovelPageLoader.kt
@@ -46,7 +46,7 @@ class LocalNovelPageLoader(
                 var text = source.fetchPageText(Page(page.index, page.url, page.imageUrl))
                 // Apply auto-split if enabled
                 if (readerPreferences.novelAutoSplitText.get()) {
-                    val wordCount = readerPreferences.novelAutoSplitWordCount.get()
+                    val wordCount = readerPreferences.novelAutoSplitWordCount.get().coerceAtLeast(20)
                     if (wordCount > 0) {
                         text = TextSplitter.splitText(text, wordCount)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -1169,6 +1169,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             content = stripChapterTitle(content, chapter.chapter.name)
         }
 
+        // Keep preprocessing consistent with normal WebView loads.
+        content = applyRegexReplacements(content)
+
         // Optionally force lowercase
         if (preferences.novelForceTextLowercase.get()) {
             content = content.lowercase()
@@ -1280,6 +1283,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
 
         evaluateJavascriptSafe(js, null)
 
+        // Re-run custom JS for newly prepended DOM so selector-based scripts apply consistently.
+        webView.postDelayed({ injectCustomScript() }, 120)
+
         logcat(LogPriority.DEBUG) {
             "NovelWebViewViewer: Prepended chapter $chapterId (${loadedChapterIds.size} total)"
         }
@@ -1327,6 +1333,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         """.trimIndent()
 
         evaluateJavascriptSafe(js, null)
+
+        // Re-run custom JS for newly appended DOM so selector-based scripts apply consistently.
+        webView.postDelayed({ injectCustomScript() }, 120)
 
         logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Appended chapter $chapterId (${loadedChapterIds.size} total)" }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/TextSplitter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/TextSplitter.kt
@@ -18,14 +18,15 @@ object TextSplitter {
      */
     fun splitText(text: String, wordCount: Int): String {
         if (wordCount <= 0) return text
+        val effectiveWordCount = wordCount.coerceAtLeast(20)
 
         // Check if this is HTML content
-        val isHtml = text.contains("<p>") || text.contains("<br") || text.contains("<div")
+        val isHtml = Regex("<\\s*(p|div|br|body)\\b", RegexOption.IGNORE_CASE).containsMatchIn(text)
 
         return if (isHtml) {
-            splitHtmlText(text, wordCount)
+            splitHtmlText(text, effectiveWordCount)
         } else {
-            splitPlainText(text, wordCount)
+            splitPlainText(text, effectiveWordCount)
         }
     }
 
@@ -84,7 +85,11 @@ object TextSplitter {
                 // Check if it's a paragraph or break tag - reset counter
                 if (tag.lowercase().startsWith("<p>") ||
                     tag.lowercase().startsWith("<br") ||
-                    tag.lowercase().startsWith("</p>")
+                    tag.lowercase().startsWith("</p>") ||
+                    tag.lowercase().startsWith("<div") ||
+                    tag.lowercase().startsWith("</div") ||
+                    tag.lowercase().startsWith("<body") ||
+                    tag.lowercase().startsWith("</body")
                 ) {
                     wordsSincePunctuation = 0
                 }
@@ -114,7 +119,9 @@ object TextSplitter {
 
                     val endsWithPunctuation = word.lastOrNull()?.let { it in sentenceEndingPunctuation } == true
                     if (endsWithPunctuation && wordsSincePunctuation >= targetWordCount) {
-                        result.append("</p><p>")
+                        // Use line breaks instead of forcing paragraph tags.
+                        // This keeps splitting valid for <div>-based chapters and body-level plain HTML.
+                        result.append("<br><br>")
                         wordsSincePunctuation = 0
                     }
                 }


### PR DESCRIPTION
Reduce text splitter minimum to 20
Improve text splitter detection logic, more html tags ect
Apply js on newly loaded chapters when using inf scroll