### PR TITLE
feat: increase TTS speed and pitch maximum limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Changed
 - Novel downloads will be saved as zip format [@mrissaoussama](https://github.com/mrissaoussama) [#202](https://github.com/tsundoku-otaku/tsundoku/pull/202)
+- TTS speed/pitch range increased from 0.5x–2.0x to 0.5x–6.0x [@mrissaoussama](https://github.com/mrissaoussama) [#215](https://github.com/tsundoku-otaku/tsundoku/pull/215)
 
 ### Improved
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -1566,20 +1566,20 @@ internal fun ColumnScope.NovelTtsTab(screenModel: ReaderSettingsScreenModel) {
         }
     }
 
-    // Speech Speed Slider (0.5x to 2.0x)
+    // Speech Speed Slider (0.5x to 6.0x)
     SliderItem(
         label = stringResource(TDMR.strings.pref_novel_tts_speed),
         value = (ttsSpeed * 10).toInt(),
-        valueRange = 5..20,
+        valueRange = 5..60,
         onChange = { screenModel.preferences.novelTtsSpeed.set(it / 10f) },
         valueString = String.format("%.1fx", ttsSpeed),
     )
 
-    // Speech Pitch Slider (0.5x to 2.0x)
+    // Speech Pitch Slider (0.5x to 6.0x)
     SliderItem(
         label = stringResource(TDMR.strings.pref_novel_tts_pitch),
         value = (ttsPitch * 10).toInt(),
-        valueRange = 5..20,
+        valueRange = 5..60,
         onChange = { screenModel.preferences.novelTtsPitch.set(it / 10f) },
         valueString = String.format("%.1fx", ttsPitch),
     )


### PR DESCRIPTION
- Update `NovelPage.kt` to expand the range of TTS speed and pitch sliders from 0.5x–2.0x to 0.5x–6.0x.

Fixes #213 