### PR TITLE
feat: implement customizable tap-zone navigation for novel viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Tap zones for novels [@mrissaoussama](https://github.com/mrissaoussama) [#210](https://github.com/tsundoku-otaku/tsundoku/pull/210)
+
 ### Improved
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)
 - Novel description screen now supports novel searches when tapping novel title [@mrissaoussama](https://github.com/mrissaoussama) [#207](https://github.com/tsundoku-otaku/tsundoku/pull/207)

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -566,16 +566,17 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
         }
 
         // Add explicit center-only mode (small center tap shows app bars)
-        val centerIndex = ReaderPreferences.TapZones.size
         FilterChip(
-            selected = navigationModeNovel == centerIndex,
-            onClick = { screenModel.preferences.navigationModeNovel.set(centerIndex) },
-            label = { Text("Center only") },
+            selected = navigationModeNovel == ReaderPreferences.TAPZONE_CENTER_INDEX,
+            onClick = { screenModel.preferences.navigationModeNovel.set(ReaderPreferences.TAPZONE_CENTER_INDEX) },
+            label = { Text(stringResource(TDMR.strings.novel_nav_center_only)) },
         )
     }
 
     // Show invert options only when navigation is not disabled or center-only
-    if (navigationModeNovel != 5 && navigationModeNovel != ReaderPreferences.TapZones.size) {
+    if (navigationModeNovel != ReaderPreferences.TAPZONE_DISABLED_INDEX &&
+        navigationModeNovel != ReaderPreferences.TAPZONE_CENTER_INDEX
+    ) {
         Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
             Text(stringResource(MR.strings.pref_read_with_tapping_inverted), style = MaterialTheme.typography.bodyMedium)
             SettingsChipRow("") {

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.data.font.FontManager
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -552,11 +553,42 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
         pref = screenModel.preferences.novelVolumeKeysScroll,
     )
 
-    // Tap to Scroll
-    CheckboxItem(
-        label = stringResource(TDMR.strings.pref_novel_tap_to_scroll),
-        pref = screenModel.preferences.novelTapToScroll,
-    )
+    // Tap-zone navigation settings for novel viewer
+    val navigationModeNovel by screenModel.preferences.navigationModeNovel.collectAsState()
+    val novelNavInverted by screenModel.preferences.novelNavInverted.collectAsState()
+    SettingsChipRow(MR.strings.pref_viewer_nav) {
+        ReaderPreferences.TapZones.forEachIndexed { idx, res ->
+            FilterChip(
+                selected = navigationModeNovel == idx,
+                onClick = { screenModel.preferences.navigationModeNovel.set(idx) },
+                label = { Text(stringResource(res)) },
+            )
+        }
+
+        // Add explicit center-only mode (small center tap shows app bars)
+        val centerIndex = ReaderPreferences.TapZones.size
+        FilterChip(
+            selected = navigationModeNovel == centerIndex,
+            onClick = { screenModel.preferences.navigationModeNovel.set(centerIndex) },
+            label = { Text("Center only") },
+        )
+    }
+
+    // Show invert options only when navigation is not disabled or center-only
+    if (navigationModeNovel != 5 && navigationModeNovel != ReaderPreferences.TapZones.size) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+            Text(stringResource(MR.strings.pref_read_with_tapping_inverted), style = MaterialTheme.typography.bodyMedium)
+            SettingsChipRow("") {
+                ReaderPreferences.TappingInvertMode.entries.forEach { entry ->
+                    FilterChip(
+                        selected = entry == novelNavInverted,
+                        onClick = { screenModel.preferences.novelNavInverted.set(entry) },
+                        label = { Text(stringResource(entry.titleRes)) },
+                    )
+                }
+            }
+        }
+    }
 
     // Swipe Navigation
     CheckboxItem(
@@ -586,34 +618,37 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
         stringResource(TDMR.strings.novel_vertical_scrollbar_left) to "vertical_left",
         stringResource(TDMR.strings.novel_vertical_scrollbar_right) to "vertical_right",
     )
-    InlineSettingsChipRow(TDMR.strings.pref_novel_scrollbar_mode) {
-        scrollbarModeOptions.map { (label, value) ->
-            FilterChip(
-                selected = scrollbarMode == value,
-                onClick = {
-                    when (value) {
-                        "none" -> {
-                            screenModel.preferences.novelShowProgressSlider.set(false)
-                            screenModel.preferences.novelVerticalScrollbar.set(false)
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Text(stringResource(TDMR.strings.pref_novel_scrollbar_mode), style = MaterialTheme.typography.bodyMedium)
+        SettingsChipRow("") {
+            scrollbarModeOptions.forEach { (label, value) ->
+                FilterChip(
+                    selected = scrollbarMode == value,
+                    onClick = {
+                        when (value) {
+                            "none" -> {
+                                screenModel.preferences.novelShowProgressSlider.set(false)
+                                screenModel.preferences.novelVerticalScrollbar.set(false)
+                            }
+                            "horizontal" -> {
+                                screenModel.preferences.novelShowProgressSlider.set(true)
+                                screenModel.preferences.novelVerticalScrollbar.set(false)
+                            }
+                            "vertical_left" -> {
+                                screenModel.preferences.novelShowProgressSlider.set(true)
+                                screenModel.preferences.novelVerticalScrollbarPosition.set("left")
+                                screenModel.preferences.novelVerticalScrollbar.set(true)
+                            }
+                            "vertical_right" -> {
+                                screenModel.preferences.novelShowProgressSlider.set(true)
+                                screenModel.preferences.novelVerticalScrollbarPosition.set("right")
+                                screenModel.preferences.novelVerticalScrollbar.set(true)
+                            }
                         }
-                        "horizontal" -> {
-                            screenModel.preferences.novelShowProgressSlider.set(true)
-                            screenModel.preferences.novelVerticalScrollbar.set(false)
-                        }
-                        "vertical_left" -> {
-                            screenModel.preferences.novelShowProgressSlider.set(true)
-                            screenModel.preferences.novelVerticalScrollbarPosition.set("left")
-                            screenModel.preferences.novelVerticalScrollbar.set(true)
-                        }
-                        "vertical_right" -> {
-                            screenModel.preferences.novelShowProgressSlider.set(true)
-                            screenModel.preferences.novelVerticalScrollbarPosition.set("right")
-                            screenModel.preferences.novelVerticalScrollbar.set(true)
-                        }
-                    }
-                },
-                label = { Text(label) },
-            )
+                    },
+                    label = { Text(label) },
+                )
+            }
         }
     }
 
@@ -652,13 +687,16 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
     }
     if (infiniteScrollEnabled) {
         val effectiveAutoLoadAt = if (autoLoadAt > 0) autoLoadAt else 95
-        SliderItem(
-            label = stringResource(TDMR.strings.pref_novel_auto_load_next_at),
-            value = effectiveAutoLoadAt,
-            valueRange = 1..99,
-            valueString = "$effectiveAutoLoadAt%",
-            onChange = { screenModel.preferences.novelAutoLoadNextChapterAt.set(it) },
-        )
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+            Text(stringResource(TDMR.strings.pref_novel_auto_load_next_at), style = MaterialTheme.typography.bodyMedium)
+            SliderItem(
+                label = "",
+                value = effectiveAutoLoadAt,
+                valueRange = 1..99,
+                valueString = "$effectiveAutoLoadAt%",
+                onChange = { screenModel.preferences.novelAutoLoadNextChapterAt.set(it) },
+            )
+        }
     }
 
     // Chapter Sort Order

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -556,13 +556,26 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
     // Tap-zone navigation settings for novel viewer
     val navigationModeNovel by screenModel.preferences.navigationModeNovel.collectAsState()
     val novelNavInverted by screenModel.preferences.novelNavInverted.collectAsState()
+    val effectiveNavigationModeNovel = if (navigationModeNovel == ReaderPreferences.TAPZONE_DISABLED_INDEX) {
+        0
+    } else {
+        navigationModeNovel
+    }
     SettingsChipRow(MR.strings.pref_viewer_nav) {
         ReaderPreferences.TapZones.forEachIndexed { idx, res ->
-            FilterChip(
-                selected = navigationModeNovel == idx,
-                onClick = { screenModel.preferences.navigationModeNovel.set(idx) },
-                label = { Text(stringResource(res)) },
-            )
+            if (idx == 0) {
+                FilterChip(
+                    selected = effectiveNavigationModeNovel == 0,
+                    onClick = { screenModel.preferences.navigationModeNovel.set(ReaderPreferences.TAPZONE_DISABLED_INDEX) },
+                    label = { Text(stringResource(res)) },
+                )
+            } else if (idx != ReaderPreferences.TAPZONE_DISABLED_INDEX) {
+                FilterChip(
+                    selected = effectiveNavigationModeNovel == idx,
+                    onClick = { screenModel.preferences.navigationModeNovel.set(idx) },
+                    label = { Text(stringResource(res)) },
+                )
+            }
         }
 
         // Add explicit center-only mode (small center tap shows app bars)
@@ -573,9 +586,9 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
         )
     }
 
-    // Show invert options only when navigation is not disabled or center-only
-    if (navigationModeNovel != ReaderPreferences.TAPZONE_DISABLED_INDEX &&
-        navigationModeNovel != ReaderPreferences.TAPZONE_CENTER_INDEX
+    // Show invert options only when navigation is not default, disabled, or center-only
+    if (effectiveNavigationModeNovel != 0 &&
+        effectiveNavigationModeNovel != ReaderPreferences.TAPZONE_CENTER_INDEX
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
             Text(stringResource(MR.strings.pref_read_with_tapping_inverted), style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -15,12 +15,15 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
+import eu.kanade.tachiyomi.ui.reader.viewer.text.NovelViewer
+import eu.kanade.tachiyomi.ui.reader.viewer.text.NovelWebViewViewer
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.HeadingItem
 import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.util.collectAsState
 import java.text.NumberFormat
 
@@ -54,6 +57,8 @@ internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel)
     val viewer by screenModel.viewerFlow.collectAsState()
     if (viewer is WebtoonViewer) {
         WebtoonViewerSettings(screenModel)
+    } else if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
+        NovelViewerSettings(screenModel)
     } else {
         PagerViewerSettings(screenModel)
     }
@@ -201,6 +206,20 @@ private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenM
     CheckboxItem(
         label = stringResource(MR.strings.pref_webtoon_disable_zoom_out),
         pref = screenModel.preferences.webtoonDisableZoomOut,
+    )
+}
+
+@Composable
+private fun ColumnScope.NovelViewerSettings(screenModel: ReaderSettingsScreenModel) {
+    HeadingItem(TDMR.strings.novel_viewer)
+
+    val navigationModeNovel by screenModel.preferences.navigationModeNovel.collectAsState()
+    val novelNavInverted by screenModel.preferences.novelNavInverted.collectAsState()
+    TapZonesItems(
+        selected = navigationModeNovel,
+        onSelect = screenModel.preferences.navigationModeNovel::set,
+        invertMode = novelNavInverted,
+        onSelectInvertMode = screenModel.preferences.novelNavInverted::set,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -156,7 +156,7 @@ class ReaderPreferences(
     val navigationModeWebtoon: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_webtoon", 0)
 
     // Navigation mode for novel viewers (tap zones)
-    val navigationModeNovel: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_novel", 6)
+    val navigationModeNovel: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_novel", 5)
 
     val pagerNavInverted: Preference<TappingInvertMode> = preferenceStore.getEnum(
         "reader_tapping_inverted",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -156,7 +156,7 @@ class ReaderPreferences(
     val navigationModeWebtoon: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_webtoon", 0)
 
     // Navigation mode for novel viewers (tap zones)
-    val navigationModeNovel: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_novel", 0)
+    val navigationModeNovel: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_novel", 6)
 
     val pagerNavInverted: Preference<TappingInvertMode> = preferenceStore.getEnum(
         "reader_tapping_inverted",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -155,6 +155,9 @@ class ReaderPreferences(
 
     val navigationModeWebtoon: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_webtoon", 0)
 
+    // Navigation mode for novel viewers (tap zones)
+    val navigationModeNovel: Preference<Int> = preferenceStore.getInt("reader_navigation_mode_novel", 0)
+
     val pagerNavInverted: Preference<TappingInvertMode> = preferenceStore.getEnum(
         "reader_tapping_inverted",
         TappingInvertMode.NONE,
@@ -162,6 +165,11 @@ class ReaderPreferences(
 
     val webtoonNavInverted: Preference<TappingInvertMode> = preferenceStore.getEnum(
         "reader_tapping_inverted_webtoon",
+        TappingInvertMode.NONE,
+    )
+
+    val novelNavInverted: Preference<TappingInvertMode> = preferenceStore.getEnum(
+        "reader_tapping_inverted_novel",
         TappingInvertMode.NONE,
     )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -365,6 +365,9 @@ class ReaderPreferences(
 
         const val MILLI_CONVERSION = 100
 
+        const val TAPZONE_DISABLED_INDEX = 5
+        const val TAPZONE_CENTER_INDEX = 6
+
         val TapZones = listOf(
             MR.strings.label_default,
             MR.strings.l_nav,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/CenterNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/CenterNavigation.kt
@@ -1,0 +1,17 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.navigation
+
+import android.graphics.RectF
+import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
+
+/**
+ * Small center zone that maps to the MENU action (show app bars)
+ */
+class CenterNavigation : ViewerNavigation() {
+
+    override var regionList: List<Region> = listOf(
+        Region(
+            rectF = RectF(0.4f, 0.4f, 0.6f, 0.6f),
+            type = NavigationRegion.MENU,
+        ),
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelConfig.kt
@@ -1,0 +1,51 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.text
+
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import eu.kanade.tachiyomi.ui.reader.viewer.ViewerConfig
+import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.EdgeNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.KindlishNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.LNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.RightAndLeftNavigation
+import eu.kanade.tachiyomi.ui.reader.viewer.navigation.CenterNavigation
+import kotlinx.coroutines.CoroutineScope
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class NovelConfig(
+    scope: CoroutineScope,
+    readerPreferences: ReaderPreferences = Injekt.get(),
+) : ViewerConfig(readerPreferences, scope) {
+
+    init {
+        readerPreferences.navigationModeNovel
+            .register({ navigationMode = it }, { updateNavigation(navigationMode) })
+
+        readerPreferences.novelNavInverted
+            .register({ tappingInverted = it }, { navigator.invertMode = it })
+    }
+
+    override var navigator: ViewerNavigation = defaultNavigation()
+        set(value) {
+            field = value.also { it.invertMode = tappingInverted }
+        }
+
+    override fun defaultNavigation(): ViewerNavigation {
+        return LNavigation()
+    }
+
+    override fun updateNavigation(navigationMode: Int) {
+        this.navigator = when (navigationMode) {
+            0 -> defaultNavigation()
+            1 -> LNavigation()
+            2 -> KindlishNavigation()
+            3 -> EdgeNavigation()
+            4 -> RightAndLeftNavigation()
+            6 -> CenterNavigation()
+            5 -> DisabledNavigation()
+            else -> defaultNavigation()
+        }
+        navigationModeChangedListener?.invoke()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelConfig.kt
@@ -42,8 +42,8 @@ class NovelConfig(
             2 -> KindlishNavigation()
             3 -> EdgeNavigation()
             4 -> RightAndLeftNavigation()
-            6 -> CenterNavigation()
-            5 -> DisabledNavigation()
+            ReaderPreferences.TAPZONE_CENTER_INDEX -> CenterNavigation()
+            ReaderPreferences.TAPZONE_DISABLED_INDEX -> DisabledNavigation()
             else -> defaultNavigation()
         }
         navigationModeChangedListener?.invoke()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -415,11 +415,20 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
     private var isAutoScrolling = false
     private var autoScrollJob: Job? = null
 
-    private var navigator: eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation = eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation()
+    
 
 
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val config = NovelConfig(scope)
+    private val navigator get() = config.navigator
+
+    init {
+        config.navigationModeChangedListener = {
+            val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
+            activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
+        }
+    }
     private var loadJob: Job? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
@@ -515,6 +524,18 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
                     e.x / container.width.toFloat(),
                     e.y / container.height.toFloat(),
                 )
+
+                if (preferences.navigationModeNovel.get() == ReaderPreferences.TapZones.size) {
+                    val centerXStart = 0.4f
+                    val centerXEnd = 0.6f
+                    val centerYStart = 0.4f
+                    val centerYEnd = 0.6f
+                    if (pos.x in centerXStart..centerXEnd && pos.y in centerYStart..centerYEnd) {
+                        activity.toggleMenu()
+                        return true
+                    }
+                    return false
+                }
 
                 when (navigator.getAction(pos)) {
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.MENU -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -112,7 +112,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private var isAutoScrolling = false
     private var autoScrollJob: Job? = null
 
-    private var navigator: eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation = eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation()
+    private val config = NovelConfig(scope)
+    private val navigator get() = config.navigator
+
+    init {
+        config.navigationModeChangedListener = {
+            val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
+            activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
+        }
+    }
 
     // TTS support
     private var tts: TextToSpeech? = null
@@ -195,6 +203,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     e.x / container.width.toFloat(),
                     e.y / container.height.toFloat(),
                 )
+
+                if (preferences.navigationModeNovel.get() == ReaderPreferences.TapZones.size) {
+                    val centerXStart = 0.4f
+                    val centerXEnd = 0.6f
+                    val centerYStart = 0.4f
+                    val centerYEnd = 0.6f
+                    if (pos.x in centerXStart..centerXEnd && pos.y in centerYStart..centerYEnd) {
+                        activity.toggleMenu()
+                        return true
+                    }
+                    return false
+                }
 
                 when (navigator.getAction(pos)) {
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.MENU -> {

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -38,6 +38,7 @@
 
     <!-- Reader Section -->
     <string name="novel_viewer">Novel (text)</string>
+    <string name="novel_nav_center_only">Center only</string>
     <string name="chapter_progress_novel">%1$d%%</string>
     <!-- Library -->
     <string name="chapters_from_database">Chapter entries from database</string>


### PR DESCRIPTION
- Added `navigationModeNovel` and `novelNavInverted` to reader preferences
- Introduced `NovelConfig` to manage navigation state and mapping for novel viewers
- Implemented `CenterNavigation` to support a "Center only" tap zone for menu actions
- Updated `NovelPage` settings UI to include navigation mode selection and invert options
- Integrated the new navigation configuration into `NovelViewer` and `NovelWebViewViewer`
- Added novel-specific tap zone settings to the `ReadingModePage`
- Refactored scrollbar and auto-load settings UI for improved layout consistency
<img width="720" height="1544" alt="image" src="https://github.com/user-attachments/assets/05967297-be4c-488b-bd62-8d4c7941d0c1" />
