### PR TITLE
Revert MD reversion in #182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Added padding to edit mode to prevent keyboard overlap [@mrissaoussama](https://github.com/mrissaoussama) [#171](https://github.com/tsundoku-otaku/tsundoku/pull/171)
 - Fixed MAL login [@mrissaoussama](https://github.com/mrissaoussama) [#174](https://github.com/tsundoku-otaku/tsundoku/pull/174)
 - Webview scrollbar [@mrissaoussama](https://github.com/mrissaoussama) [#183](https://github.com/tsundoku-otaku/tsundoku/pull/183)
+- Fix added MD support (accidental reversion)  [@Rojikku](https://github.com/Rojikku) [#195](https://github.com/tsundoku-otaku/tsundoku/pull/195)
 - Snippet code field should focus when editing [@mrissaoussama](https://github.com/mrissaoussama) [#167](https://github.com/tsundoku-otaku/tsundoku/pull/167)
 - JS Plugin entries now refresh with global updates [@mrissaoussama](https://github.com/mrissaoussama) [#151](https://github.com/tsundoku-otaku/tsundoku/pull/151)
 - JS when using infinite scroll now applies [@mrissaoussama](https://github.com/mrissaoussama) [#162](https://github.com/tsundoku-otaku/tsundoku/pull/162)

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -88,15 +88,16 @@ actual class LocalNovelSource(
             0L
         }
 
-        var novelDirs = fileSystem.getFilesInBaseDirectory()
-            // Filter out files that are hidden and is not a folder
-            .filter { it.isDirectory && !it.name.orEmpty().startsWith('.') }
-            .distinctBy { it.name }
+        var novelEntries = fileSystem.getFilesInBaseDirectory()
+            .filterNot { it.name.orEmpty().startsWith('.') }
+            .filter { it.isDirectory || isChapterSupported(it) }
+            .distinctBy { it.name.orEmpty() }
             .filter {
+                val displayTitle = if (it.isDirectory) it.name.orEmpty() else it.nameWithoutExtension.orEmpty()
                 if (lastModifiedLimit == 0L && query.isBlank()) {
                     true
                 } else if (lastModifiedLimit == 0L) {
-                    it.name.orEmpty().contains(query, ignoreCase = true)
+                    displayTitle.contains(query, ignoreCase = true)
                 } else {
                     it.lastModified() >= lastModifiedLimit
                 }
@@ -105,17 +106,21 @@ actual class LocalNovelSource(
         filters.forEach { filter ->
             when (filter) {
                 is OrderBy.Popular -> {
-                    novelDirs = if (filter.state!!.ascending) {
-                        novelDirs.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name.orEmpty() })
+                    novelEntries = if (filter.state!!.ascending) {
+                        novelEntries.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) {
+                            if (it.isDirectory) it.name.orEmpty() else it.nameWithoutExtension.orEmpty()
+                        })
                     } else {
-                        novelDirs.sortedWith(compareByDescending(String.CASE_INSENSITIVE_ORDER) { it.name.orEmpty() })
+                        novelEntries.sortedWith(compareByDescending(String.CASE_INSENSITIVE_ORDER) {
+                            if (it.isDirectory) it.name.orEmpty() else it.nameWithoutExtension.orEmpty()
+                        })
                     }
                 }
                 is OrderBy.Latest -> {
-                    novelDirs = if (filter.state!!.ascending) {
-                        novelDirs.sortedBy(UniFile::lastModified)
+                    novelEntries = if (filter.state!!.ascending) {
+                        novelEntries.sortedBy(UniFile::lastModified)
                     } else {
-                        novelDirs.sortedByDescending(UniFile::lastModified)
+                        novelEntries.sortedByDescending(UniFile::lastModified)
                     }
                 }
                 else -> {
@@ -124,15 +129,20 @@ actual class LocalNovelSource(
             }
         }
 
-        val novels = novelDirs
-            .map { novelDir ->
+        val novels = novelEntries
+            .map { novelEntry ->
                 async {
                     SManga.create().apply {
-                        title = novelDir.name.orEmpty()
-                        url = novelDir.name.orEmpty()
+                        title = if (novelEntry.isDirectory) {
+                            novelEntry.name.orEmpty()
+                        } else {
+                            novelEntry.nameWithoutExtension.orEmpty()
+                        }
+                        // Keep URL as the exact entry name so both directories and files can resolve.
+                        url = novelEntry.name.orEmpty()
 
                         // Try to find the cover
-                        coverManager.find(novelDir.name.orEmpty())?.let {
+                        coverManager.find(url)?.let {
                             thumbnail_url = it.uri.toString()
                         }
                     }
@@ -151,29 +161,41 @@ actual class LocalNovelSource(
 
         // Augment novel details based on metadata files
         try {
-            val novelDir = fileSystem.getNovelDirectory(manga.url) ?: error("${manga.url} is not a valid directory")
-            val novelDirFiles = novelDir.listFiles().orEmpty()
+            val novelEntry = resolveNovelEntry(manga.url) ?: error("${manga.url} is not a valid local novel entry")
+            if (novelEntry.isDirectory) {
+                val novelDirFiles = novelEntry.listFiles().orEmpty()
 
-            val comicInfoFile = novelDirFiles
-                .firstOrNull { it.name == COMIC_INFO_FILE }
-            val legacyJsonDetailsFile = novelDirFiles
-                .firstOrNull { it.extension == "json" }
+                val comicInfoFile = novelDirFiles
+                    .firstOrNull { it.name == COMIC_INFO_FILE }
+                val legacyJsonDetailsFile = novelDirFiles
+                    .firstOrNull { it.extension == "json" }
 
-            when {
-                // Top level ComicInfo.xml
-                comicInfoFile != null -> {
-                    setNovelDetailsFromComicInfoFile(comicInfoFile.openInputStream(), manga)
+                when {
+                    // Top level ComicInfo.xml
+                    comicInfoFile != null -> {
+                        setNovelDetailsFromComicInfoFile(comicInfoFile.openInputStream(), manga)
+                    }
+
+                    // Old custom JSON format
+                    legacyJsonDetailsFile != null -> {
+                        json.decodeFromStream<MangaDetails>(legacyJsonDetailsFile.openInputStream()).run {
+                            title?.let { manga.title = it }
+                            author?.let { manga.author = it }
+                            artist?.let { manga.artist = it }
+                            description?.let { manga.description = it }
+                            genre?.let { manga.genre = it.joinToString() }
+                            status?.let { manga.status = it }
+                        }
+                    }
                 }
-
-                // Old custom JSON format
-                legacyJsonDetailsFile != null -> {
-                    json.decodeFromStream<MangaDetails>(legacyJsonDetailsFile.openInputStream()).run {
-                        title?.let { manga.title = it }
-                        author?.let { manga.author = it }
-                        artist?.let { manga.artist = it }
-                        description?.let { manga.description = it }
-                        genre?.let { manga.genre = it.joinToString() }
-                        status?.let { manga.status = it }
+            } else if (novelEntry.extension.equals("epub", true)) {
+                novelEntry.epubReader(context).use { epub ->
+                    val chapter = SChapter.create().apply {
+                        name = novelEntry.nameWithoutExtension.orEmpty()
+                    }
+                    epub.fillMetadata(manga, chapter)
+                    if (manga.title.isBlank()) {
+                        manga.title = chapter.name
                     }
                 }
             }
@@ -206,17 +228,25 @@ actual class LocalNovelSource(
     override suspend fun getChapterList(manga: SManga): List<SChapter> = withIOContext {
         val allChapters = mutableListOf<SChapter>()
 
-        val chapterFiles = fileSystem.getFilesInNovelDirectory(manga.url)
-            // Only keep supported formats
-            .filterNot { it.name.orEmpty().startsWith('.') }
-            .filter { isChapterSupported(it) }
-            .sortedWith { f1, f2 ->
-                f1.name.orEmpty().compareToCaseInsensitiveNaturalOrder(f2.name.orEmpty())
-            }
+        val novelEntry = resolveNovelEntry(manga.url)
+            ?: return@withIOContext emptyList()
+
+        val chapterFiles = if (novelEntry.isDirectory) {
+            fileSystem.getFilesInNovelDirectory(manga.url)
+                .filterNot { it.name.orEmpty().startsWith('.') }
+                .filter { isChapterSupported(it) }
+                .sortedWith { f1, f2 ->
+                    f1.name.orEmpty().compareToCaseInsensitiveNaturalOrder(f2.name.orEmpty())
+                }
+        } else {
+            listOf(novelEntry)
+        }
+
+        val isSingleFileNovel = !novelEntry.isDirectory
 
         val hasMultipleEpubFiles = chapterFiles.count { it.extension.equals("epub", true) } > 1
-        var epubFileIndex = 0
-        chapterFiles.forEachIndexed { fileIndex, chapterFile ->
+
+        chapterFiles.forEachIndexed { _, chapterFile ->
             // Check if this is a multi-chapter EPUB
             if (chapterFile.extension.equals("epub", true)) {
                 try {
@@ -250,11 +280,6 @@ actual class LocalNovelSource(
                         val tocChapters = epub.getNormalizedTableOfContents()
                         if (tocChapters.isNotEmpty()) {
                             val spinePageHrefs = epub.getSpinePageHrefs()
-                            val chapterNumberOffset = if (hasMultipleEpubFiles) {
-                                epubFileIndex * 100_000f
-                            } else {
-                                0f
-                            }
                             allChapters.addAll(
                                 buildEpubChaptersFromToc(
                                     mangaUrl = manga.url,
@@ -264,10 +289,8 @@ actual class LocalNovelSource(
                                     tocChapters = tocChapters,
                                     spinePageHrefs = spinePageHrefs,
                                     hasMultipleEpubFiles = hasMultipleEpubFiles,
-                                    chapterNumberOffset = chapterNumberOffset,
                                 ),
                             )
-                            epubFileIndex++
                             return@forEachIndexed
                         }
 
@@ -283,13 +306,11 @@ actual class LocalNovelSource(
                                 epub.fillMetadata(manga, this)
                             },
                         )
-                        epubFileIndex++
                     }
                 } catch (e: Throwable) {
                     logcat(LogPriority.ERROR, e) { "Error reading epub for ${chapterFile.name}" }
                     // Fallback: add as single chapter
                     allChapters.add(createSimpleChapter(manga, chapterFile))
-                    epubFileIndex++
                 }
             } else {
                 // Non-EPUB file/directory
@@ -349,15 +370,12 @@ actual class LocalNovelSource(
     override suspend fun fetchPageText(page: Page): String = withIOContext {
         try {
             // Check if URL contains a chapter fragment (for multi-chapter EPUBs)
-            // Format: novelDir/epubFile.epub#chapterHref
+            // Format: novelDir/file.ext#chapterHref or file.ext#chapterHref
             val urlParts = page.url.split("#", limit = 2)
             val filePath = urlParts[0]
             val chapterFragment = urlParts.getOrNull(1)
 
-            val (novelDirName, chapterName) = filePath.split('/', limit = 2)
-            val chapterFile = fileSystem.getBaseDirectory()
-                ?.findFile(novelDirName)
-                ?.findFile(chapterName)
+            val chapterFile = resolveChapterFile(filePath)
                 ?: throw Exception(context.stringResource(MR.strings.chapter_not_found))
 
             when {
@@ -420,10 +438,7 @@ actual class LocalNovelSource(
         try {
             val urlParts = chapter.url.split("#", limit = 2)
             val filePath = urlParts[0]
-            val (novelDirName, chapterName) = filePath.split('/', limit = 2)
-            val chapterFile = fileSystem.getBaseDirectory()
-                ?.findFile(novelDirName)
-                ?.findFile(chapterName)
+            val chapterFile = resolveChapterFile(filePath)
                 ?: return@withIOContext null
 
             when {
@@ -466,12 +481,9 @@ actual class LocalNovelSource(
 
     fun getFormat(chapter: SChapter): Format {
         try {
-            val filePath = chapter.url.substringBefore("#")
-            val (novelDirName, chapterName) = filePath.split('/', limit = 2)
-            return fileSystem.getBaseDirectory()
-                ?.findFile(novelDirName)
-                ?.findFile(chapterName)
-                ?.let(Format.Companion::valueOf)
+            val filePath = chapter.url.substringBefore('#')
+            return resolveChapterFile(filePath)
+                ?.let(Format::valueOf)
                 ?: throw Exception(context.stringResource(MR.strings.chapter_not_found))
         } catch (e: Format.UnknownFormatException) {
             throw Exception(context.stringResource(MR.strings.local_invalid_format))
@@ -488,6 +500,7 @@ actual class LocalNovelSource(
 
         private val SUPPORTED_EXTENSIONS = setOf(
             "txt", "text", // Plain text
+            "md", "markdown", // Markdown
             "html", "htm", "xhtml", // HTML
             "epub", // EPUB
             "zip", "cbz", // ZIP archives
@@ -497,11 +510,32 @@ actual class LocalNovelSource(
         private val TEXT_EXTENSIONS = setOf(
             "txt",
             "text",
+            "md",
+            "markdown",
             "html",
             "htm",
             "xhtml",
         )
 
+    }
+
+    private fun resolveNovelEntry(url: String): UniFile? {
+        val base = fileSystem.getBaseDirectory() ?: return null
+        return base.findFile(url)
+            ?: base.listFiles().orEmpty().firstOrNull {
+                !it.isDirectory && it.nameWithoutExtension.orEmpty().equals(url, ignoreCase = true)
+            }
+    }
+
+    private fun resolveChapterFile(filePath: String): UniFile? {
+        val base = fileSystem.getBaseDirectory() ?: return null
+
+        return if (filePath.contains('/')) {
+            val (novelDirName, chapterName) = filePath.split('/', limit = 2)
+            base.findFile(novelDirName)?.findFile(chapterName)
+        } else {
+            resolveNovelEntry(filePath)
+        }
     }
 }
 


### PR DESCRIPTION
#182 breaks markdown support through accidental reversion.
This reverts *all* changes to `LocalNovelSource.kt` back to the version that supported markdown.

I did a visual and none of the changes looked relevant to the functionality of #182, but please review.