### PR TITLE
Implement `end()` and link previous selection in JS Cheerio wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Fixed issue where some chapters wouldn't be marked read [@mrissaoussama](https://github.com/mrissaoussama) [#148](https://github.com/tsundoku-otaku/tsundoku/pull/148)
+- JS Plugins can now use `end()` [@mrissaoussama](https://github.com/mrissaoussama) [#184](https://github.com/tsundoku-otaku/tsundoku/pull/184)
 - Added padding to edit mode to prevent keyboard overlap [@mrissaoussama](https://github.com/mrissaoussama) [#171](https://github.com/tsundoku-otaku/tsundoku/pull/171)
 - Fixed MAL login [@mrissaoussama](https://github.com/mrissaoussama) [#174](https://github.com/tsundoku-otaku/tsundoku/pull/174)
 - Webview scrollbar [@mrissaoussama](https://github.com/mrissaoussama) [#183](https://github.com/tsundoku-otaku/tsundoku/pull/183)

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
@@ -1165,7 +1165,9 @@ class JSLibraryProvider(
                 find: function(s) {
                     // If s is a wrapped cheerio object, return it directly
                     if (s && s._h !== undefined) return s;
-                    return __wrapHandle(__cheerioSelect(h, typeof s === 'string' ? s : ''));
+                    var next = __wrapHandle(__cheerioSelect(h, typeof s === 'string' ? s : ''));
+                    next._prev = this;
+                    return next;
                 },
                 text: function() { return __cheerioText(h); },
                 html: function() { return __cheerioHtml(h); },
@@ -1274,7 +1276,7 @@ class JSLibraryProvider(
                 removeClass: function() { return this; },
                 replaceWith: function(content) { if (typeof content === 'string') { __cheerioAfter(h, content); __cheerioRemove(h); } return this; },
                 addBack: function() { return this; },
-                end: function() { return this; },
+                end: function() { return this._prev || this; },
                 slice: function(start, end) {
                     var arr = this.toArray();
                     return __arrayToCheerio(arr.slice(start, end));

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -807,8 +807,14 @@ class JsSource(
                 title = obj["name"]?.jsonPrimitive?.content?.decodeEntities() ?: existing.title
                 author = obj["author"]?.jsonPrimitive?.content?.decodeEntities() ?: existing.author
                 artist = obj["artist"]?.jsonPrimitive?.content?.decodeEntities()
-                description = normalizeHtmlDescription(obj["summary"]?.jsonPrimitive?.content)
+                description = normalizeHtmlDescription(
+                    obj["summary"]?.jsonPrimitive?.content
+                        ?: obj["desc"]?.jsonPrimitive?.content
+                        ?: obj["description"]?.jsonPrimitive?.content,
+                )
                 genre = obj["genres"]?.jsonPrimitive?.content?.decodeEntities()
+                    ?: obj["tags"]?.jsonPrimitive?.content?.decodeEntities()
+                    ?: obj["genre"]?.jsonPrimitive?.content?.decodeEntities()
                 // Parse alternative names if available
                 val altNames = obj["alternativeNames"]?.jsonPrimitive?.content?.decodeEntities()
                     ?: obj["altNames"]?.jsonPrimitive?.content?.decodeEntities()


### PR DESCRIPTION
fixes some js plugins using end() causing JsSource to return unintended element contents