### PR TITLE
Add move by url, improve duplicate screen, massimport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Move by URL [@mrissaoussama](https://github.com/mrissaoussama) [#163](https://github.com/tsundoku-otaku/tsundoku/pull/163)
+
 
 ### Improved
+- Duplicate screen and mass import [@mrissaoussama](https://github.com/mrissaoussama) [#163](https://github.com/tsundoku-otaku/tsundoku/pull/163)
 - Visual feedback for tag/extension refreshes [@mrissaoussama](https://github.com/mrissaoussama) [#150](https://github.com/tsundoku-otaku/tsundoku/pull/150)
 - Paragraph auto-split [@mrissaoussama](https://github.com/mrissaoussama) [#162](https://github.com/tsundoku-otaku/tsundoku/pull/162)
 

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -92,30 +92,53 @@ fun MassImportDialog(
     var pendingUrls by remember { mutableStateOf(initialText) }
     var urlText by remember { mutableStateOf("") }
 
-    // File picker launcher for reading URLs from multiple files
+    // File picker launcher for reading URLs from files
     val filePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenMultipleDocuments(),
         onResult = { uris ->
-            if (uris.isNotEmpty()) {
-                var totalAdded = 0
-                try {
-                    val combinedContent = uris.joinToString("\n") { uri ->
-                        val inputStream = context.contentResolver.openInputStream(uri)
-                        val content = inputStream?.bufferedReader()?.use { it.readText() } ?: ""
-                        totalAdded += content.lines().count { it.isNotBlank() }
-                        content
-                    }
+            if (uris.isEmpty()) return@rememberLauncherForActivityResult
 
-                    // Add file content to pending URLs
-                    pendingUrls = if (pendingUrls.isBlank()) {
-                        combinedContent
-                    } else {
-                        "$pendingUrls\n$combinedContent"
+            var loadedFiles = 0
+            val mergedBuilder = StringBuilder()
+
+            uris.forEach { uri ->
+                try {
+                    var fileHadContent = false
+                    context.contentResolver.openInputStream(uri)
+                        ?.bufferedReader()
+                        ?.useLines { lines ->
+                            lines.forEach { rawLine ->
+                                val line = rawLine.trim()
+                                if (line.isNotBlank()) {
+                                    if (mergedBuilder.isNotEmpty()) {
+                                        mergedBuilder.append('\n')
+                                    }
+                                    mergedBuilder.append(line)
+                                    fileHadContent = true
+                                }
+                            }
+                        }
+
+                    if (fileHadContent) {
+                        loadedFiles++
                     }
-                    context.toast("Added $totalAdded URLs from file(s)")
                 } catch (e: Exception) {
-                    context.toast("Error reading file(s): ${e.message}")
+                    context.toast("Error reading file: ${e.message}")
                 }
+            }
+
+            if (mergedBuilder.isNotEmpty()) {
+                val merged = mergedBuilder.toString()
+                pendingUrls = if (pendingUrls.isBlank()) {
+                    merged
+                } else {
+                    "$pendingUrls\n$merged"
+                }
+
+                val addedCount = merged.lines().count { it.isNotBlank() }
+                context.toast("Added $addedCount URLs from $loadedFiles file(s)")
+            } else {
+                context.toast("No readable URLs found in selected files")
             }
         },
     )
@@ -182,10 +205,6 @@ fun MassImportDialog(
     val massImportNovels = remember { Injekt.get<MassImport>() }
 
     val queue by MassImportJob.sharedQueue.collectAsState()
-
-    LaunchedEffect(Unit) {
-        MassImportJob.restoreQueueFromWorkManager(context)
-    }
 
     val getCategories = remember { Injekt.get<GetCategories>() }
     // Filter categories by content type (manga vs novel)
@@ -564,22 +583,24 @@ fun MassImportDialog(
             }
         },
         confirmButton = {
-            val allUrlsText = listOf(pendingUrls, urlText)
-                .filter { it.isNotBlank() }
-                .joinToString("\n")
-            val hasUrls = allUrlsText.isNotBlank()
+            val hasUrls = pendingUrls.isNotBlank() || urlText.isNotBlank()
 
             TextButton(
                 onClick = {
                     // Run URL parsing and job enqueue off main thread
                     dialogScope.launch(Dispatchers.Default) {
-                        val urls = massImportNovels.parseUrls(allUrlsText)
-                        // Deduplicate URLs before adding to queue
-                        val uniqueUrls = urls.toSet().toList()
+                        val uniqueUrls = LinkedHashSet<String>()
+                        if (pendingUrls.isNotBlank()) {
+                            uniqueUrls.addAll(massImportNovels.parseUrls(pendingUrls))
+                        }
+                        if (urlText.isNotBlank()) {
+                            uniqueUrls.addAll(massImportNovels.parseUrls(urlText))
+                        }
+
                         withContext(Dispatchers.Main) {
                             MassImportJob.start(
                                 context = context,
-                                urls = uniqueUrls,
+                                urls = uniqueUrls.toList(),
                                 addToLibrary = true,
                                 fetchDetails = fetchDetails,
                                 categoryId = selectedCategoryId ?: 0L,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -8,12 +8,16 @@ import android.webkit.WebStorage
 import android.webkit.WebView
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,6 +28,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DriveFileMove
+import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.FileOpen
@@ -32,7 +37,11 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -233,8 +242,8 @@ object SettingsAdvancedScreen : SearchableSettings {
         var showBulkRemovalDialog by remember { mutableStateOf(false) }
         var showResetSettingsDialog by remember { mutableStateOf(false) }
 
-        // Load categories when dialog is shown
-        if (showMoveToCategoryDialog && categories.isEmpty()) {
+        // Load categories when category-based dialogs are shown
+        if ((showMoveToCategoryDialog || showBulkRemovalDialog) && categories.isEmpty()) {
             scope.launch {
                 categories = Injekt.get<GetCategories>().await()
             }
@@ -591,7 +600,7 @@ object SettingsAdvancedScreen : SearchableSettings {
             }
         }
 
-        // Bulk removal dialog
+        // Bulk URL processing dialog
         if (showBulkRemovalDialog) {
             // Queue-based approach to handle large files without memory issues
             var pendingUrls by remember { mutableStateOf("") }
@@ -599,6 +608,9 @@ object SettingsAdvancedScreen : SearchableSettings {
             var isRemoving by remember { mutableStateOf(false) }
             var removedCount by remember { mutableStateOf(0) }
             var errorCount by remember { mutableStateOf(0) }
+            var moveToCategoryMode by remember { mutableStateOf(false) }
+            var selectedCategoryId by remember { mutableStateOf<Long?>(null) }
+            var categoryDropdownExpanded by remember { mutableStateOf(false) }
 
             val pendingUrlCount = remember(pendingUrls) {
                 if (pendingUrls.isBlank()) 0 else pendingUrls.lines().filter { it.isNotBlank() }.size
@@ -606,31 +618,171 @@ object SettingsAdvancedScreen : SearchableSettings {
 
             // File picker for URL list
             val filePickerLauncher = rememberLauncherForActivityResult(
-                contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
-                onResult = { uri ->
-                    uri?.let {
+                contract = androidx.activity.result.contract.ActivityResultContracts.OpenMultipleDocuments(),
+                onResult = { uris ->
+                    if (uris.isEmpty()) return@rememberLauncherForActivityResult
+
+                    var loadedFiles = 0
+                    val mergedBuilder = StringBuilder()
+                    uris.forEach { uri ->
                         try {
-                            val inputStream = context.contentResolver.openInputStream(uri)
-                            val content = inputStream?.bufferedReader()?.use { it.readText() } ?: return@let
+                            var fileHadContent = false
+                            context.contentResolver.openInputStream(uri)
+                                ?.bufferedReader()
+                                ?.useLines { lines ->
+                                    lines.forEach { rawLine ->
+                                        val line = rawLine.trim()
+                                        if (line.isNotBlank()) {
+                                            if (mergedBuilder.isNotEmpty()) {
+                                                mergedBuilder.append('\n')
+                                            }
+                                            mergedBuilder.append(line)
+                                            fileHadContent = true
+                                        }
+                                    }
+                                }
 
-                            // Add to pending queue instead of text field
-                            pendingUrls = if (pendingUrls.isBlank()) content else "$pendingUrls\n$content"
-
-                            val newCount = content.lines().filter { it.isNotBlank() }.size
-                            context.toast("Added $newCount URLs to queue (Total: $pendingUrlCount)")
+                            if (fileHadContent) {
+                                loadedFiles++
+                            }
                         } catch (e: Exception) {
-                            context.toast("Error reading file: ${e.message}")
+                            logcat(LogPriority.ERROR, e) { "Error reading file: $uri" }
                         }
+                    }
+
+                    if (mergedBuilder.isNotEmpty()) {
+                        val merged = mergedBuilder.toString()
+                        pendingUrls = if (pendingUrls.isBlank()) merged else "$pendingUrls\n$merged"
+                        val newCount = merged.lines().count { it.isNotBlank() }
+                        val totalCount = pendingUrls.lines().count { it.isNotBlank() }
+                        context.toast("Added $newCount URLs from $loadedFiles file(s) (Total: $totalCount)")
+                    } else {
+                        context.toast("No readable URLs found in selected files")
                     }
                 },
             )
 
+            val userCategories = remember(categories) {
+                categories
+                    .asSequence()
+                    .filterNot(Category::isSystemCategory)
+                    .filter { it.contentType != Category.CONTENT_TYPE_MANGA }
+                    .toList()
+            }
+            val selectedCategory = userCategories.firstOrNull { it.id == selectedCategoryId }
+            val defaultCategoryName = stringResource(MR.strings.default_category)
+            val selectedCategoryName = if (selectedCategoryId == null) {
+                defaultCategoryName
+            } else {
+                selectedCategory?.name ?: defaultCategoryName
+            }
+
             AlertDialog(
                 onDismissRequest = { if (!isRemoving) showBulkRemovalDialog = false },
-                title = { Text(text = "Bulk Remove by URL") },
+                title = {
+                    Text(
+                        text = if (moveToCategoryMode) {
+                            "Bulk Move to Category by URL"
+                        } else {
+                            "Bulk Remove by URL"
+                        },
+                    )
+                },
                 text = {
                     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                        Text(text = "Enter URLs to remove from library:")
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            TextButton(
+                                onClick = { moveToCategoryMode = false },
+                                enabled = !isRemoving,
+                            ) {
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text("Remove")
+                            }
+                            TextButton(
+                                onClick = { moveToCategoryMode = true },
+                                enabled = !isRemoving,
+                            ) {
+                                Icon(Icons.Filled.DriveFileMove, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text("Move to Category")
+                            }
+                        }
+
+                        if (moveToCategoryMode) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(text = "Target category:")
+                            Spacer(modifier = Modifier.height(4.dp))
+                            if (userCategories.isEmpty()) {
+                                Text(
+                                    text = "No categories available.",
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            } else {
+                                Box(modifier = Modifier.fillMaxWidth()) {
+                                    OutlinedTextField(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        readOnly = true,
+                                        enabled = false,
+                                        value = selectedCategoryName,
+                                        onValueChange = {},
+                                        label = { Text("Category") },
+                                        trailingIcon = {
+                                            Icon(
+                                                imageVector = Icons.Outlined.ArrowDropDown,
+                                                contentDescription = null,
+                                            )
+                                        },
+                                        colors = OutlinedTextFieldDefaults.colors(
+                                            disabledTextColor = MaterialTheme.colorScheme.onSurface,
+                                            disabledBorderColor = MaterialTheme.colorScheme.outline,
+                                            disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            disabledTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        ),
+                                    )
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clickable { categoryDropdownExpanded = true },
+                                    )
+
+                                    DropdownMenu(
+                                        expanded = categoryDropdownExpanded,
+                                        onDismissRequest = { categoryDropdownExpanded = false },
+                                        modifier = Modifier.heightIn(max = 260.dp),
+                                    ) {
+                                        DropdownMenuItem(
+                                            text = { Text(defaultCategoryName) },
+                                            onClick = {
+                                                selectedCategoryId = null
+                                                categoryDropdownExpanded = false
+                                            },
+                                        )
+                                        userCategories.forEach { category ->
+                                            DropdownMenuItem(
+                                                text = { Text(category.name) },
+                                                onClick = {
+                                                    selectedCategoryId = category.id
+                                                    categoryDropdownExpanded = false
+                                                },
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+
+                        Text(
+                            text = if (moveToCategoryMode) {
+                                "Enter URLs to move to selected category:"
+                            } else {
+                                "Enter URLs to remove from library:"
+                            },
+                        )
                         Spacer(modifier = Modifier.height(8.dp))
 
                         // Text field for manual entry
@@ -671,7 +823,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                             ) {
                                 Icon(Icons.Outlined.FileOpen, contentDescription = null, modifier = Modifier.size(18.dp))
                                 Spacer(modifier = Modifier.width(4.dp))
-                                Text("Load File")
+                                Text("Load Files")
                             }
                         }
 
@@ -733,21 +885,20 @@ object SettingsAdvancedScreen : SearchableSettings {
                                 removedCount = 0
                                 errorCount = 0
                                 try {
-                                    val urls = pendingUrls.split("\n", ",", ";")
-                                        .map { it.trim() }
-                                        .filter { it.startsWith("http://") || it.startsWith("https://") }
-
-                                    if (urls.isEmpty()) {
-                                        context.toast("No valid URLs to process")
+                                    if (moveToCategoryMode && selectedCategoryId == null) {
+                                        context.toast("Select a target category first")
                                         isRemoving = false
                                         return@launch
                                     }
 
                                     val mangaRepo = Injekt.get<MangaRepository>()
+                                    val setMangaCategories = Injekt.get<SetMangaCategories>()
 
                                     val chunkSize = 50
                                     val favorites = mangaRepo.getFavoriteIdAndUrl()
-                                    for (urlChunk in urls.chunked(chunkSize)) {
+                                    val allMatchedIds = mutableSetOf<Long>()
+
+                                    fun processChunk(urlChunk: List<String>) {
                                         try {
                                             val toUnfavorite = mutableSetOf<Long>()
 
@@ -777,22 +928,65 @@ object SettingsAdvancedScreen : SearchableSettings {
                                                 }
                                             }
 
-                                            // Unfavorite in batch
-                                            if (toUnfavorite.isNotEmpty()) {
-                                                val updates = toUnfavorite.map { MangaUpdate(id = it, favorite = false) }
-                                                mangaRepo.updateAll(updates)
-                                                removedCount += toUnfavorite.size
-                                            }
+                                            allMatchedIds.addAll(toUnfavorite)
                                         } catch (e: Exception) {
                                             logcat(LogPriority.ERROR, e) { "Error processing chunk" }
                                             errorCount += urlChunk.size
                                         }
                                     }
 
+                                    var validUrlCount = 0
+                                    val buffer = ArrayList<String>(chunkSize)
+
+                                    pendingUrls
+                                        .lineSequence()
+                                        .forEach { rawLine ->
+                                            rawLine.split(',', ';')
+                                                .asSequence()
+                                                .map { it.trim() }
+                                                .filter { it.startsWith("http://") || it.startsWith("https://") }
+                                                .forEach { url ->
+                                                    validUrlCount++
+                                                    buffer.add(url)
+                                                    if (buffer.size >= chunkSize) {
+                                                        val chunk = buffer.toList()
+                                                        buffer.clear()
+                                                        processChunk(chunk)
+                                                    }
+                                                }
+                                        }
+
+                                    if (buffer.isNotEmpty()) {
+                                        processChunk(buffer.toList())
+                                        buffer.clear()
+                                    }
+
+                                    if (validUrlCount == 0) {
+                                        context.toast("No valid URLs to process")
+                                        isRemoving = false
+                                        return@launch
+                                    }
+
+                                    if (allMatchedIds.isNotEmpty()) {
+                                        if (moveToCategoryMode) {
+                                            setMangaCategories.add(allMatchedIds.toList(), listOf(selectedCategoryId!!))
+                                            removedCount = allMatchedIds.size
+                                        } else {
+                                            val updates = allMatchedIds.map { MangaUpdate(id = it, favorite = false) }
+                                            mangaRepo.updateAll(updates)
+                                            removedCount = allMatchedIds.size
+                                        }
+                                    }
+
                                     withUIContext {
                                         context.toast(
                                             buildString {
-                                                append("Removed $removedCount entries")
+                                                if (moveToCategoryMode) {
+                                                    val categoryName = selectedCategory?.name ?: "selected category"
+                                                    append("Moved $removedCount entries to $categoryName")
+                                                } else {
+                                                    append("Removed $removedCount entries")
+                                                }
                                                 if (errorCount > 0) append(" ($errorCount errors)")
                                             },
                                         )
@@ -810,12 +1004,18 @@ object SettingsAdvancedScreen : SearchableSettings {
                                 }
                             }
                         },
-                        enabled = !isRemoving && pendingUrlCount > 0,
+                        enabled = !isRemoving && pendingUrlCount > 0 && (!moveToCategoryMode || selectedCategoryId != null),
                     ) {
                         if (isRemoving) {
                             CircularProgressIndicator(modifier = Modifier.size(16.dp))
                         } else {
-                            Text(text = "Remove ($pendingUrlCount)")
+                            Text(
+                                text = if (moveToCategoryMode) {
+                                    "Move ($pendingUrlCount)"
+                                } else {
+                                    "Remove ($pendingUrlCount)"
+                                },
+                            )
                         }
                     }
                 },

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -534,26 +534,49 @@ object SettingsAdvancedScreen : SearchableSettings {
                         }
                     },
                     confirmButton = {
-                        TextButton(
-                            onClick = {
-                                scope.launch {
-                                    isRemoving = true
-                                    val result = Injekt.get<MangaRepository>()
-                                        .removePotentialDuplicates(removeDupDoubleSlashes)
-                                    isRemoving = false
-                                    if (result.first > 0) {
-                                        removedDuplicates = result.second
-                                        showRemovedList = true
-                                        context.toast("Removed ${result.first} duplicate entries")
-                                    } else {
-                                        context.toast("No duplicates found")
-                                        showRemoveDuplicatesDialog = false
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            TextButton(
+                                onClick = {
+                                    scope.launch {
+                                        isRemoving = true
+                                        val result = Injekt.get<MangaRepository>()
+                                            .normalizeAllUrlsAdvanced(removeDupDoubleSlashes)
+                                        isRemoving = false
+
+                                        duplicateUrls = result.second
+                                        if (duplicateUrls.isNotEmpty()) {
+                                            showMoveToCategoryDialog = true
+                                            showRemoveDuplicatesDialog = false
+                                        } else {
+                                            context.toast("No duplicates found")
+                                        }
                                     }
-                                }
-                            },
-                            enabled = !isRemoving,
-                        ) {
-                            Text(text = "Remove Duplicates")
+                                },
+                                enabled = !isRemoving,
+                            ) {
+                                Text(text = "Move to Category")
+                            }
+                            TextButton(
+                                onClick = {
+                                    scope.launch {
+                                        isRemoving = true
+                                        val result = Injekt.get<MangaRepository>()
+                                            .removePotentialDuplicates(removeDupDoubleSlashes)
+                                        isRemoving = false
+                                        if (result.first > 0) {
+                                            removedDuplicates = result.second
+                                            showRemovedList = true
+                                            context.toast("Removed ${result.first} duplicate entries")
+                                        } else {
+                                            context.toast("No duplicates found")
+                                            showRemoveDuplicatesDialog = false
+                                        }
+                                    }
+                                },
+                                enabled = !isRemoving,
+                            ) {
+                                Text(text = "Remove Duplicates")
+                            }
                         }
                     },
                     dismissButton = {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -201,6 +201,24 @@ class DownloadCache(
     }
 
     /**
+     * Returns downloaded chapter counts for multiple manga with a single cache refresh.
+     */
+    fun getDownloadCounts(mangaList: List<Manga>): Map<Long, Int> {
+        renewCache()
+
+        return mangaList.associate { manga ->
+            val sourceDir = rootDownloadsDir.sourceDirs[manga.source]
+            val count = if (sourceDir != null) {
+                val mangaDir = sourceDir.mangaDirs[provider.getMangaDirName(manga.title)]
+                mangaDir?.chapterDirs?.size ?: 0
+            } else {
+                0
+            }
+            manga.id to count
+        }
+    }
+
+    /**
      * Adds a chapter that has just been download to this cache.
      *
      * @param chapterDirName the downloaded chapter's directory name.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -247,6 +247,17 @@ class DownloadManager(
         return cache.getDownloadCount(manga)
     }
 
+    /**
+     * Batch fetch download counts for multiple manga.
+     * More efficient than calling getDownloadCount() separately for each manga.
+     *
+     * @param mangaList the list of manga to check.
+     * @return a map of manga ID to download count.
+     */
+    fun getDownloadCounts(mangaList: List<Manga>): Map<Long, Int> {
+        return cache.getDownloadCounts(mangaList)
+    }
+
     fun cancelQueuedDownloads(downloads: List<Download>) {
         removeFromDownloadQueue(downloads.map { it.toDomainChapter() })
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -91,6 +91,7 @@ import tachiyomi.domain.manga.interactor.DuplicateMatchMode
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
@@ -484,7 +485,7 @@ class DuplicateDetectionScreen : Screen {
                                 onCheckedChange = { screenModel.setFilterByGroupCategory(it) },
                             )
                             Text(
-                                "Filter by group strictly (at least one valid item)",
+                                stringResource(TDMR.strings.duplicate_flexible_group_matching),
                                 style = MaterialTheme.typography.bodyMedium,
                                 modifier = Modifier.padding(start = 8.dp),
                             )
@@ -627,6 +628,28 @@ class DuplicateDetectionScreen : Screen {
                                     Text(
                                         stringResource(MR.strings.duplicate_category_label),
                                         style = MaterialTheme.typography.labelMedium,
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    FilterChip(
+                                        selected = state.categoryIncludeMode ==
+                                            DuplicateDetectionScreenModel.CategoryIncludeMode.ANY,
+                                        onClick = {
+                                            screenModel.setCategoryIncludeMode(
+                                                DuplicateDetectionScreenModel.CategoryIncludeMode.ANY,
+                                            )
+                                        },
+                                        label = { Text(stringResource(TDMR.strings.duplicate_category_include_or)) },
+                                    )
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                    FilterChip(
+                                        selected = state.categoryIncludeMode ==
+                                            DuplicateDetectionScreenModel.CategoryIncludeMode.ALL,
+                                        onClick = {
+                                            screenModel.setCategoryIncludeMode(
+                                                DuplicateDetectionScreenModel.CategoryIncludeMode.ALL,
+                                            )
+                                        },
+                                        label = { Text(stringResource(TDMR.strings.duplicate_category_include_and)) },
                                     )
                                     if (state.selectedCategoryFilters.isNotEmpty() ||
                                         state.excludedCategoryFilters.isNotEmpty()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
@@ -61,6 +61,11 @@ class DuplicateDetectionScreenModel(
         STUB,
     }
 
+    enum class CategoryIncludeMode {
+        ANY,
+        ALL,
+    }
+
     data class State(
         val isLoading: Boolean = false,
         val hasStartedAnalysis: Boolean = false,
@@ -72,11 +77,13 @@ class DuplicateDetectionScreenModel(
         val showMoveToCategoryDialog: Boolean = false,
         val categories: List<Category> = emptyList(),
         val selectedCategoryFilters: Set<Long> = emptySet(),
+        val categoryIncludeMode: CategoryIncludeMode = CategoryIncludeMode.ANY,
         val searchQuery: String = "",
         val excludedCategoryFilters: Set<Long> = emptySet(),
         val filterByGroupCategory: Boolean = false,
         val sortMode: SortMode = SortMode.NAME,
         val mangaCategories: Map<Long, List<Category>> = emptyMap(),
+        val mangaCategoryIdSets: Map<Long, Set<Long>> = emptyMap(),
         val showFullUrls: Boolean = false,
         val mangaDownloadCounts: Map<Long, Int> = emptyMap(),
         val mangaReadCounts: Map<Long, Int> = emptyMap(),
@@ -116,34 +123,31 @@ class DuplicateDetectionScreenModel(
                     if (filterByGroupCategory) {
                         contentFiltered.filter { (_, novels) ->
                             val groupMatches = novels.any { novel ->
-                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
-                                val categoryIds = novelCategories.map { it.id }.toSet().ifEmpty { setOf(0L) }
+                                val categoryIds = mangaCategoryIdSets[novel.manga.id] ?: setOf(0L)
                                 val passesInclude =
-                                    selectedCategoryFilters.isEmpty() ||
-                                        categoryIds.any { it in selectedCategoryFilters }
-                                passesInclude
-                            }
-                            val groupExcluded = excludedCategoryFilters.isNotEmpty() && novels.any { novel ->
-                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
-                                val categoryIds = novelCategories.map { it.id }.toSet().ifEmpty { setOf(0L) }
-                                categoryIds.any { it in excludedCategoryFilters }
-                            }
-                            groupMatches && !groupExcluded
-                        }
-                    } else {
-                        contentFiltered.mapValues { (_, novels) ->
-                            novels.filter { novel ->
-                                val novelCategories = mangaCategories[novel.manga.id] ?: emptyList()
-                                // Treat uncategorized manga as being in the default category (id=0)
-                                val categoryIds = novelCategories.map { it.id }.toSet()
-                                    .ifEmpty { setOf(0L) }
-                                val passesInclude = selectedCategoryFilters.isEmpty() ||
-                                    categoryIds.any { it in selectedCategoryFilters }
+                                    selectedCategoryFilters.isEmpty() || when (categoryIncludeMode) {
+                                        CategoryIncludeMode.ANY -> categoryIds.any { it in selectedCategoryFilters }
+                                        CategoryIncludeMode.ALL -> selectedCategoryFilters.all { it in categoryIds }
+                                    }
                                 val passesExclude = excludedCategoryFilters.isEmpty() ||
                                     categoryIds.none { it in excludedCategoryFilters }
                                 passesInclude && passesExclude
                             }
-                        }.filter { it.value.size > 1 }
+                            groupMatches
+                        }
+                    } else {
+                        contentFiltered.filter { (_, novels) ->
+                            novels.all { novel ->
+                                val categoryIds = mangaCategoryIdSets[novel.manga.id] ?: setOf(0L)
+                                val passesInclude = selectedCategoryFilters.isEmpty() || when (categoryIncludeMode) {
+                                    CategoryIncludeMode.ANY -> categoryIds.any { it in selectedCategoryFilters }
+                                    CategoryIncludeMode.ALL -> selectedCategoryFilters.all { it in categoryIds }
+                                }
+                                val passesExclude = excludedCategoryFilters.isEmpty() ||
+                                    categoryIds.none { it in excludedCategoryFilters }
+                                passesInclude && passesExclude
+                            }
+                        }
                     }
                 }
 
@@ -299,12 +303,11 @@ class DuplicateDetectionScreenModel(
                 val groups = findDuplicateNovels.findDuplicatesGrouped(state.value.matchMode)
 
                 val allMangaItems = groups.values.flatten()
-                val mangaCategoriesMap = mutableMapOf<Long, List<Category>>()
-                allMangaItems.map { it.manga.id }.distinct().chunked(500).forEach { chunk ->
-                    chunk.forEach { mangaId ->
-                        ensureActive()
-                        mangaCategoriesMap[mangaId] = getCategories.await(mangaId)
-                    }
+                val allMangaIds = allMangaItems.map { it.manga.id }.distinct()
+
+                val mangaCategoriesMap = getCategories.awaitForMangas(allMangaIds)
+                val mangaCategoryIdSets = mangaCategoriesMap.mapValues { (_, categories) ->
+                    categories.map { it.id }.toSet().ifEmpty { setOf(0L) }
                 }
 
                 // Build set of novel source IDs for content type filtering
@@ -313,26 +316,19 @@ class DuplicateDetectionScreenModel(
                     sourceManager.getOrStub(sourceId).isNovelSource()
                 }.toSet()
 
-                // Build source type map for priority-based selection
                 val sourceTypeMap = allSourceIds.associateWith { sourceId ->
                     classifySourceType(sourceId)
                 }
 
-                // Use readCount from getMangaWithCounts (already fetched), only compute download counts
-                val downloadCounts = mutableMapOf<Long, Int>()
-                val readCounts = mutableMapOf<Long, Int>()
+                val downloadCounts = downloadManager.getDownloadCounts(allMangaItems.map { it.manga })
 
-                allMangaItems.forEach { mangaWithCount ->
-                    ensureActive()
-                    downloadCounts[mangaWithCount.manga.id] = downloadManager.getDownloadCount(mangaWithCount.manga)
-                    // readCount is already available from the query
-                    readCounts[mangaWithCount.manga.id] = mangaWithCount.readCount.toInt()
-                }
+                val readCounts = allMangaItems.associate { it.manga.id to it.readCount.toInt() }
 
                 mutableState.update {
                     it.copy(
                         duplicateGroups = groups,
                         mangaCategories = mangaCategoriesMap,
+                        mangaCategoryIdSets = mangaCategoryIdSets,
                         novelSourceIds = novelSourceIds,
                         sourceTypeMap = sourceTypeMap,
                         mangaDownloadCounts = downloadCounts,
@@ -380,6 +376,10 @@ class DuplicateDetectionScreenModel(
 
     fun clearCategoryFilters() {
         mutableState.update { it.copy(selectedCategoryFilters = emptySet(), excludedCategoryFilters = emptySet()) }
+    }
+
+    fun setCategoryIncludeMode(mode: CategoryIncludeMode) {
+        mutableState.update { it.copy(categoryIncludeMode = mode) }
     }
 
     fun setFilterByGroupCategory(filter: Boolean) {

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -35,6 +35,21 @@ class CategoryRepositoryImpl(
         }
     }
 
+    override suspend fun getCategoriesByMangaIds(mangaIds: List<Long>): Map<Long, List<Category>> {
+        if (mangaIds.isEmpty()) return emptyMap()
+
+        val resultMap = mutableMapOf<Long, MutableList<Category>>()
+        mangaIds.chunked(500).forEach { chunk ->
+            handler.awaitList {
+                categoriesQueries.getCategoriesByMangaIds(chunk) { mangaId, id, name, order, flags, contentType ->
+                    resultMap.getOrPut(mangaId) { mutableListOf() }
+                        .add(mapCategory(id, name, order, flags, contentType))
+                }
+            }
+        }
+        return resultMap
+    }
+
     override suspend fun getAllMangaCategoryPairs(): List<Pair<Long, Long>> {
         return handler.awaitList {
             mangas_categoriesQueries.getAllMangaCategoryPairs { mangaId, categoryId ->

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -26,6 +26,25 @@ class MangaRepositoryImpl(
     private val handler: DatabaseHandler,
 ) : MangaRepository {
 
+    private data class UrlMaintenanceRow(
+        val id: Long,
+        val source: Long,
+        val url: String,
+        val title: String,
+        val favorite: Boolean,
+    )
+
+    private fun normalizeUrlForMaintenance(url: String, removeDoubleSlashes: Boolean): String {
+        var normalizedUrl = url.trimEnd('/').substringBefore('#')
+        if (removeDoubleSlashes) {
+            val placeholder = "###PROTOCOL###"
+            normalizedUrl = normalizedUrl.replace("://", placeholder)
+            normalizedUrl = normalizedUrl.replace("//", "/")
+            normalizedUrl = normalizedUrl.replace(placeholder, "://")
+        }
+        return normalizedUrl
+    }
+
     override suspend fun getMangaById(id: Long): Manga {
         return handler.awaitOne {
             mangasQueries.getMangaById(id) {
@@ -1500,20 +1519,24 @@ class MangaRepositoryImpl(
             val duplicates = mutableListOf<MangaRepository.DuplicateUrlInfo>()
             val seen = mutableSetOf<Pair<Long, String>>()
             handler.await(inTransaction = true) {
-                val allManga = mangasQueries.getAllManga(MangaMapper::mapMangaFull).executeAsList()
-                allManga.forEach { manga ->
-                    var normalizedUrl = manga.url.trimEnd('/').substringBefore('#')
+                val allManga = mangasQueries.getAllMangaUrlMaintenanceRows {
+                        id,
+                        source,
+                        url,
+                        title,
+                        favorite,
+                    ->
+                    UrlMaintenanceRow(
+                        id = id,
+                        source = source,
+                        url = url,
+                        title = title,
+                        favorite = favorite,
+                    )
+                }.executeAsList()
 
-                    // Remove double slashes if enabled (but preserve protocol ://)
-                    if (removeDoubleSlashes) {
-                        // First, temporarily replace :// with a placeholder
-                        val placeholder = "###PROTOCOL###"
-                        normalizedUrl = normalizedUrl.replace("://", placeholder)
-                        // Then remove double slashes
-                        normalizedUrl = normalizedUrl.replace("//", "/")
-                        // Restore protocol
-                        normalizedUrl = normalizedUrl.replace(placeholder, "://")
-                    }
+                allManga.forEach { manga ->
+                    val normalizedUrl = normalizeUrlForMaintenance(manga.url, removeDoubleSlashes)
 
                     if (normalizedUrl != manga.url) {
                         val key = manga.source to normalizedUrl
@@ -1576,18 +1599,25 @@ class MangaRepositoryImpl(
             val idsToDelete = mutableListOf<Long>()
 
             handler.await(inTransaction = true) {
-                val allManga = mangasQueries.getAllManga(MangaMapper::mapMangaFull).executeAsList()
+                val allManga = mangasQueries.getAllMangaUrlMaintenanceRows {
+                        id,
+                        source,
+                        url,
+                        title,
+                        favorite,
+                    ->
+                    UrlMaintenanceRow(
+                        id = id,
+                        source = source,
+                        url = url,
+                        title = title,
+                        favorite = favorite,
+                    )
+                }.executeAsList()
 
                 // First pass: identify which manga would be kept (first occurrence of each normalized URL)
                 allManga.forEach { manga ->
-                    var normalizedUrl = manga.url.trimEnd('/').substringBefore('#')
-
-                    if (removeDoubleSlashes) {
-                        val placeholder = "###PROTOCOL###"
-                        normalizedUrl = normalizedUrl.replace("://", placeholder)
-                        normalizedUrl = normalizedUrl.replace("//", "/")
-                        normalizedUrl = normalizedUrl.replace(placeholder, "://")
-                    }
+                    val normalizedUrl = normalizeUrlForMaintenance(manga.url, removeDoubleSlashes)
 
                     val key = manga.source to normalizedUrl
                     if (key !in seenNormalizedUrls) {
@@ -1599,14 +1629,7 @@ class MangaRepositoryImpl(
                 allManga.forEach { manga ->
                     if (!manga.favorite) return@forEach // Skip non-favorites
 
-                    var normalizedUrl = manga.url.trimEnd('/').substringBefore('#')
-
-                    if (removeDoubleSlashes) {
-                        val placeholder = "###PROTOCOL###"
-                        normalizedUrl = normalizedUrl.replace("://", placeholder)
-                        normalizedUrl = normalizedUrl.replace("//", "/")
-                        normalizedUrl = normalizedUrl.replace(placeholder, "://")
-                    }
+                    val normalizedUrl = normalizeUrlForMaintenance(manga.url, removeDoubleSlashes)
 
                     val key = manga.source to normalizedUrl
                     val firstOccurrenceId = seenNormalizedUrls[key]

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -45,6 +45,21 @@ JOIN mangas_categories MC
 ON C._id = MC.category_id
 WHERE MC.manga_id = :mangaId;
 
+-- Batch fetch categories for multiple manga IDs - optimized for duplicate detection
+getCategoriesByMangaIds:
+SELECT
+MC.manga_id,
+C._id AS id,
+C.name,
+C.sort AS `order`,
+C.flags,
+C.content_type
+FROM categories C
+JOIN mangas_categories MC
+ON C._id = MC.category_id
+WHERE MC.manga_id IN :mangaIds
+ORDER BY MC.manga_id, C.sort;
+
 getCategoriesByContentType:
 SELECT
 _id AS id,

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -757,3 +757,9 @@ getFavoriteIdAndTitle:
 SELECT _id, title
 FROM mangas
 WHERE favorite = 1;
+
+-- Lightweight row shape for URL maintenance operations
+-- (avoids decoding heavy text/list columns for large libraries)
+getAllMangaUrlMaintenanceRows:
+SELECT _id, source, url, title, favorite
+FROM mangas;

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -299,7 +299,7 @@ ORDER BY totalCount DESC;
 -- Uses same columns to keep SQLDelight column adapters working
 getMangaWithCountsLight:
 SELECT
-    M._id, M.source, M.url, M.artist, M.author, M.description, M.genre, M.title, M.alternative_titles, M.status, M.thumbnail_url, M.favorite, M.last_update, M.next_update, M.initialized, M.viewer, M.chapter_flags, M.cover_last_modified, M.date_added, M.update_strategy, M.calculate_interval, M.last_modified_at, M.favorite_modified_at, M.version, M.is_syncing, M.notes, M.is_novel,
+    M._id, M.source, M.url, M.artist, M.author, NULL AS description, NULL AS genre, M.title, NULL AS alternative_titles, M.status, M.thumbnail_url, M.favorite, M.last_update, M.next_update, M.initialized, M.viewer, M.chapter_flags, M.cover_last_modified, M.date_added, M.update_strategy, M.calculate_interval, M.last_modified_at, M.favorite_modified_at, M.version, M.is_syncing, '' AS notes, M.is_novel,
     COALESCE(CC.totalCount, 0) AS totalCount,
     COALESCE(CC.readCount, 0) AS readCount
 FROM mangas M

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/GetCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/GetCategories.kt
@@ -28,6 +28,10 @@ class GetCategories(
         return categoryRepository.getCategoriesByMangaId(mangaId)
     }
 
+    suspend fun awaitForMangas(mangaIds: List<Long>): Map<Long, List<Category>> {
+        return categoryRepository.getCategoriesByMangaIds(mangaIds)
+    }
+
     suspend fun awaitByContentType(contentType: Int): List<Category> {
         return categoryRepository.getCategoriesByContentType(contentType)
     }

--- a/domain/src/main/java/tachiyomi/domain/category/repository/CategoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/repository/CategoryRepository.kt
@@ -17,6 +17,12 @@ interface CategoryRepository {
     fun getCategoriesByMangaIdAsFlow(mangaId: Long): Flow<List<Category>>
 
     /**
+     * Batch fetch categories for multiple manga IDs. Returns a map of mangaId -> List<Category>.
+     * Optimized for duplicate detection and bulk operations.
+     */
+    suspend fun getCategoriesByMangaIds(mangaIds: List<Long>): Map<Long, List<Category>>
+
+    /**
      * Lightweight bulk query: returns all (manga_id, category_id) pairs.
      */
     suspend fun getAllMangaCategoryPairs(): List<Pair<Long, Long>>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -41,6 +41,7 @@
     <string name="chapter_progress_novel">%1$d%%</string>
     <!-- Library -->
     <string name="chapters_from_database">Chapter entries from database</string>
+    <string name="delete_local_novel_files">Delete local EPUB/HTML?</string>
     <!-- Browse Source -->
     <string name="local_novel_source">Local novels</string>
     <!-- History -->
@@ -217,6 +218,11 @@
     <string name="epub_import_complete">Import Complete</string>
     <string name="epub_import_success_count">%d imported successfully</string>
     <string name="epub_import_error_count">%d failed</string>
+
+    <!-- Duplicate detection -->
+    <string name="duplicate_flexible_group_matching">Flexible group matching (allow at least one match)</string>
+    <string name="duplicate_category_include_or">OR</string>
+    <string name="duplicate_category_include_and">AND</string>
     <string name="epub_create_dir_failed">Failed to create directory for: %s</string>
     <string name="epub_novels_export_count">%d novel(s) will be exported.</string>
     <string name="epub_and_more">… and %d more</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1213,7 +1213,7 @@
     <string name="pref_db_maintenance">Database maintenance</string>
     <string name="pref_db_maintenance_subtitle">ANALYZE, REINDEX, and VACUUM. VACUUM temporarily needs free space equal to the database size.</string>
     <string name="pref_bulk_remove_url">Bulk remove by URL</string>
-    <string name="pref_bulk_remove_url_subtitle">Remove multiple entries from library by URL list</string>
+    <string name="pref_bulk_remove_url_subtitle">Remove or move multiple entries from library by URL list</string>
 
     <!-- Translation queue / batch -->
     <string name="translation_all_downloaded_already_translated">All downloaded chapters are already translated</string>


### PR DESCRIPTION

Add multi file selection to massimport, improve file handling

In the advanced settings "Bulk Remove by URL" dialog, added the ability to move items to a selected category by URL.

Add And/Or filters in duplicate screen and optimize related queries
