### PR TITLE
fix(library): properly handle download count and badge visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - JS Plugins can now use `end()` [@mrissaoussama](https://github.com/mrissaoussama) [#184](https://github.com/tsundoku-otaku/tsundoku/pull/184)
 - Added padding to edit mode to prevent keyboard overlap [@mrissaoussama](https://github.com/mrissaoussama) [#171](https://github.com/tsundoku-otaku/tsundoku/pull/171)
 - Fixed MAL login [@mrissaoussama](https://github.com/mrissaoussama) [#174](https://github.com/tsundoku-otaku/tsundoku/pull/174)
+- Download count badge and its visibility [@mrissaoussama](https://github.com/mrissaoussama) [#194](https://github.com/tsundoku-otaku/tsundoku/pull/194)
 - Webview scrollbar [@mrissaoussama](https://github.com/mrissaoussama) [#183](https://github.com/tsundoku-otaku/tsundoku/pull/183)
 - Snippet code field should focus when editing [@mrissaoussama](https://github.com/mrissaoussama) [#167](https://github.com/tsundoku-otaku/tsundoku/pull/167)
 - JS Plugin entries now refresh with global updates [@mrissaoussama](https://github.com/mrissaoussama) [#151](https://github.com/tsundoku-otaku/tsundoku/pull/151)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -326,7 +326,10 @@ class LibraryScreenModel(
         val result = fastFilter {
             // Quick exit for some checks that are fast
             val downloadPasses = applyFilter(filterDownloaded) {
-                it.libraryManga.manga.isLocal() || it.libraryManga.manga.isLocalNovel() || it.downloadCount > 0
+                it.libraryManga.manga.isLocal() ||
+                    it.libraryManga.manga.isLocalNovel() ||
+                    it.downloadCount > 0 ||
+                    downloadManager.getDownloadCount(it.libraryManga.manga) > 0
             }
             if (!downloadPasses) return@fastFilter false
 
@@ -650,10 +653,15 @@ class LibraryScreenModel(
                     LibraryType.Novel -> if (!manga.manga.isNovel) continue
                 }
 
-                val dlCount = downloadManager.getDownloadCount(manga.manga).toLong()
-
                 val cached = itemCache[manga.id]
                 val cachedRef = itemCacheMangaRef[manga.id]
+
+                val dlCount = if (preferences.downloadBadge) {
+                    downloadManager.getDownloadCount(manga.manga).toLong()
+                } else {
+                    0L
+                }
+
                 if (cached != null && cachedRef === manga && cached.downloadCount == dlCount) {
                     result.add(cached)
                     continue
@@ -695,11 +703,13 @@ class LibraryScreenModel(
 
     private fun getLibraryDisplayPreferencesFlow(): Flow<DisplayPreferences> {
         return combine(
+            libraryPreferences.downloadBadge.changes(),
             libraryPreferences.unreadBadge.changes(),
             libraryPreferences.localBadge.changes(),
             libraryPreferences.languageBadge.changes(),
-        ) { unreadBadge, localBadge, languageBadge ->
+        ) { downloadBadge, unreadBadge, localBadge, languageBadge ->
             DisplayPreferences(
+                downloadBadge = downloadBadge,
                 unreadBadge = unreadBadge,
                 localBadge = localBadge,
                 languageBadge = languageBadge,
@@ -1701,6 +1711,7 @@ class LibraryScreenModel(
 
     @Immutable
     private data class DisplayPreferences(
+        val downloadBadge: Boolean,
         val unreadBadge: Boolean,
         val localBadge: Boolean,
         val languageBadge: Boolean,


### PR DESCRIPTION
* Update `fastFilter` to include `downloadManager` count when filtering for downloaded items.
* Conditionalize `dlCount` calculation based on the `downloadBadge` preference to optimize item mapping.
* Add `downloadBadge` to `DisplayPreferences` to ensure the library UI reacts to preference changes.

Fixes #191 
