### PR TITLE
fix: implement novel-specific keep screen on setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Hide manga should hide manga-only screens from search index [@mrissaoussama](https://github.com/mrissaoussama) [#172](https://github.com/tsundoku-otaku/tsundoku/pull/172)
 - Visual feedback for tag/extension refreshes [@mrissaoussama](https://github.com/mrissaoussama) [#150](https://github.com/tsundoku-otaku/tsundoku/pull/150)
 - Paragraph auto-split [@mrissaoussama](https://github.com/mrissaoussama) [#162](https://github.com/tsundoku-otaku/tsundoku/pull/162)
+- Novel-specific keep screen on setting [@mrissaoussama](https://github.com/mrissaoussama) [#199](https://github.com/tsundoku-otaku/tsundoku/pull/199)
 
 
 ### Fixed

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1625,7 +1625,17 @@ class ReaderActivity : BaseActivity() {
                 .onEach(::setNovelCustomBrightness)
                 .launchIn(lifecycleScope)
 
-            // Apply novel brightness when viewer changes to a novel viewer
+            // Novel-specific keep screen on
+            readerPreferences.novelKeepScreenOn.changes()
+                .onEach { enabled ->
+                    val viewer = viewModel.state.value.viewer
+                    if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
+                        setKeepScreenOn(enabled)
+                    }
+                }
+                .launchIn(lifecycleScope)
+
+            // Apply novel brightness and keep screen on when viewer changes to a novel viewer
             viewModel.state
                 .map { it.viewer }
                 .distinctUntilChanged()
@@ -1633,6 +1643,10 @@ class ReaderActivity : BaseActivity() {
                 .onEach { viewer ->
                     if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
                         setNovelCustomBrightness(readerPreferences.novelCustomBrightness.get())
+                        setKeepScreenOn(readerPreferences.novelKeepScreenOn.get())
+                    } else {
+                        // Switch back to manga reader settings for non-novel viewers
+                        setKeepScreenOn(readerPreferences.keepScreenOn.get())
                     }
                 }
                 .launchIn(lifecycleScope)


### PR DESCRIPTION

- Add logic to track and apply `novelKeepScreenOn` preference when using novel viewers.
- Ensure the screen-on state reverts to standard manga reader settings when switching away from novel viewers.
- Update `ReaderActivity` to reactively handle both preference changes and viewer transitions for screen-on state.