### PR TITLE
Fix/epub chapter list parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Shiny new import EPUB process [@mrissaoussama](https://github.com/mrissaoussama) [#177](https://github.com/tsundoku-otaku/tsundoku/pull/177)
+- Better detection of chapter lists from EPUBs [@mrissaoussama](https://github.com/mrissaoussama) [#178](https://github.com/tsundoku-otaku/tsundoku/pull/178)
 - Duplicate screen and mass import [@mrissaoussama](https://github.com/mrissaoussama) [#163](https://github.com/tsundoku-otaku/tsundoku/pull/163)
 - Show include/exclude icon on tag chips [@mrissaoussama](https://github.com/mrissaoussama) [#168](https://github.com/tsundoku-otaku/tsundoku/pull/168)
 - Local novels now show under downloaded-only [@mrissaoussama](https://github.com/mrissaoussama) [#169](https://github.com/tsundoku-otaku/tsundoku/pull/169)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/ParseEpubPreview.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/ParseEpubPreview.kt
@@ -162,9 +162,16 @@ class ParseEpubPreview {
 
     fun defaultCustomTitleFromCandidates(candidates: List<TitleCandidate>): String {
         if (candidates.isEmpty()) return ""
-        if (candidates.size == 1) return candidates.first().title
+        if (candidates.size == 1) {
+            val first = candidates.first()
+            return first.title.trim().ifBlank {
+                first.fileName.substringBeforeLast('.', first.fileName)
+            }
+        }
 
-        val commonCollection = candidates.mapNotNull { it.collection }.distinct()
+        val commonCollection = candidates
+            .mapNotNull { it.collection?.trim()?.takeIf { collection -> collection.isNotEmpty() } }
+            .distinct()
         if (commonCollection.size == 1) return commonCollection.first()
 
         val first = candidates.first()

--- a/app/src/test/java/eu/kanade/domain/manga/interactor/ParseEpubPreviewTest.kt
+++ b/app/src/test/java/eu/kanade/domain/manga/interactor/ParseEpubPreviewTest.kt
@@ -55,4 +55,35 @@ class ParseEpubPreviewTest {
 
         assertEquals("first_book", parser.defaultCustomTitleFromCandidates(files))
     }
+
+    @Test
+    fun `defaultCustomTitle ignores blank collections`() {
+        val files = listOf(
+            ParseEpubPreview.TitleCandidate(
+                fileName = "pg57493-images-3.epub",
+                title = "Natural History",
+                collection = "   ",
+            ),
+            ParseEpubPreview.TitleCandidate(
+                fileName = "pg49008-images-3.epub",
+                title = "Pliny",
+                collection = "",
+            ),
+        )
+
+        assertEquals("pg57493-images-3", parser.defaultCustomTitleFromCandidates(files))
+    }
+
+    @Test
+    fun `defaultCustomTitle single candidate falls back to filename when title blank`() {
+        val files = listOf(
+            ParseEpubPreview.TitleCandidate(
+                fileName = "pg49008-images-3.epub",
+                title = "  ",
+                collection = null,
+            ),
+        )
+
+        assertEquals("pg49008-images-3", parser.defaultCustomTitleFromCandidates(files))
+    }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -7,11 +7,16 @@ import org.jsoup.parser.Parser
 import java.io.Closeable
 import java.io.File
 import java.io.InputStream
+import java.net.URLDecoder
 
 /**
  * Wrapper over ArchiveReader to load files in epub format.
  */
 class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
+
+    private fun String.urlDecoded(): String {
+        return runCatching { URLDecoder.decode(this, "UTF-8") }.getOrDefault(this)
+    }
 
     /**
      * Path separator used by this epub.
@@ -126,7 +131,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             .associateBy { it.attr("id") }
 
         val spine = document.select("spine > itemref").map { it.attr("idref") }
-        return spine.mapNotNull { pages[it] }.map { it.attr("href") }
+        return spine.mapNotNull { pages[it] }.map { it.attr("href").urlDecoded() }
     }
 
     /**
@@ -356,7 +361,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             val navElement = doc.selectFirst("nav[*|type=toc], nav#toc, nav[epub\\:type=toc]")
             navElement?.select("li a")?.forEachIndexed { index, element ->
                 val title = element.text().trim()
-                val href = element.attr("href").trim()
+                val href = element.attr("href").trim().urlDecoded()
                 if (title.isNotEmpty() && href.isNotEmpty()) {
                     // Resolve path and then restore fragment (if present).
                     val pathPart = href.substringBefore("#")
@@ -392,7 +397,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             val doc = Jsoup.parse(inputStream, null, "", Parser.xmlParser())
             doc.select("navPoint").forEachIndexed { index, navPoint ->
                 val title = navPoint.selectFirst("navLabel > text")?.text()?.trim() ?: ""
-                val href = navPoint.selectFirst("content")?.attr("src")?.trim() ?: ""
+                val href = navPoint.selectFirst("content")?.attr("src")?.trim()?.urlDecoded() ?: ""
                 if (title.isNotEmpty() && href.isNotEmpty()) {
                     // Resolve path and then restore fragment (if present).
                     val pathPart = href.substringBefore("#")
@@ -468,7 +473,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                     else -> return@forEach
                 }
 
-                val src = rawSrc.substringBefore("#").trim()
+                val src = rawSrc.substringBefore("#").trim().urlDecoded()
                 if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:")) {
                     return@forEach
                 }
@@ -509,7 +514,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             document.select("link[rel=stylesheet]").forEach { link ->
                 val href = link.attr("href")
                 if (href.isNotBlank()) {
-                    val cssPath = resolveZipPath(imageBasePath, href)
+                    val cssPath = resolveZipPath(imageBasePath, href.urlDecoded())
                     try {
                         getInputStream(cssPath)?.use { stream ->
                             var cssText = stream.reader().readText()
@@ -524,7 +529,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
 
                                 val cssDir = getParentDirectory(cssPath)
                                 val assetPath =
-                                    resolveZipPath(cssDir, assetUrl.substringBefore("?").substringBefore("#"))
+                                    resolveZipPath(cssDir, assetUrl.substringBefore("?").substringBefore("#").urlDecoded())
                                 inlineAssetAsDataUri(assetPath)?.let { "url('$it')" } ?: match.value
                             }
 
@@ -542,7 +547,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             document.select("script[src]").forEach { script ->
                 val src = script.attr("src")
                 if (src.isNotBlank() && !src.startsWith("http") && !src.startsWith("//")) {
-                    val jsPath = resolveZipPath(imageBasePath, src)
+                    val jsPath = resolveZipPath(imageBasePath, src.urlDecoded())
                     try {
                         getInputStream(jsPath)?.use { stream ->
                             val jsText = stream.reader().readText()

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -630,22 +630,41 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
     }
 
     private fun materializeFragmentElement(element: Element): String? {
+        findHeadingElement(element)?.let { heading ->
+            return extractHeadingSectionHtml(heading)
+        }
+
         if (isMeaningfulFragmentElement(element)) {
             return element.outerHtml()
         }
 
-        // Some EPUB TOCs point to empty anchors (e.g. <a id="..."></a>).
-        // Walk up to a meaningful container; otherwise return null and fall back
-        // to full body/document content.
-        var current: Element? = element.parent()
-        while (current != null && current.tagName() !in setOf("body", "html")) {
-            if (isMeaningfulFragmentElement(current)) {
-                return current.outerHtml()
+        return null
+    }
+
+    private fun findHeadingElement(element: Element): Element? {
+        return if (isHeadingTag(element.tagName())) {
+            element
+        } else {
+            element.parents().firstOrNull { isHeadingTag(it.tagName()) }
+        }
+    }
+
+    private fun extractHeadingSectionHtml(heading: Element): String? {
+        val headingLevel = heading.tagName().removePrefix("h").toIntOrNull() ?: return heading.outerHtml()
+        val section = Element("div")
+
+        var node: org.jsoup.nodes.Node? = heading
+        while (node != null) {
+            if (node !== heading && node is Element && isHeadingTag(node.tagName())) {
+                val siblingHeadingLevel = node.tagName().removePrefix("h").toIntOrNull() ?: Int.MAX_VALUE
+                if (siblingHeadingLevel <= headingLevel) break
             }
-            current = current.parent()
+
+            section.appendChild(node.clone())
+            node = node.nextSibling()
         }
 
-        return null
+        return section.html().ifBlank { heading.outerHtml() }
     }
 
     private fun isMeaningfulFragmentElement(element: Element): Boolean {
@@ -653,5 +672,9 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         if (text.length >= 80) return true
 
         return element.select("p, div, section, article, table, ul, ol, blockquote, pre, figure, img, svg").isNotEmpty()
+    }
+
+    private fun isHeadingTag(tagName: String): Boolean {
+        return tagName.length == 2 && tagName[0] == 'h' && tagName[1] in '1'..'6'
     }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -612,17 +612,46 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }.distinct()
 
         for (candidate in candidates) {
-            document.getElementById(candidate)?.outerHtml()?.let { return it }
+            document.getElementById(candidate)?.let { element ->
+                materializeFragmentElement(element)?.let { return it }
+            }
 
             val escaped = candidate
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"")
             document
                 .selectFirst("*[id=\"$escaped\"], *[name=\"$escaped\"]")
-                ?.outerHtml()
-                ?.let { return it }
+                ?.let { element ->
+                    materializeFragmentElement(element)?.let { return it }
+                }
         }
 
         return null
+    }
+
+    private fun materializeFragmentElement(element: Element): String? {
+        if (isMeaningfulFragmentElement(element)) {
+            return element.outerHtml()
+        }
+
+        // Some EPUB TOCs point to empty anchors (e.g. <a id="..."></a>).
+        // Walk up to a meaningful container; otherwise return null and fall back
+        // to full body/document content.
+        var current: Element? = element.parent()
+        while (current != null && current.tagName() !in setOf("body", "html")) {
+            if (isMeaningfulFragmentElement(current)) {
+                return current.outerHtml()
+            }
+            current = current.parent()
+        }
+
+        return null
+    }
+
+    private fun isMeaningfulFragmentElement(element: Element): Boolean {
+        val text = element.text().trim()
+        if (text.length >= 80) return true
+
+        return element.select("p, div, section, article, table, ul, ol, blockquote, pre, figure, img, svg").isNotEmpty()
     }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -291,10 +291,20 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         return pages.mapIndexed { index, page ->
             EpubChapter(
                 title = "Chapter ${index + 1}",
-                href = page,
+                href = resolveZipPath(opfBasePath, page),
                 order = index,
             )
         }
+    }
+
+    /**
+     * Returns XHTML resources listed in OPF spine, resolved to archive paths.
+     */
+    fun getSpinePageHrefs(): List<String> {
+        val ref = getPackageHref()
+        val doc = getPackageDocument(ref)
+        val opfBasePath = getParentDirectory(ref)
+        return getPagesFromDocument(doc).map { resolveZipPath(opfBasePath, it) }
     }
 
     /**

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -448,7 +448,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         useReaderImageScheme: Boolean,
         bodyOnly: Boolean,
     ): String {
-        val pathPart = chapterHref.substringBefore("#").trim()
+        val pathPart = chapterHref.substringBefore("#").trim().urlDecoded()
         val fragment = chapterHref.substringAfter("#", "").takeIf { it.isNotBlank() }
 
         val packagePath = getPackageHref()

--- a/source-local/build.gradle.kts
+++ b/source-local/build.gradle.kts
@@ -32,6 +32,14 @@ kotlin {
                 implementation(libs.bundles.serialization)
             }
         }
+
+        androidUnitTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.bundles.test)
+                runtimeOnly(libs.junit.platform.launcher)
+            }
+        }
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/EpubChapterListBuilder.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/EpubChapterListBuilder.kt
@@ -9,32 +9,90 @@ internal fun buildEpubChaptersFromToc(
     chapterFileNameWithoutExtension: String?,
     chapterLastModified: Long,
     tocChapters: List<EpubReader.EpubChapter>,
+    spinePageHrefs: List<String> = emptyList(),
     hasMultipleEpubFiles: Boolean,
 ): List<SChapter> {
-    if (tocChapters.isEmpty()) return emptyList()
+    if (tocChapters.isEmpty() && spinePageHrefs.isEmpty()) return emptyList()
 
     val emittedUrls = linkedSetOf<String>()
     var chapterNumber = 0
+    val chapters = mutableListOf<SChapter>()
 
-    return tocChapters.mapNotNull { tocEntry ->
-        val chapterHref = tocEntry.href.trim()
-        if (chapterHref.isBlank() || !emittedUrls.add(chapterHref)) {
-            return@mapNotNull null
-        }
+    fun addChapter(chapterHref: String, title: String?) {
+        val href = chapterHref.trim()
+        if (href.isBlank() || !emittedUrls.add(href)) return
 
         chapterNumber += 1
-        val resolvedTitle = tocEntry.title.trim().ifBlank { "Chapter $chapterNumber" }
+        val resolvedTitle = title?.trim().orEmpty().ifBlank { "Chapter $chapterNumber" }
         val chapterDisplayName = if (hasMultipleEpubFiles) {
             "${chapterFileNameWithoutExtension.orEmpty()} - $resolvedTitle"
         } else {
             resolvedTitle
         }
 
-        SChapter.create().apply {
-            url = "$mangaUrl/${chapterFileName.orEmpty()}#$chapterHref"
+        chapters += SChapter.create().apply {
+            url = "$mangaUrl/${chapterFileName.orEmpty()}#$href"
             name = chapterDisplayName
             date_upload = chapterLastModified
             chapter_number = chapterNumber.toFloat()
         }
     }
+
+    if (spinePageHrefs.isEmpty()) {
+        tocChapters.forEach { tocEntry ->
+            addChapter(tocEntry.href, tocEntry.title)
+        }
+        return chapters
+    }
+
+    val tocByPath = linkedMapOf<String, MutableList<EpubReader.EpubChapter>>()
+    tocChapters.forEach { tocEntry ->
+        val href = tocEntry.href.trim()
+        if (href.isBlank()) return@forEach
+        val path = href.substringBefore('#').trim()
+        if (path.isBlank()) return@forEach
+        tocByPath.getOrPut(path) { mutableListOf() }.add(tocEntry)
+    }
+
+    spinePageHrefs.forEach { spineHref ->
+        val spinePath = spineHref.substringBefore('#').trim()
+        if (spinePath.isBlank()) return@forEach
+
+        val pathTocEntries = tocByPath.remove(spinePath).orEmpty()
+        if (pathTocEntries.isNotEmpty()) {
+            pathTocEntries.forEach { tocEntry ->
+                addChapter(tocEntry.href, tocEntry.title)
+            }
+            return@forEach
+        }
+
+        if (isLikelyNavigationDocument(spinePath)) return@forEach
+
+        val fallbackTitle = spinePath.substringAfterLast('/')
+            .substringBeforeLast('.')
+            .replace('_', ' ')
+            .replace('-', ' ')
+            .trim()
+
+        addChapter(spinePath, fallbackTitle)
+    }
+
+    // Keep any TOC items that are not listed in OPF spine (rare but valid in malformed EPUBs).
+    tocByPath.values.flatten().forEach { tocEntry ->
+        addChapter(tocEntry.href, tocEntry.title)
+    }
+
+    return chapters
+}
+
+private fun isLikelyNavigationDocument(path: String): Boolean {
+    val lower = path.lowercase()
+    return lower.endsWith("/nav.xhtml") ||
+        lower.endsWith("/nav.html") ||
+        lower.endsWith("/toc.xhtml") ||
+        lower.endsWith("/toc.html") ||
+        lower == "nav.xhtml" ||
+        lower == "nav.html" ||
+        lower == "toc.xhtml" ||
+        lower == "toc.html"
 }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/EpubChapterListBuilder.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/EpubChapterListBuilder.kt
@@ -1,0 +1,40 @@
+package tachiyomi.source.local
+
+import eu.kanade.tachiyomi.source.model.SChapter
+import mihon.core.archive.EpubReader
+
+internal fun buildEpubChaptersFromToc(
+    mangaUrl: String,
+    chapterFileName: String?,
+    chapterFileNameWithoutExtension: String?,
+    chapterLastModified: Long,
+    tocChapters: List<EpubReader.EpubChapter>,
+    hasMultipleEpubFiles: Boolean,
+): List<SChapter> {
+    if (tocChapters.isEmpty()) return emptyList()
+
+    val emittedUrls = linkedSetOf<String>()
+    var chapterNumber = 0
+
+    return tocChapters.mapNotNull { tocEntry ->
+        val chapterHref = tocEntry.href.trim()
+        if (chapterHref.isBlank() || !emittedUrls.add(chapterHref)) {
+            return@mapNotNull null
+        }
+
+        chapterNumber += 1
+        val resolvedTitle = tocEntry.title.trim().ifBlank { "Chapter $chapterNumber" }
+        val chapterDisplayName = if (hasMultipleEpubFiles) {
+            "${chapterFileNameWithoutExtension.orEmpty()} - $resolvedTitle"
+        } else {
+            resolvedTitle
+        }
+
+        SChapter.create().apply {
+            url = "$mangaUrl/${chapterFileName.orEmpty()}#$chapterHref"
+            name = chapterDisplayName
+            date_upload = chapterLastModified
+            chapter_number = chapterNumber.toFloat()
+        }
+    }
+}

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -215,8 +215,6 @@ actual class LocalNovelSource(
             }
 
         val hasMultipleEpubFiles = chapterFiles.count { it.extension.equals("epub", true) } > 1
-        var orderedTocChapterNumber = 0
-
         chapterFiles.forEachIndexed { fileIndex, chapterFile ->
             // Check if this is a multi-chapter EPUB
             if (chapterFile.extension.equals("epub", true)) {
@@ -249,69 +247,18 @@ actual class LocalNovelSource(
                         }
 
                         val tocChapters = epub.getNormalizedTableOfContents()
-                        val spineHrefs = extractSpineHrefs(epub)
-                        val guideTitleByHref = extractGuideTitlesByHref(epub)
-
-                        // If EPUB has multiple TOC entries, build chapter list from spine order so
-                        // preface/cover/titlepage entries not present in ToC are still accessible.
-                        if (tocChapters.size > 1) {
-                            val tocByHrefKey = tocChapters
-                                .associateBy { it.href.substringBefore('#') }
-                                .toMutableMap()
-                            val emittedUrls = LinkedHashSet<String>()
-
-                            if (spineHrefs.isNotEmpty()) {
-                                spineHrefs.forEachIndexed { index, spineHref ->
-                                    val tocEntry = tocByHrefKey[spineHref.substringBefore('#')]
-                                    val chapterHref = tocEntry?.href ?: spineHref
-                                    if (!emittedUrls.add(chapterHref)) return@forEachIndexed
-
-                                    orderedTocChapterNumber += 1
-                                    val generatedTitle = tocEntry?.title
-                                        ?: guideTitleByHref[spineHref.substringBefore('#')]
-                                        ?: "Chapter 0.${index + 1}"
-                                    val chapterDisplayName = if (hasMultipleEpubFiles) {
-                                        "${chapterFile.nameWithoutExtension.orEmpty()} - $generatedTitle"
-                                    } else {
-                                        generatedTitle
-                                    }
-
-                                    allChapters.add(
-                                        SChapter.create().apply {
-                                            // URL format: novelDir/epubFile.epub#chapterHref
-                                            url = "${manga.url}/${chapterFile.name}#$chapterHref"
-                                            name = chapterDisplayName
-                                            date_upload = chapterFile.lastModified()
-                                            chapter_number = orderedTocChapterNumber.toFloat()
-                                        },
-                                    )
-                                }
-                            }
-
-                            // Keep any ToC-only entries that weren't part of the spine map.
-                            tocChapters.forEach { tocEntry ->
-                                if (!emittedUrls.add(tocEntry.href)) return@forEach
-
-                                orderedTocChapterNumber += 1
-
-                                val resolvedTitle = tocEntry.title.trim().ifBlank { "Chapter $orderedTocChapterNumber" }
-
-                                val chapterDisplayName = if (hasMultipleEpubFiles) {
-                                    "${chapterFile.nameWithoutExtension.orEmpty()} - $resolvedTitle"
-                                } else {
-                                    resolvedTitle
-                                }
-
-                                allChapters.add(
-                                    SChapter.create().apply {
-                                        url = "${manga.url}/${chapterFile.name}#${tocEntry.href}"
-                                        name = chapterDisplayName
-                                        date_upload = chapterFile.lastModified()
-                                        chapter_number = orderedTocChapterNumber.toFloat()
-                                    },
-                                )
-                            }
-                            return@forEachIndexed // Don't add the EPUB as a single chapter
+                        if (tocChapters.isNotEmpty()) {
+                            allChapters.addAll(
+                                buildEpubChaptersFromToc(
+                                    mangaUrl = manga.url,
+                                    chapterFileName = chapterFile.name,
+                                    chapterFileNameWithoutExtension = chapterFile.nameWithoutExtension.orEmpty(),
+                                    chapterLastModified = chapterFile.lastModified(),
+                                    tocChapters = tocChapters,
+                                    hasMultipleEpubFiles = hasMultipleEpubFiles,
+                                ),
+                            )
+                            return@forEachIndexed
                         }
 
                         // Single chapter EPUB - treat as before
@@ -358,50 +305,6 @@ actual class LocalNovelSource(
             chapter_number = ChapterRecognition
                 .parseChapterNumber(manga.title, this.name, this.chapter_number.toDouble())
                 .toFloat()
-        }
-    }
-
-    private fun extractSpineHrefs(epub: EpubReader): List<String> {
-        return runCatching {
-            val packageDoc = epub.getPackageDocument(epub.getPackageHref())
-            val manifest = packageDoc
-                .select("manifest > item[id]")
-                .associate { item ->
-                    item.attr("id") to item.attr("href")
-                }
-
-            packageDoc
-                .select("spine > itemref[idref]")
-                .mapNotNull { itemRef ->
-                    manifest[itemRef.attr("idref")]
-                }
-                .map { href -> href.trim() }
-                .filter { href -> href.isNotEmpty() }
-                .distinctBy { href -> href.substringBefore('#') }
-        }.getOrElse {
-            emptyList()
-        }
-    }
-
-    private fun extractGuideTitlesByHref(epub: EpubReader): Map<String, String> {
-        return runCatching {
-            val packageDoc = epub.getPackageDocument(epub.getPackageHref())
-            packageDoc
-                .select("guide > reference[href]")
-                .mapNotNull { ref ->
-                    val href = ref.attr("href").substringBefore('#').trim()
-                    val title = ref.attr("title").trim()
-                    if (href.isEmpty()) {
-                        null
-                    } else {
-                        href to if (title.isNotEmpty()) title else null
-                    }
-                }
-                .associate { (href, title) ->
-                    href to (title ?: href.substringAfterLast('/').substringBeforeLast('.').replace('_', ' '))
-                }
-        }.getOrElse {
-            emptyMap()
         }
     }
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -371,18 +371,10 @@ actual class LocalNovelSource(
                     chapterFile.epubReader(context).use { epub ->
                         if (chapterFragment != null) {
                             // Multi-chapter EPUB: read specific chapter
-                            val content = epub.getChapterContent(chapterFragment)
-                            logcat(LogPriority.DEBUG) {
-                                "TEMP EPUB DEBUG: file=${chapterFile.name.orEmpty()} fragmentPath=${chapterFragment.substringBefore('#')} textLength=${content.length}"
-                            }
-                            content
+                            epub.getChapterContent(chapterFragment)
                         } else {
                             // Single chapter EPUB: read all content
-                            val content = epub.getTextContent()
-                            logcat(LogPriority.DEBUG) {
-                                "TEMP EPUB DEBUG: file=${chapterFile.name.orEmpty()} fullTextLength=${content.length}"
-                            }
-                            content
+                            epub.getTextContent()
                         }
                     }
                 }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -248,6 +248,7 @@ actual class LocalNovelSource(
 
                         val tocChapters = epub.getNormalizedTableOfContents()
                         if (tocChapters.isNotEmpty()) {
+                            val spinePageHrefs = epub.getSpinePageHrefs()
                             allChapters.addAll(
                                 buildEpubChaptersFromToc(
                                     mangaUrl = manga.url,
@@ -255,6 +256,7 @@ actual class LocalNovelSource(
                                     chapterFileNameWithoutExtension = chapterFile.nameWithoutExtension.orEmpty(),
                                     chapterLastModified = chapterFile.lastModified(),
                                     tocChapters = tocChapters,
+                                    spinePageHrefs = spinePageHrefs,
                                     hasMultipleEpubFiles = hasMultipleEpubFiles,
                                 ),
                             )

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -371,10 +371,18 @@ actual class LocalNovelSource(
                     chapterFile.epubReader(context).use { epub ->
                         if (chapterFragment != null) {
                             // Multi-chapter EPUB: read specific chapter
-                            epub.getChapterContent(chapterFragment)
+                            val content = epub.getChapterContent(chapterFragment)
+                            logcat(LogPriority.DEBUG) {
+                                "TEMP EPUB DEBUG: file=${chapterFile.name.orEmpty()} fragmentPath=${chapterFragment.substringBefore('#')} textLength=${content.length}"
+                            }
+                            content
                         } else {
                             // Single chapter EPUB: read all content
-                            epub.getTextContent()
+                            val content = epub.getTextContent()
+                            logcat(LogPriority.DEBUG) {
+                                "TEMP EPUB DEBUG: file=${chapterFile.name.orEmpty()} fullTextLength=${content.length}"
+                            }
+                            content
                         }
                     }
                 }

--- a/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
+++ b/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
@@ -44,4 +44,86 @@ class EpubChapterListBuilderTest {
         assertEquals(2f, chapters[1].chapter_number)
         assertEquals(123456789L, chapters[0].date_upload)
     }
+
+    @Test
+    fun `buildEpubChaptersFromToc includes spine-only pages not in toc`() {
+        val tocChapters = listOf(
+            EpubReader.EpubChapter(
+                title = "PART ONE",
+                href = "Fahrenheit_451_split_001.html",
+                order = 0,
+            ),
+            EpubReader.EpubChapter(
+                title = "PART TWO",
+                href = "Fahrenheit_451_split_002.html",
+                order = 1,
+            ),
+            EpubReader.EpubChapter(
+                title = "PART THREE",
+                href = "Fahrenheit_451_split_003.html",
+                order = 2,
+            ),
+        )
+
+        val spinePages = listOf(
+            "titlepage.xhtml",
+            "Fahrenheit_451_split_000.html",
+            "Fahrenheit_451_split_001.html",
+            "Fahrenheit_451_split_002.html",
+            "Fahrenheit_451_split_003.html",
+            "Fahrenheit_451_split_004.html",
+        )
+
+        val chapters = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/f451",
+            chapterFileName = "f451.epub",
+            chapterFileNameWithoutExtension = "f451",
+            chapterLastModified = 123L,
+            tocChapters = tocChapters,
+            spinePageHrefs = spinePages,
+            hasMultipleEpubFiles = false,
+        )
+
+        assertEquals(6, chapters.size)
+        assertEquals("local-novels/f451/f451.epub#titlepage.xhtml", chapters[0].url)
+        assertEquals("local-novels/f451/f451.epub#Fahrenheit_451_split_000.html", chapters[1].url)
+        assertEquals("local-novels/f451/f451.epub#Fahrenheit_451_split_001.html", chapters[2].url)
+        assertEquals("local-novels/f451/f451.epub#Fahrenheit_451_split_002.html", chapters[3].url)
+        assertEquals("local-novels/f451/f451.epub#Fahrenheit_451_split_003.html", chapters[4].url)
+        assertEquals("local-novels/f451/f451.epub#Fahrenheit_451_split_004.html", chapters[5].url)
+
+        assertEquals("titlepage", chapters[0].name)
+        assertEquals("Fahrenheit 451 split 000", chapters[1].name)
+        assertEquals("PART ONE", chapters[2].name)
+        assertEquals("PART TWO", chapters[3].name)
+        assertEquals("PART THREE", chapters[4].name)
+        assertEquals("Fahrenheit 451 split 004", chapters[5].name)
+    }
+
+    @Test
+    fun `buildEpubChaptersFromToc skips navigation docs in spine when not in toc`() {
+        val chapters = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/book",
+            chapterFileName = "volume.epub",
+            chapterFileNameWithoutExtension = "volume",
+            chapterLastModified = 1L,
+            tocChapters = listOf(
+                EpubReader.EpubChapter(
+                    title = "Chapter 1",
+                    href = "text/chapter1.xhtml",
+                    order = 0,
+                ),
+            ),
+            spinePageHrefs = listOf(
+                "nav.xhtml",
+                "toc.xhtml",
+                "text/chapter1.xhtml",
+            ),
+            hasMultipleEpubFiles = false,
+        )
+
+        assertEquals(1, chapters.size)
+        assertEquals("local-novels/book/volume.epub#text/chapter1.xhtml", chapters[0].url)
+        assertEquals("Chapter 1", chapters[0].name)
+    }
 }

--- a/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
+++ b/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
@@ -1,0 +1,47 @@
+package tachiyomi.source.local
+
+import mihon.core.archive.EpubReader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EpubChapterListBuilderTest {
+
+    @Test
+    fun `buildEpubChaptersFromToc preserves fragment-based chapters`() {
+        val tocChapters = listOf(
+            EpubReader.EpubChapter(
+                title = "Capitolo 1",
+                href = "chapter.xhtml#one",
+                order = 0,
+            ),
+            EpubReader.EpubChapter(
+                title = "Capitolo 1",
+                href = "chapter.xhtml#one",
+                order = 1,
+            ),
+            EpubReader.EpubChapter(
+                title = "Capitolo 2",
+                href = "chapter.xhtml#two",
+                order = 2,
+            ),
+        )
+
+        val chapters = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/book",
+            chapterFileName = "volume.epub",
+            chapterFileNameWithoutExtension = "volume",
+            chapterLastModified = 123456789L,
+            tocChapters = tocChapters,
+            hasMultipleEpubFiles = false,
+        )
+
+        assertEquals(2, chapters.size)
+        assertEquals("local-novels/book/volume.epub#chapter.xhtml#one", chapters[0].url)
+        assertEquals("local-novels/book/volume.epub#chapter.xhtml#two", chapters[1].url)
+        assertEquals("Capitolo 1", chapters[0].name)
+        assertEquals("Capitolo 2", chapters[1].name)
+        assertEquals(1f, chapters[0].chapter_number)
+        assertEquals(2f, chapters[1].chapter_number)
+        assertEquals(123456789L, chapters[0].date_upload)
+    }
+}


### PR DESCRIPTION

**EPUB chapter extraction improvements:**

* Added a new utility function `buildEpubChaptersFromToc` in `EpubChapterListBuilder.kt` to generate chapter lists from the EPUB TOC and spine, handling edge cases like duplicate fragments and spine-only pages not present in the TOC.
* Added tests