### PR TITLE
Feat/enhance translation ui/performace + new engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - TTS speed/pitch range increased from 0.5x–2.0x to 0.5x–6.0x [@mrissaoussama](https://github.com/mrissaoussama) [#215](https://github.com/tsundoku-otaku/tsundoku/pull/215)
 
 ### Improved
+- Translation: NVIDIA NIM, Cache reliability, auto-translation option, better error handling/UX, and rendering improvements [@mrissaoussama](https://github.com/mrissaoussama) [#218](https://github.com/tsundoku-otaku/tsundoku/pull/218)
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)
 - Novel description screen now supports novel searches when tapping novel title [@mrissaoussama](https://github.com/mrissaoussama) [#207](https://github.com/tsundoku-otaku/tsundoku/pull/207)
 - Webview constants refactor, also fixes (non-infinite) scroll having dividers - Changes that affect custom CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#209](https://github.com/tsundoku-otaku/tsundoku/pull/209)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
@@ -247,6 +247,9 @@ object SettingsTranslationScreen : SearchableSettings {
 
         // Collect all preference states
         val openAiKey by prefs.openAiApiKey().collectAsState()
+        val nvidiaNimBaseUrl by prefs.nvidiaNimBaseUrl().collectAsState()
+        val nvidiaNimApiKey by prefs.nvidiaNimApiKey().collectAsState()
+        val nvidiaNimModel by prefs.nvidiaNimModel().collectAsState()
         val deepSeekKey by prefs.deepSeekApiKey().collectAsState()
         val systranKey by prefs.systranApiKey().collectAsState()
         val deepLKey by prefs.deepLApiKey().collectAsState()
@@ -269,34 +272,38 @@ object SettingsTranslationScreen : SearchableSettings {
 
         fun testButton(engine: tachiyomi.domain.translation.model.TranslationEngine): Preference.PreferenceItem.TextPreference {
             val engineId = engine.id
+            val engineConfigured = engine.isConfigured()
             return Preference.PreferenceItem.TextPreference(
                 title = testEngineFormat.format(engine.name),
                 subtitle = when {
                     testingEngineId == engineId -> testingStr
                     testResults.containsKey(engineId) -> testResults[engineId]!!
+                    !engineConfigured -> "Not configured"
                     else -> testSendStr
                 },
-                enabled = testingEngineId == null,
+                enabled = testingEngineId == null && engineConfigured,
                 onClick = {
-                    testingEngineId = engineId
-                    testResults.remove(engineId)
-                    scope.launch {
-                        try {
-                            val result = engine.translate(
-                                listOf(testTextStr),
-                                sourceLanguage,
-                                targetLanguage,
-                            )
-                            testResults[engineId] = when (result) {
-                                is TranslationResult.Success ->
-                                    "✓ ${result.translatedTexts.joinToString(" | ")}"
-                                is TranslationResult.Error ->
-                                    "✗ ${result.message}"
+                    if (engineConfigured) {
+                        testingEngineId = engineId
+                        testResults.remove(engineId)
+                        scope.launch {
+                            try {
+                                val result = engine.translate(
+                                    listOf(testTextStr),
+                                    sourceLanguage,
+                                    targetLanguage,
+                                )
+                                testResults[engineId] = when (result) {
+                                    is TranslationResult.Success ->
+                                        "✓ ${result.translatedTexts.joinToString(" | ")}"
+                                    is TranslationResult.Error ->
+                                        "✗ ${result.message}"
+                                }
+                            } catch (e: Exception) {
+                                testResults[engineId] = "✗ ${e.message ?: e.javaClass.simpleName}"
+                            } finally {
+                                testingEngineId = null
                             }
-                        } catch (e: Exception) {
-                            testResults[engineId] = "✗ ${e.message ?: e.javaClass.simpleName}"
-                        } finally {
-                            testingEngineId = null
                         }
                     }
                 },
@@ -324,6 +331,28 @@ object SettingsTranslationScreen : SearchableSettings {
                         subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
                     ),
                     testButton(engineManager.engines.first { it.name.contains("OpenAI") }),
+                ),
+            ),
+            // NVIDIA NIM
+            Preference.PreferenceGroup(
+                title = "NVIDIA NIM",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.nvidiaNimBaseUrl(),
+                        title = stringResource(MR.strings.pref_translation_api_url),
+                        subtitle = if (nvidiaNimBaseUrl.isNotBlank()) nvidiaNimBaseUrl else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.nvidiaNimApiKey(),
+                        title = stringResource(MR.strings.pref_translation_api_key),
+                        subtitle = if (nvidiaNimApiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.nvidiaNimModel(),
+                        title = stringResource(TDMR.strings.pref_translation_ollama_model),
+                        subtitle = nvidiaNimModel.ifBlank { stringResource(TDMR.strings.not_set) },
+                    ),
+                    testButton(engineManager.getEngineById(TranslationEngineManager.ENGINE_NVIDIA_NIM)!!),
                 ),
             ),
             // DeepSeek

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationEngineManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationEngineManager.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.data.translation.engine.GoogleTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.GoogleTranslateScraperEngine
 import eu.kanade.tachiyomi.data.translation.engine.HuggingFaceTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.LibreTranslateEngine
+import eu.kanade.tachiyomi.data.translation.engine.NvidiaNimTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.OllamaTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.OpenAITranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.SystranTranslateEngine
@@ -32,6 +33,7 @@ class TranslationEngineManager(
         listOf(
             LibreTranslateEngine(), // Free, open-source
             OpenAITranslateEngine(), // Paid, high quality
+            NvidiaNimTranslateEngine(), // OpenAI-compatible NIM endpoint
             DeepSeekTranslateEngine(), // Paid, affordable
             OllamaTranslateEngine(), // Local AI, free
             HuggingFaceTranslateEngine(), // Free, limited languages
@@ -115,5 +117,6 @@ class TranslationEngineManager(
         const val ENGINE_DEEPL = 6L
         const val ENGINE_GOOGLE = 7L
         const val ENGINE_GEMINI = 8L
+        const val ENGINE_NVIDIA_NIM = 11L
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationHtmlUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationHtmlUtils.kt
@@ -50,6 +50,17 @@ object TranslationHtmlUtils {
         return result
     }
 
+    /**
+     * Normalize line-break variants so paragraph handling is stable.
+     */
+    fun normalizeLineBreaks(text: String): String {
+        return text
+            .replace("\r\n", "\n")
+            .replace('\r', '\n')
+            .replace('\u2028', '\n')
+            .replace('\u2029', '\n')
+    }
+
     // ── Text ↔ HTML conversion ──────────────────────────────────────
 
     /**
@@ -74,9 +85,10 @@ object TranslationHtmlUtils {
             }
         }
 
-        return doc.text()
-            // Normalise whitespace produced by Jsoup's .text()
-            .replace(Regex("[ \\t]+"), " ")
+        return normalizeLineBreaks(doc.body().wholeText())
+            .replace(Regex("[ \\t\\u000B\\f]+"), " ")
+            .replace(Regex("\\n[ \\t]+"), "\n")
+            .replace(Regex("[ \\t]+\\n"), "\n")
             .replace(Regex("\n{3,}"), "\n\n")
             .trim()
     }
@@ -85,11 +97,9 @@ object TranslationHtmlUtils {
      * Wrap plain text (paragraphs separated by `\n\n`) back into `<p>` elements.
      */
     fun wrapTextInHtml(text: String): String {
-        return text
-            .split("\n\n")
-            .filter { it.isNotBlank() }
+        return splitParagraphsPreserving(text)
             .joinToString("") { paragraph ->
-                "<p>${escapeHtml(paragraph.trim()).replace("\n", "<br/>")}</p>"
+                "<p>${escapeHtml(normalizeLineBreaks(paragraph).trim()).replace("\n", "<br/>")}</p>"
             }
     }
 
@@ -188,9 +198,10 @@ object TranslationHtmlUtils {
      */
     fun splitParagraphsPreserving(text: String): List<String> {
         if (text.isBlank()) return emptyList()
-        val byDouble = text.split(Regex("\n{2,}")).map { it.trim() }.filter { it.isNotBlank() }
+        val normalized = normalizeLineBreaks(text)
+        val byDouble = normalized.split(Regex("\n{2,}")).map { it.trim() }.filter { it.isNotBlank() }
         if (byDouble.size > 1) return byDouble
         // Fallback to single-line breaks
-        return text.split(Regex("\n")).map { it.trim() }.filter { it.isNotBlank() }
+        return normalized.split(Regex("\n")).map { it.trim() }.filter { it.isNotBlank() }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationHtmlUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationHtmlUtils.kt
@@ -12,6 +12,8 @@ import org.jsoup.parser.Parser
  */
 object TranslationHtmlUtils {
 
+    private const val SOURCE_HASH_COMMENT_PREFIX = "<!-- tsundoku-source-hash:"
+
     // ── Image / media preservation ──────────────────────────────────
 
     /** CSS selector for elements that must survive the translate round-trip. */
@@ -89,6 +91,10 @@ object TranslationHtmlUtils {
             .joinToString("") { paragraph ->
                 "<p>${escapeHtml(paragraph.trim()).replace("\n", "<br/>")}</p>"
             }
+    }
+
+    fun hasSourceHashTag(content: String): Boolean {
+        return content.startsWith(SOURCE_HASH_COMMENT_PREFIX)
     }
 
     /**
@@ -172,5 +178,19 @@ object TranslationHtmlUtils {
             .replace("<", "&lt;")
             .replace(">", "&gt;")
             .replace("\"", "&quot;")
+    }
+
+    /**
+     * Split translated text into paragraphs while being robust to model output.
+     * Prefer splitting on two-or-more newlines; if none are present, fall back
+     * to single-line breaks so models that preserve only single newlines still
+     * return sensible paragraphs.
+     */
+    fun splitParagraphsPreserving(text: String): List<String> {
+        if (text.isBlank()) return emptyList()
+        val byDouble = text.split(Regex("\n{2,}")).map { it.trim() }.filter { it.isNotBlank() }
+        if (byDouble.size > 1) return byDouble
+        // Fallback to single-line breaks
+        return text.split(Regex("\n")).map { it.trim() }.filter { it.isNotBlank() }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.translation.engine.DeepSeekTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.GeminiTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.LibreTranslateEngine
+import eu.kanade.tachiyomi.data.translation.engine.NvidiaNimTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.OllamaTranslateEngine
 import eu.kanade.tachiyomi.data.translation.engine.OpenAITranslateEngine
 import eu.kanade.tachiyomi.source.fetchNovelPageText
@@ -41,6 +42,7 @@ import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import tachiyomi.domain.translation.service.TranslationPreferences
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -507,7 +509,7 @@ class TranslationService(
                             } else {
                                 translated
                             }
-                            val translatedParagraphs = cleanedTranslation.split("\n\n").filter { it.isNotBlank() }
+                            val translatedParagraphs = TranslationHtmlUtils.splitParagraphsPreserving(cleanedTranslation)
                             // Update previous chunk tracking for next iteration
                             previousRawParagraphs = chunkParagraphsList[chunkIndex]
                             previousTranslatedParagraphs = translatedParagraphs.ifEmpty { listOf(cleanedTranslation) }
@@ -751,7 +753,7 @@ class TranslationService(
         // Check for existing translation in database
         if (chapterId != null) {
             val existingTranslation = translatedChapterRepository.getTranslatedChapter(chapterId, tgtLang)
-            if (existingTranslation != null) {
+            if (existingTranslation != null && isCachedTranslationCompatible(existingTranslation.translatedContent, content)) {
                 logcat(LogPriority.DEBUG) { "Using cached translation for chapter $chapterId (lang: $tgtLang)" }
                 return existingTranslation.translatedContent
             }
@@ -774,6 +776,8 @@ class TranslationService(
                     translatedHtml = TranslationHtmlUtils.reinsertImages(translatedHtml, preservedImages)
                 }
 
+                val cachedTranslatedHtml = wrapTranslatedHtmlWithSourceHash(content, translatedHtml)
+
                 // Save translation to database
                 if (chapterId != null && mangaId != null) {
                     val engine = translationEngineManager.getEngine()
@@ -782,7 +786,7 @@ class TranslationService(
                         mangaId = mangaId,
                         targetLanguage = tgtLang,
                         engineId = engine?.id?.toString() ?: "unknown",
-                        translatedContent = translatedHtml,
+                        translatedContent = cachedTranslatedHtml,
                         dateTranslated = System.currentTimeMillis(),
                     )
                     try {
@@ -796,12 +800,38 @@ class TranslationService(
                     }
                 }
 
-                translatedHtml
+                cachedTranslatedHtml
             }
             is TranslationResult.Error -> {
                 logcat(LogPriority.WARN) { "Translation failed: ${result.message}" }
-                content // Return original content on error
+                throw IllegalStateException(result.message)
             }
+        }
+    }
+
+    private fun isCachedTranslationCompatible(cachedContent: String, sourceContent: String): Boolean {
+        val cachedHash = extractSourceHash(cachedContent) ?: return false
+        return cachedHash == computeSourceHash(sourceContent)
+    }
+
+    private fun wrapTranslatedHtmlWithSourceHash(sourceContent: String, translatedHtml: String): String {
+        val hash = computeSourceHash(sourceContent)
+        return "<!-- tsundoku-source-hash:$hash -->\n$translatedHtml"
+    }
+
+    private fun extractSourceHash(cachedContent: String): String? {
+        val prefix = "<!-- tsundoku-source-hash:"
+        val start = cachedContent.indexOf(prefix)
+        if (start < 0) return null
+        val end = cachedContent.indexOf("-->", start)
+        if (end < 0) return null
+        return cachedContent.substring(start + prefix.length, end).trim().takeIf { it.isNotEmpty() }
+    }
+
+    private fun computeSourceHash(content: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+        return buildString(digest.size * 2) {
+            digest.forEach { byte -> append("%02x".format(byte)) }
         }
     }
 
@@ -894,6 +924,7 @@ class TranslationService(
     companion object {
         /** Priority values for translation queue. */
         const val PRIORITY_LOW = 0
+        const val PRIORITY_AHEAD = 25
         const val PRIORITY_NORMAL = 50
         const val PRIORITY_HIGH = 100
         const val PRIORITY_MANUAL_READ = 200
@@ -901,6 +932,7 @@ class TranslationService(
         /** Engine IDs for LLM-based engines that support contextual anchoring. */
         val LLM_ENGINE_IDS = setOf(
             OpenAITranslateEngine.ENGINE_ID,
+            NvidiaNimTranslateEngine.ENGINE_ID,
             DeepSeekTranslateEngine.ENGINE_ID,
             OllamaTranslateEngine.ENGINE_ID,
             GeminiTranslateEngine.ENGINE_ID,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -375,7 +375,7 @@ class TranslationService(
 
         // Extract text from HTML (delegated — fix DRY 2.4)
         val plainText = TranslationHtmlUtils.extractTextFromHtml(contentWithoutImages)
-        val paragraphs = plainText.split("\n\n").filter { it.isNotBlank() }
+        val paragraphs = TranslationHtmlUtils.splitParagraphsPreserving(plainText)
 
         logcat(LogPriority.DEBUG) { "Translating ${paragraphs.size} paragraphs for chapter ${chapter.name}" }
 
@@ -394,8 +394,9 @@ class TranslationService(
         val existingTmpParagraphs = run {
             val tmp = translatedChapterRepository.getTmpTranslation(task.chapterId, task.targetLanguage)
             if (tmp != null) {
-                TranslationHtmlUtils.extractTextFromHtml(tmp.translatedContent)
-                    .split("\n\n").filter { it.isNotBlank() }
+                TranslationHtmlUtils.splitParagraphsPreserving(
+                    TranslationHtmlUtils.extractTextFromHtml(tmp.translatedContent),
+                )
             } else {
                 emptyList()
             }
@@ -407,7 +408,7 @@ class TranslationService(
         if (existingTmpParagraphs.isNotEmpty() && !task.forceRetranslate) {
             var coveredParagraphs = 0
             for ((i, chunk) in chunks.withIndex()) {
-                val chunkParagraphCount = chunk.split("\n\n").filter { it.isNotBlank() }.size
+                val chunkParagraphCount = TranslationHtmlUtils.splitParagraphsPreserving(chunk).size
                 coveredParagraphs += chunkParagraphCount
                 if (coveredParagraphs <= existingTmpParagraphs.size) {
                     resumeFromChunk = i + 1
@@ -446,7 +447,7 @@ class TranslationService(
         val useAnchoring = isLlmEngine && anchoringEnabled && anchoringParagraphs > 0
 
         // Build per-chunk paragraph lists for context tracking
-        val chunkParagraphsList = chunks.map { c -> c.split("\n\n").filter { it.isNotBlank() } }
+        val chunkParagraphsList = chunks.map { c -> TranslationHtmlUtils.splitParagraphsPreserving(c) }
         // Track the raw paragraphs of the previously translated chunk
         var previousRawParagraphs = emptyList<String>()
         // Track the translated paragraphs of the previous chunk

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
@@ -5,6 +5,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -32,6 +35,7 @@ class GeminiTranslateEngine(
     override val supportedLanguages: List<Pair<String, String>> =
         LanguageCodes.COMMON_LANGUAGES
 
+
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
@@ -53,7 +57,8 @@ class GeminiTranslateEngine(
     private data class GenerateResponse(val candidates: List<Candidate>? = null)
 
     override fun isConfigured(): Boolean {
-        return preferences.geminiApiKey().get().isNotBlank()
+        return preferences.geminiApiKey().get().isNotBlank() &&
+            preferences.geminiModel().get().isNotBlank()
     }
 
     override suspend fun translate(
@@ -106,20 +111,24 @@ class GeminiTranslateEngine(
         }
 
         val prompt = """
-You are a professional translator specializing in novel/fiction translation.
+    You are a professional translator specializing in novel/fiction translation.
 
-$fromClause
+    $fromClause
 
-Rules:
-- Only output the translation, nothing else
-- Preserve paragraph structure
-- Maintain style and tone
-- Keep character names consistent
+    Rules:
+    - Only output the translation, nothing else
+    - Preserve paragraph structure
+    - Do NOT summarize.
+    - Do NOT merge or split paragraphs.
+    - Do NOT normalize whitespace.
+    - Maintain style and tone
+    - Keep character names consistent
+    - Every line break in the input MUST be preserved exactly in the output.
+    - Do NOT wrap lines.
+    Text:
+    $text
 
-Text:
-$text
-
-Translation:
+    Translation:
         """.trimIndent()
 
         val request = GenerateRequest(
@@ -146,8 +155,19 @@ Translation:
                 429 -> TranslationResult.ErrorCode.RATE_LIMITED
                 else -> TranslationResult.ErrorCode.UNKNOWN
             }
+            // Try to extract the error payload from Gemini's response for better diagnostics
+            val errorDetail = try {
+                val el = json.parseToJsonElement(responseBody)
+                val err = el.jsonObject["error"]?.jsonObject
+                val msg = err?.get("message")?.jsonPrimitive?.content
+                val status = err?.get("status")?.jsonPrimitive?.content
+                listOfNotNull(status, msg).joinToString(" - ").ifEmpty { responseBody }
+            } catch (_: Exception) {
+                responseBody
+            }
+
             throw TranslationException(
-                "Gemini error: HTTP ${response.code}",
+                "Gemini error: HTTP ${response.code}: $errorDetail",
                 errorCode,
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.translation.engine
 
+import eu.kanade.tachiyomi.data.translation.TranslationHtmlUtils
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import kotlinx.serialization.json.Json
@@ -154,7 +155,18 @@ class GoogleTranslateScraperEngine : TranslationEngine {
 
     private suspend fun translateSingleInternal(text: String, source: String, target: String): String {
         try {
-            val token = calculateToken(text)
+            val normalizedText = TranslationHtmlUtils.normalizeLineBreaks(text)
+            val paragraphs = TranslationHtmlUtils.splitParagraphsPreserving(normalizedText)
+
+            if (paragraphs.size > 1) {
+                val translatedParagraphs = mutableListOf<String>()
+                for (paragraph in paragraphs) {
+                    translatedParagraphs += translateRawText(paragraph, source, target)
+                }
+                return translatedParagraphs.joinToString("\n\n")
+            }
+
+            val token = calculateToken(normalizedText)
             val url = "https://translate.google.com/translate_a/single".toHttpUrl().newBuilder()
                 .addQueryParameter("client", "gtx")
                 .addQueryParameter("sl", source)
@@ -177,7 +189,7 @@ class GoogleTranslateScraperEngine : TranslationEngine {
                 .addQueryParameter("tsel", "0")
                 .addQueryParameter("kc", "7")
                 .addQueryParameter("tk", token)
-                .addQueryParameter("q", text)
+                .addQueryParameter("q", normalizedText)
                 .build()
 
             val request = GET(url)
@@ -185,7 +197,7 @@ class GoogleTranslateScraperEngine : TranslationEngine {
             val body = response.use { it.body.string() }
 
             if (!response.isSuccessful) {
-                return text
+                return normalizedText
             }
 
             val jsonArray = json.parseToJsonElement(body).jsonArray
@@ -206,6 +218,57 @@ class GoogleTranslateScraperEngine : TranslationEngine {
             e.printStackTrace()
             return text
         }
+    }
+
+    private suspend fun translateRawText(text: String, source: String, target: String): String {
+        val token = calculateToken(text)
+        val url = "https://translate.google.com/translate_a/single".toHttpUrl().newBuilder()
+            .addQueryParameter("client", "gtx")
+            .addQueryParameter("sl", source)
+            .addQueryParameter("tl", target)
+            .addQueryParameter("hl", target)
+            .addQueryParameter("dt", "at")
+            .addQueryParameter("dt", "bd")
+            .addQueryParameter("dt", "ex")
+            .addQueryParameter("dt", "ld")
+            .addQueryParameter("dt", "md")
+            .addQueryParameter("dt", "qca")
+            .addQueryParameter("dt", "rw")
+            .addQueryParameter("dt", "rm")
+            .addQueryParameter("dt", "ss")
+            .addQueryParameter("dt", "t")
+            .addQueryParameter("ie", "UTF-8")
+            .addQueryParameter("oe", "UTF-8")
+            .addQueryParameter("otf", "1")
+            .addQueryParameter("ssel", "0")
+            .addQueryParameter("tsel", "0")
+            .addQueryParameter("kc", "7")
+            .addQueryParameter("tk", token)
+            .addQueryParameter("q", text)
+            .build()
+
+        val request = GET(url)
+        val response = client.newCall(request).execute()
+        val body = response.use { it.body.string() }
+
+        if (!response.isSuccessful) {
+            return text
+        }
+
+        val jsonArray = json.parseToJsonElement(body).jsonArray
+
+        val result = StringBuilder()
+        val sentences = jsonArray[0].jsonArray
+
+        for (sentence in sentences) {
+            val sentenceArray = sentence.jsonArray
+            if (sentenceArray.isNotEmpty()) {
+                val translatedPart = sentenceArray[0].jsonPrimitive.content
+                result.append(translatedPart)
+            }
+        }
+
+        return result.toString()
     }
 
     // TKK calculation logic ported from various open source implementations

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
@@ -5,6 +5,8 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
@@ -138,13 +140,15 @@ class GoogleTranslateScraperEngine : TranslationEngine {
         sourceLanguage: String,
         targetLanguage: String,
     ): TranslationResult {
-        return try {
-            val translated = texts.map { text ->
-                translateSingleInternal(text, sourceLanguage, targetLanguage)
+        return withContext(Dispatchers.IO) {
+            try {
+                val translated = texts.map { text ->
+                    translateSingleInternal(text, sourceLanguage, targetLanguage)
+                }
+                TranslationResult.Success(translated, null)
+            } catch (e: Exception) {
+                TranslationResult.Error(e.message ?: "Unknown error", TranslationResult.ErrorCode.UNKNOWN)
             }
-            TranslationResult.Success(translated, null)
-        } catch (e: Exception) {
-            TranslationResult.Error(e.message ?: "Unknown error", TranslationResult.ErrorCode.UNKNOWN)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
@@ -1,0 +1,207 @@
+package eu.kanade.tachiyomi.data.translation.engine
+
+import eu.kanade.tachiyomi.network.NetworkHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.domain.translation.model.LanguageCodes
+import tachiyomi.domain.translation.model.TranslationEngine
+import tachiyomi.domain.translation.model.TranslationResult
+import tachiyomi.domain.translation.service.TranslationPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * NVIDIA NIM translation engine.
+ * Uses the OpenAI-compatible chat completions API exposed by NIM.
+ */
+class NvidiaNimTranslateEngine(
+    private val networkHelper: NetworkHelper = Injekt.get(),
+    private val preferences: TranslationPreferences = Injekt.get(),
+) : TranslationEngine {
+
+    private val client: OkHttpClient get() = networkHelper.client
+
+    override val id: Long = ENGINE_ID
+    override val name: String = "NVIDIA NIM"
+    override val requiresApiKey: Boolean = false
+    override val isRateLimited: Boolean = true
+    override val isOffline: Boolean = false
+
+    override val supportedLanguages: List<Pair<String, String>> = LanguageCodes.COMMON_LANGUAGES
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class ChatRequest(
+        val model: String,
+        val messages: List<Message>,
+        val temperature: Double = 0.3,
+        @SerialName("max_tokens")
+        val maxTokens: Int = 4096,
+    )
+
+    @Serializable
+    private data class Message(
+        val role: String,
+        val content: String,
+    )
+
+    @Serializable
+    private data class ChatResponse(
+        val choices: List<Choice> = emptyList(),
+        val error: ErrorInfo? = null,
+    )
+
+    @Serializable
+    private data class Choice(
+        val message: Message,
+    )
+
+    @Serializable
+    private data class ErrorInfo(
+        val message: String,
+        val type: String? = null,
+        val code: String? = null,
+    )
+
+    override fun isConfigured(): Boolean {
+        return preferences.nvidiaNimBaseUrl().get().isNotBlank() &&
+            preferences.nvidiaNimModel().get().isNotBlank()
+    }
+
+    override suspend fun translate(
+        texts: List<String>,
+        sourceLanguage: String,
+        targetLanguage: String,
+    ): TranslationResult = withContext(Dispatchers.IO) {
+        val baseUrl = preferences.nvidiaNimBaseUrl().get().trimEnd('/')
+        val model = preferences.nvidiaNimModel().get().trim()
+        val apiKey = preferences.nvidiaNimApiKey().get().trim()
+
+        if (baseUrl.isBlank()) {
+            return@withContext TranslationResult.Error(
+                "NVIDIA NIM base URL not configured",
+                TranslationResult.ErrorCode.API_KEY_MISSING,
+            )
+        }
+
+        if (model.isBlank()) {
+            return@withContext TranslationResult.Error(
+                "NVIDIA NIM model not configured",
+                TranslationResult.ErrorCode.API_KEY_MISSING,
+            )
+        }
+
+        try {
+            val translatedTexts = texts.map { text ->
+                translateSingleText(baseUrl, model, apiKey, text, sourceLanguage, targetLanguage)
+            }
+
+            TranslationResult.Success(translatedTexts)
+        } catch (e: TranslationException) {
+            TranslationResult.Error(e.message ?: "Translation failed", e.errorCode)
+        } catch (e: Exception) {
+            TranslationResult.Error(
+                e.message ?: "Unknown error",
+                TranslationResult.ErrorCode.UNKNOWN,
+            )
+        }
+    }
+
+    private suspend fun translateSingleText(
+        baseUrl: String,
+        model: String,
+        apiKey: String,
+        text: String,
+        sourceLanguage: String,
+        targetLanguage: String,
+    ): String {
+        val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
+        val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+
+        val fromClause = if (sourceLanguage == "auto") {
+            "Detect the source language and translate the following text to $targetLangName."
+        } else {
+            "Translate the following text from $sourceLangName to $targetLangName."
+        }
+
+        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
+Rules:
+- Only output the translation, nothing else
+- Preserve paragraph structure
+- Maintain the author's writing style and tone
+- Keep character names consistent
+- Do not add explanations or notes"""
+
+        val request = ChatRequest(
+            model = model,
+            messages = listOf(
+                Message(role = "system", content = systemPrompt),
+                Message(role = "user", content = text),
+            ),
+        )
+
+        val requestBody = json.encodeToString(ChatRequest.serializer(), request)
+        val apiUrl = buildApiUrl(baseUrl)
+
+        val requestBuilder = Request.Builder()
+            .url(apiUrl)
+            .post(requestBody.toRequestBody("application/json".toMediaType()))
+            .header("Content-Type", "application/json")
+
+        if (apiKey.isNotBlank()) {
+            requestBuilder.header("Authorization", "Bearer $apiKey")
+        }
+
+        val response = client.newCall(requestBuilder.build()).execute()
+        val responseBody = response.use { it.body.string() }
+
+        if (!response.isSuccessful) {
+            val errorCode = when (response.code) {
+                401, 403 -> TranslationResult.ErrorCode.API_KEY_INVALID
+                429 -> TranslationResult.ErrorCode.RATE_LIMITED
+                503 -> TranslationResult.ErrorCode.SERVICE_UNAVAILABLE
+                402 -> TranslationResult.ErrorCode.QUOTA_EXCEEDED
+                else -> TranslationResult.ErrorCode.UNKNOWN
+            }
+
+            val errorMessage = try {
+                val errorResponse = json.decodeFromString(ChatResponse.serializer(), responseBody)
+                errorResponse.error?.message ?: "HTTP ${response.code}"
+            } catch (_: Exception) {
+                "HTTP ${response.code}: $responseBody"
+            }
+
+            throw TranslationException(errorMessage, errorCode)
+        }
+
+        val chatResponse = json.decodeFromString(ChatResponse.serializer(), responseBody)
+        return chatResponse.choices.firstOrNull()?.message?.content?.trim()
+            ?: throw TranslationException("Empty response from NVIDIA NIM", TranslationResult.ErrorCode.UNKNOWN)
+    }
+
+    private fun buildApiUrl(baseUrl: String): String {
+        val normalizedBaseUrl = baseUrl.trimEnd('/')
+        return if (normalizedBaseUrl.endsWith("/v1")) {
+            "$normalizedBaseUrl/chat/completions"
+        } else {
+            "$normalizedBaseUrl/v1/chat/completions"
+        }
+    }
+
+    private class TranslationException(
+        message: String,
+        val errorCode: TranslationResult.ErrorCode,
+    ) : Exception(message)
+
+    companion object {
+        const val ENGINE_ID = 11L
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1431,6 +1431,8 @@ class ReaderActivity : BaseActivity() {
             content
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Translation failed" }
+            viewModel.disableTranslation()
+            toast(e.message ?: "Translation failed")
             content
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -270,6 +271,8 @@ class ReaderViewModel @JvmOverloads constructor(
             .map(::ReaderChapter)
     }
 
+            private val pendingTranslationAheadChapterIds = mutableSetOf<Long>()
+
     private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading.get()
 
@@ -307,6 +310,15 @@ class ReaderViewModel @JvmOverloads constructor(
                 if (novelScrollProgress > 0) {
                     currentChapter.requestedPage = novelScrollProgress
                     novelScrollProgress = -1
+                }
+            }
+            .launchIn(viewModelScope)
+
+        downloadManager.statusFlow()
+            .filter { it.status == Download.State.DOWNLOADED }
+            .onEach { download ->
+                if (pendingTranslationAheadChapterIds.remove(download.chapterId)) {
+                    enqueueDownloadedChapterForTranslation(download.chapterId)
                 }
             }
             .launchIn(viewModelScope)
@@ -814,6 +826,22 @@ class ReaderViewModel @JvmOverloads constructor(
                 manga,
                 chaptersToDownload,
             )
+
+            chaptersToDownload.forEach { chapter ->
+                val chapterId = chapter.id ?: return@forEach
+                val isAlreadyDownloaded = downloadManager.isChapterDownloaded(
+                    chapter.name,
+                    chapter.scanlator,
+                    chapter.url,
+                    manga.title,
+                    manga.source,
+                )
+                if (isAlreadyDownloaded) {
+                    enqueueDownloadedChapterForTranslation(chapterId)
+                } else {
+                    pendingTranslationAheadChapterIds.add(chapterId)
+                }
+            }
         }
     }
 
@@ -1034,6 +1062,15 @@ class ReaderViewModel @JvmOverloads constructor(
     }
 
     /**
+     * Turns translation mode off without triggering a reload.
+     */
+    fun disableTranslation() {
+        if (state.value.isTranslating) {
+            mutableState.update { it.copy(isTranslating = false) }
+        }
+    }
+
+    /**
      * Force retranslate the current chapter.
      * Deletes existing translation and re-enqueues for translation.
      */
@@ -1055,6 +1092,23 @@ class ReaderViewModel @JvmOverloads constructor(
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR, e) { "Error reloading chapter for retranslation" }
             }
+        }
+    }
+
+    private fun enqueueDownloadedChapterForTranslation(chapterId: Long) {
+        val currentManga = manga ?: return
+        val chapter = chapterList.firstOrNull { it.chapter.id == chapterId } ?: return
+
+        if (
+            sourceManager.get(currentManga.source)?.isNovelSource() == true &&
+            translationPreferences.translationEnabled().get() &&
+            translationPreferences.smartAutoTranslate().get()
+        ) {
+            translationService.enqueue(
+                manga = currentManga,
+                chapter = chapter.chapter.toDomainChapter()!!,
+                priority = TranslationService.PRIORITY_AHEAD,
+            )
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewer.kt
@@ -31,6 +31,7 @@ import androidx.core.widget.NestedScrollView
 import coil3.asDrawable
 import coil3.imageLoader
 import coil3.request.ImageRequest
+import eu.kanade.tachiyomi.data.translation.TranslationHtmlUtils
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
@@ -432,6 +433,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
     private var loadJob: Job? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
+    private var renderGeneration = 0L
 
     // Track loaded chapters for infinite scroll
     private data class LoadedChapter(
@@ -1543,12 +1545,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
 
         // Load existing progress map
         val progressJson = preferences.novelTtsLastReadParagraph.get()
-        val progressMap = try {
-            kotlinx.serialization.json.Json.decodeFromString<Map<String, Int>>(progressJson)
-                .toMutableMap()
-        } catch (e: Exception) {
-            mutableMapOf()
-        }
+        val progressMap = NovelViewerTextUtils.decodeIntMapPreference(progressJson)
 
         // Update with current chapter progress
         progressMap[chapterId.toString()] = paragraphIndex
@@ -1573,12 +1570,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
         val chapterId = currentChapter.index.toString()
         val progressJson = preferences.novelTtsLastReadParagraph.get()
 
-        return try {
-            val progressMap = kotlinx.serialization.json.Json.decodeFromString<Map<String, Int>>(progressJson)
-            progressMap[chapterId]?.coerceAtLeast(0) ?: 0
-        } catch (e: Exception) {
-            0
-        }
+        val progressMap = NovelViewerTextUtils.decodeIntMapPreference(progressJson)
+        return progressMap[chapterId]?.coerceAtLeast(0) ?: 0
     }
 
     /**
@@ -1705,30 +1698,45 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
      * Re-renders all loaded chapters with or without translation.
      */
     fun reloadWithTranslation() {
+        val generation = ++renderGeneration
         // Re-render all loaded chapters with new translation state
         loadedChapters.forEach { loadedChapter ->
             val page = loadedChapter.chapter.pages?.firstOrNull() as? ReaderPage ?: return@forEach
             val content = page.text ?: return@forEach
             val textView = loadedChapter.textView
+            val preparedContent = prepareContentForTranslation(content, loadedChapter.chapter.chapter.name)
 
             // Apply translation if enabled (async)
             if (activity.isTranslationEnabled()) {
+                textView.gravity = Gravity.CENTER
                 textView.text = "Translating..."
                 scope.launch {
-                    val translatedContent = activity.translateContentIfEnabled(content)
+                    val translatedContent = activity.translateContentIfEnabled(preparedContent)
                     withContext(Dispatchers.Main) {
+                        if (generation != renderGeneration) return@withContext
                         if (!textView.isAttachedToWindow) return@withContext
-                        setTextViewContent(textView, translatedContent, loadedChapter.chapter.chapter.url)
+                        setTextViewContent(
+                            textView,
+                            translatedContent,
+                            loadedChapter.chapter.chapter.url,
+                            processContent = false,
+                        )
                     }
                 }
             } else {
                 // Show original content
-                setTextViewContent(textView, content, loadedChapter.chapter.chapter.url)
+                setTextViewContent(
+                    textView,
+                    preparedContent,
+                    loadedChapter.chapter.chapter.url,
+                    processContent = false,
+                )
             }
         }
     }
 
     override fun setChapters(chapters: ViewerChapters) {
+        renderGeneration++
         val page = chapters.currChapter.pages?.firstOrNull() as? ReaderPage ?: return
 
         loadJob?.cancel()
@@ -1816,6 +1824,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
             content = content.lowercase()
         }
 
+        val preparedContent = content
+
         // Check if chapter is already loaded - return early to prevent duplicate adds
         val existingIndex = loadedChapters.indexOfFirst { it.chapter.chapter.id == chapter.chapter.id }
         if (existingIndex >= 0) {
@@ -1893,14 +1903,23 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
         contentContainer.addView(textView)
 
         // Apply translation if enabled (async)
-        val finalContent = content
         // Always show content immediately; translation (if enabled) replaces it asynchronously.
-        setTextViewContent(textView, finalContent, chapter.chapter.url)
+        setTextViewContent(
+            textView,
+            preparedContent,
+            chapter.chapter.url,
+            processContent = false,
+        )
         if (activity.isTranslationEnabled() && !preferences.novelShowRawHtml.get()) {
             scope.launch {
-                val translatedContent = activity.translateContentIfEnabled(finalContent)
+                val translatedContent = activity.translateContentIfEnabled(preparedContent)
                 withContext(Dispatchers.Main) {
-                    setTextViewContent(textView, translatedContent, chapter.chapter.url)
+                    setTextViewContent(
+                        textView,
+                        translatedContent,
+                        chapter.chapter.url,
+                        processContent = false,
+                    )
                 }
             }
         }
@@ -2151,7 +2170,12 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
     private fun getThemeColors(theme: String): Pair<Int, Int> =
         NovelViewerTextUtils.getThemeColors(activity, preferences, theme)
 
-    private fun setTextViewContent(textView: TextView, content: String, chapterUrl: String?) {
+    private fun setTextViewContent(
+        textView: TextView,
+        content: String,
+        chapterUrl: String?,
+        processContent: Boolean = true,
+    ) {
         // Check if raw HTML mode is enabled (for debugging)
         val showRawHtml = preferences.novelShowRawHtml.get()
         if (showRawHtml) {
@@ -2166,7 +2190,11 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
 
         // Process content to ensure paragraph tags exist for styling
         var processedContent = if (plainTextMode) {
-            NovelViewerTextUtils.normalizePlainTextContent(content)
+            if (!processContent && TranslationHtmlUtils.hasSourceHashTag(content)) {
+                TranslationHtmlUtils.extractTextFromHtml(content)
+            } else {
+                NovelViewerTextUtils.normalizePlainTextContent(content)
+            }
         } else {
             NovelViewerTextUtils.normalizeContentForHtml(content, chapterUrl)
         }
@@ -2180,7 +2208,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
         // Strip noscript tags
         processedContent = processedContent.replace(Regex("<noscript[^>]*>.*?</noscript>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)), "")
 
-        processedContent = applyRegexReplacements(processedContent)
+        if (processContent) {
+            processedContent = applyRegexReplacements(processedContent)
+        }
 
         // Optionally strip media tags entirely when blocking media
         if (preferences.novelBlockMedia.get()) {
@@ -2314,6 +2344,18 @@ class NovelViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.OnInitLis
      */
     private fun applyRegexReplacements(content: String): String =
         NovelViewerTextUtils.applyRegexReplacements(content, preferences)
+
+    private fun prepareContentForTranslation(content: String, chapterName: String): String {
+        var prepared = content
+        if (preferences.novelHideChapterTitle.get()) {
+            prepared = stripChapterTitle(prepared, chapterName)
+        }
+        prepared = applyRegexReplacements(prepared)
+        if (preferences.novelForceTextLowercase.get()) {
+            prepared = prepared.lowercase()
+        }
+        return prepared
+    }
 
     private fun normalizeContentForHtml(content: String, chapterUrl: String?): String =
         NovelViewerTextUtils.normalizeContentForHtml(content, chapterUrl)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelViewerTextUtils.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import logcat.LogPriority
 import logcat.logcat
+import org.jsoup.Jsoup
+import java.util.concurrent.ConcurrentHashMap
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
@@ -30,6 +32,11 @@ object NovelViewerTextUtils {
     }
 
     private val frontMatterRegex = Regex("^\\uFEFF?---\\s*\\r?\\n([\\s\\S]*?)\\r?\\n---\\s*(\\r?\\n|$)")
+    private const val CHAPTER_TITLE_SEARCH_LIMIT = 3000
+
+    // Cache compiled regex replacements keyed by the JSON preference string.
+    private val regexReplacementsCache = ConcurrentHashMap<String, List<Pair<Regex, String>>>()
+    private val intMapJsonCache = ConcurrentHashMap<String, Map<String, Int>>()
 
     fun isPlainTextChapter(chapterUrl: String?): Boolean {
         val ext = chapterUrl
@@ -48,6 +55,30 @@ object NovelViewerTextUtils {
             .replace("\u0000", "")
             .replace("\r\n", "\n")
             .replace("\r", "\n")
+    }
+
+    fun normalizeUrl(url: String?): String? {
+        val value = url?.trim().orEmpty()
+        if (value.isBlank()) return url
+        return when {
+            value.startsWith("https//") -> "https://" + value.removePrefix("https//")
+            value.startsWith("http//") -> "http://" + value.removePrefix("http//")
+            else -> value
+        }
+    }
+
+    fun decodeIntMapPreference(json: String): MutableMap<String, Int> {
+        if (json.isBlank()) return mutableMapOf()
+        val cached = intMapJsonCache[json]
+        if (cached != null) return cached.toMutableMap()
+
+        return try {
+            val decoded = kotlinx.serialization.json.Json.decodeFromString<Map<String, Int>>(json)
+            intMapJsonCache[json] = decoded
+            decoded.toMutableMap()
+        } catch (_: Exception) {
+            mutableMapOf()
+        }
     }
     /**
      * Normalizes chapter content to HTML so both WebView and TextView pipelines
@@ -95,7 +126,7 @@ object NovelViewerTextUtils {
     }
 
     private fun stripFrontMatter(markdown: String): String {
-        return frontMatterRegex.replaceFirst(markdown, "")
+        return markdown.replaceFirst(frontMatterRegex, "")
     }
 
     private fun markdownToHtml(markdown: String): String {
@@ -136,32 +167,42 @@ object NovelViewerTextUtils {
         val rulesJson = preferences.novelRegexReplacements.get()
         if (rulesJson.isBlank() || rulesJson == "[]") return content
 
-        val rules: List<RegexReplacement> = try {
-            kotlinx.serialization.json.Json.decodeFromString(rulesJson)
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN) { "Failed to parse regex replacements: ${e.message}" }
-            return content
+        val compiled = regexReplacementsCache.computeIfAbsent(rulesJson) { json ->
+            try {
+                val rules: List<RegexReplacement> = kotlinx.serialization.json.Json.decodeFromString(json)
+                rules.mapNotNull { rule ->
+                    if (!rule.enabled || rule.pattern.isBlank()) return@mapNotNull null
+                    try {
+                        if (rule.isRegex) {
+                            val options = if (rule.caseSensitive) emptySet<RegexOption>() else setOf(RegexOption.IGNORE_CASE)
+                            Regex(rule.pattern, options) to rule.replacement
+                        } else {
+                            val escapedPattern = Regex.escape(rule.pattern)
+                            val boundedPattern = if (rule.matchWholeWord) {
+                                "(?<![\\p{L}\\p{N}_])(?:$escapedPattern)(?![\\p{L}\\p{N}_])"
+                            } else {
+                                escapedPattern
+                            }
+                            val options = if (rule.caseSensitive) emptySet<RegexOption>() else setOf(RegexOption.IGNORE_CASE)
+                            Regex(boundedPattern, options) to rule.replacement
+                        }
+                    } catch (e: Exception) {
+                        logcat(LogPriority.WARN) { "Failed to compile regex for '${rule.title}': ${e.message}" }
+                        null
+                    }
+                }
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN) { "Failed to parse regex replacements: ${e.message}" }
+                emptyList()
+            }
         }
 
         var result = content
-        for (rule in rules) {
-            if (!rule.enabled || rule.pattern.isBlank()) continue
+        for ((regex, replacement) in compiled) {
             try {
-                result = if (rule.isRegex) {
-                    val regex = Regex(rule.pattern)
-                    regex.replace(result, rule.replacement)
-                } else {
-                    val escapedPattern = Regex.escape(rule.pattern)
-                    val boundedPattern = if (rule.matchWholeWord) {
-                        "(?<![\\p{L}\\p{N}_])(?:$escapedPattern)(?![\\p{L}\\p{N}_])"
-                    } else {
-                        escapedPattern
-                    }
-                    val options = if (rule.caseSensitive) emptySet() else setOf(RegexOption.IGNORE_CASE)
-                    Regex(boundedPattern, options).replace(result) { rule.replacement }
-                }
+                result = regex.replace(result, replacement)
             } catch (e: Exception) {
-                logcat(LogPriority.WARN) { "Regex replacement '${rule.title}' failed: ${e.message}" }
+                logcat(LogPriority.WARN) { "Regex replacement failed: ${e.message}" }
             }
         }
         return result
@@ -174,7 +215,7 @@ object NovelViewerTextUtils {
     fun stripChapterTitle(content: String, chapterName: String): String {
         val normalizedChapterName = chapterName.trim().lowercase()
         // Search within first 3000 chars for title (to handle leading whitespace/tags/extra prefixes)
-        val searchArea = content.take(3000)
+        val searchArea = content.take(CHAPTER_TITLE_SEARCH_LIMIT)
 
         // Try to remove first heading, or other elements if they match the chapter name.
         // We unconditionally hide the first heading.
@@ -413,34 +454,46 @@ object NovelViewerTextUtils {
     fun findParagraphs(text: String): List<ParagraphInfo> {
         val paragraphs = mutableListOf<ParagraphInfo>()
 
-        // Strip HTML tags first to get plain text positions
-        val plainText = text.replace(Regex("<[^>]+>"), " ")
+        // Use Jsoup to parse HTML robustly and extract block-level elements as paragraphs.
+        val doc = try {
+            Jsoup.parse(text)
+        } catch (e: Exception) {
+            // Fallback to naive behavior if parsing fails
+            null
+        }
 
-        // Split on double newlines, paragraph tags, or significant whitespace
-        val lines = plainText.split(Regex("\n\\s*\n|<p[^>]*>|</p>"))
-        var charOffset = 0
+        val plainText = doc?.text() ?: text.replace(Regex("<[^>]+>"), " ")
 
-        for ((index, line) in lines.withIndex()) {
-            val trimmed = line.trim()
-            if (trimmed.isEmpty()) {
-                charOffset += line.length + 2  // Account for split pattern
-                continue
+        // Prefer block elements when available
+        val blocks = doc?.select("p, div, section, article, h1, h2, h3, h4, h5, h6, li")
+
+        if (blocks == null || blocks.isEmpty()) {
+            // Fallback: split on blank lines in the plain text
+            val lines = plainText.split(Regex("\\n\\s*\\n"))
+            var charOffset = 0
+            for (line in lines) {
+                val trimmed = line.trim()
+                if (trimmed.isEmpty()) {
+                    charOffset += line.length + 2
+                    continue
+                }
+                val startChar = plainText.indexOf(trimmed, charOffset)
+                if (startChar < 0) continue
+                val endChar = startChar + trimmed.length
+                paragraphs.add(ParagraphInfo(paragraphs.size, startChar, endChar, trimmed))
+                charOffset = endChar
             }
+            return paragraphs
+        }
 
-            // Find the actual position in original text
+        var charOffset = 0
+        for (elem in blocks) {
+            val trimmed = elem.text().trim()
+            if (trimmed.isEmpty()) continue
             val startChar = plainText.indexOf(trimmed, charOffset)
             if (startChar < 0) continue
-
             val endChar = startChar + trimmed.length
-
-            paragraphs.add(
-                ParagraphInfo(
-                    index = paragraphs.size,
-                    startChar = startChar,
-                    endChar = endChar,
-                    text = trimmed,
-                )
-            )
+            paragraphs.add(ParagraphInfo(paragraphs.size, startChar, endChar, trimmed))
             charOffset = endChar
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/NovelWebViewViewer.kt
@@ -54,7 +54,9 @@ import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.novel.TDMR
 import uy.kohesive.injekt.injectLazy
 import java.net.URI
+import java.io.File
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * NovelWebViewViewer renders novel content using a WebView for more flexibility.
@@ -106,6 +108,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private var loadJob: Job? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
+    private val novelImageCache = ConcurrentHashMap<String, File>()
+    private val novelImagePrefetchJobs = ConcurrentHashMap<String, Job>()
 
     // Track scroll progress
     private var lastSavedProgress = 0f
@@ -124,15 +128,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private var isAutoScrolling = false
     private var autoScrollJob: Job? = null
 
-    private val config = NovelConfig(scope)
-    private val navigator get() = config.navigator
-
-    init {
-        config.navigationModeChangedListener = {
-            val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
-            activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
-        }
-    }
+    private var navigator: eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation = eu.kanade.tachiyomi.ui.reader.viewer.navigation.DisabledNavigation()
 
     // TTS support
     private var tts: TextToSpeech? = null
@@ -155,6 +151,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
     private var ttsResumeChunkIndex: Int = 0 // Track which chunk to resume from after pause
     private var ttsViewportParagraphIndex: Int = 0
     private var hasViewportStartOverride: Boolean = false
+    @Volatile private var ttsIsPreparing = false // Track TTS initialization/preparation phase
+    @Volatile private var ttsIsStarting = false // Track when speech is about to start
+
     @Volatile private var ttsIsPreparing = false // Track TTS initialization/preparation phase
     @Volatile private var ttsIsStarting = false // Track when speech is about to start
 
@@ -217,18 +216,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     e.x / container.width.toFloat(),
                     e.y / container.height.toFloat(),
                 )
-
-                if (preferences.navigationModeNovel.get() == ReaderPreferences.TapZones.size) {
-                    val centerXStart = 0.4f
-                    val centerXEnd = 0.6f
-                    val centerYStart = 0.4f
-                    val centerYEnd = 0.6f
-                    if (pos.x in centerXStart..centerXEnd && pos.y in centerYStart..centerYEnd) {
-                        activity.toggleMenu()
-                        return true
-                    }
-                    return false
-                }
 
                 when (navigator.getAction(pos)) {
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.MENU -> {
@@ -554,21 +541,19 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     val url = request?.url?.toString() ?: return null
                     if (url.startsWith(URL_SCHEME_NOVEL_IMAGE)) {
                         val imagePath = android.net.Uri.decode(url.removePrefix(URL_SCHEME_NOVEL_IMAGE))
+                        val chapterId = currentPage?.chapter?.chapter?.id ?: currentChapters?.currChapter?.chapter?.id
+                        val cacheKey = buildNovelImageCacheKey(chapterId, imagePath)
+                        novelImageCache[cacheKey]?.takeIf { it.exists() }?.let { cachedFile ->
+                            return android.webkit.WebResourceResponse(
+                                guessNovelImageMimeType(imagePath),
+                                "UTF-8",
+                                cachedFile.inputStream(),
+                            )
+                        }
+
                         val loader = activity.viewModel.state.value.viewerChapters?.currChapter?.pageLoader
                         if (loader != null) {
-                            val stream = kotlinx.coroutines.runBlocking { loader.getPageDataStream(imagePath) }
-                            if (stream != null) {
-                                val mimeType = when (imagePath.substringAfterLast('.', "").lowercase()) {
-                                    "png" -> "image/png"
-                                    "jpg", "jpeg" -> "image/jpeg"
-                                    "gif" -> "image/gif"
-                                    "svg" -> "image/svg+xml"
-                                    "webp" -> "image/webp"
-                                    "avif" -> "image/avif"
-                                    else -> "image/jpeg"
-                                }
-                                return android.webkit.WebResourceResponse(mimeType, "UTF-8", stream)
-                            }
+                            chapterId?.let { prefetchNovelImage(it, imagePath, loader) }
                         }
                     }
                     return super.shouldInterceptRequest(view, request)
@@ -1136,6 +1121,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         ttsIsStarting = false
         isTtsAutoPlay = false
 
+        clearNovelImageCache()
+
         // Mark destroyed first so coroutine finally-blocks won't touch WebView.
         isDestroyed = true
 
@@ -1165,6 +1152,75 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         }
     }
 
+    private fun clearNovelImageCache() {
+        novelImagePrefetchJobs.values.forEach { it.cancel() }
+        novelImagePrefetchJobs.clear()
+        novelImageCache.values.forEach { cachedFile ->
+            runCatching { cachedFile.delete() }
+        }
+        novelImageCache.clear()
+    }
+
+    private fun buildNovelImageCacheKey(chapterId: Long?, imagePath: String): String {
+        return "${chapterId ?: -1L}:$imagePath"
+    }
+
+    private fun guessNovelImageMimeType(imagePath: String): String {
+        return when (imagePath.substringAfterLast('.', "").lowercase()) {
+            "png" -> "image/png"
+            "jpg", "jpeg" -> "image/jpeg"
+            "gif" -> "image/gif"
+            "svg" -> "image/svg+xml"
+            "webp" -> "image/webp"
+            "avif" -> "image/avif"
+            else -> "image/jpeg"
+        }
+    }
+
+    private fun scheduleNovelImagePrefetch(content: String, chapterId: Long?, loader: PageLoader?) {
+        if (chapterId == null || loader == null) return
+
+        val imageUrlPattern = Regex("${Regex.escape(URL_SCHEME_NOVEL_IMAGE)}([^\"'<>\\s]+)")
+        imageUrlPattern.findAll(content)
+            .mapNotNull { match -> runCatching { android.net.Uri.decode(match.groupValues[1]) }.getOrNull() }
+            .distinct()
+            .forEach { imagePath ->
+                prefetchNovelImage(chapterId, imagePath, loader)
+            }
+    }
+
+    private fun prefetchNovelImage(chapterId: Long, imagePath: String, loader: PageLoader) {
+        val cacheKey = buildNovelImageCacheKey(chapterId, imagePath)
+        if (novelImageCache[cacheKey]?.exists() == true) return
+
+        novelImagePrefetchJobs[cacheKey]?.let { existing ->
+            if (existing.isActive) return
+        }
+
+        val job = scope.launch(Dispatchers.IO) {
+            try {
+                val stream = loader.getPageDataStream(imagePath) ?: return@launch
+                val fileSuffix = imagePath.substringAfterLast('.', "bin").ifBlank { "bin" }
+                val cachedFile = File(activity.cacheDir, "novel-image-${cacheKey.hashCode().toString(16)}.$fileSuffix")
+                stream.use { input ->
+                    cachedFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+                novelImageCache[cacheKey] = cachedFile
+            } catch (e: Exception) {
+                logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Failed to prefetch image $imagePath: ${e.message}" }
+            } finally {
+                novelImagePrefetchJobs.remove(cacheKey)
+            }
+        }
+
+        val previous = novelImagePrefetchJobs.putIfAbsent(cacheKey, job)
+        if (previous != null) {
+            job.cancel()
+        }
+    }
+
     private fun shouldAutoMarkShortChapter(page: ReaderPage?): Boolean {
         if (!preferences.novelMarkShortChapterAsRead.get()) return false
         val chapter = page?.chapter?.chapter ?: return false
@@ -1185,7 +1241,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                     var maxScroll = document.documentElement.scrollHeight - document.documentElement.clientHeight;
                     return maxScroll <= 0;
                 }
-                
+
                 // Set up a ResizeObserver to wait for content to stabilize
                 var resizeObserver = new ResizeObserver(function() {
                     if (checkIfShortChapter()) {
@@ -1194,10 +1250,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                         resizeObserver.disconnect();
                     }
                 });
-                
+
                 // Observe document body for size changes
                 resizeObserver.observe(document.body);
-                
+
                 // Also check after a small delay to catch static content
                 setTimeout(function() {
                     if (checkIfShortChapter()) {
@@ -1481,6 +1537,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             } else {
                 finalContent
             }
+
+            scheduleNovelImagePrefetch(processedContent, chapter.chapter.id, page.chapter.pageLoader)
             val plainTextMode = NovelViewerTextUtils.isPlainTextChapter(chapter.chapter.url)
             val renderableContent = if (plainTextMode) {
                 NovelViewerTextUtils.normalizePlainTextContent(processedContent)
@@ -1528,12 +1586,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
      */
     private fun prependHtmlContent(content: String, chapterId: Long, chapterName: String, chapterNumber: Float, chapterUrl: String?) {
         val plainTextMode = NovelViewerTextUtils.isPlainTextChapter(chapterUrl)
-        
+
         // Get user preferences for embedded CSS/JS
         val keepEmbeddedCss = preferences.enableEpubStyles.get()
         val keepEmbeddedJs = preferences.enableEpubJs.get()
         val blockMedia = preferences.novelBlockMedia.get()
-        
+
         // Normalize and sanitize content
         var cleanContent = if (plainTextMode) {
             NovelViewerTextUtils.normalizePlainTextContent(content)
@@ -1602,12 +1660,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
      */
     private fun appendHtmlContent(content: String, chapterId: Long, chapterName: String, chapterNumber: Float, chapterUrl: String?) {
         val plainTextMode = NovelViewerTextUtils.isPlainTextChapter(chapterUrl)
-        
+
         // Get user preferences for embedded CSS/JS
         val keepEmbeddedCss = preferences.enableEpubStyles.get()
         val keepEmbeddedJs = preferences.enableEpubJs.get()
         val blockMedia = preferences.novelBlockMedia.get()
-        
+
         // Normalize and sanitize content
         var cleanContent = if (plainTextMode) {
             NovelViewerTextUtils.normalizePlainTextContent(content)
@@ -1677,12 +1735,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         val chapterPath = chapterModel?.url.orEmpty()
         val normalizedChapterUrl = normalizeUrl(chapterPath)
         val plainTextMode = NovelViewerTextUtils.isPlainTextChapter(normalizedChapterUrl)
-        
+
         // Get user preferences for embedded CSS/JS
         val keepEmbeddedCss = preferences.enableEpubStyles.get()
         val keepEmbeddedJs = preferences.enableEpubJs.get()
         val blockMedia = preferences.novelBlockMedia.get()
-        
+
         // Normalize and sanitize content
         var cleanContent = if (plainTextMode) {
             NovelViewerTextUtils.normalizePlainTextContent(content)
@@ -1690,6 +1748,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
             val normalized = NovelViewerTextUtils.normalizeContentForHtml(content, normalizedChapterUrl)
             sanitizeHtmlForWebView(normalized, keepEmbeddedCss, keepEmbeddedJs, blockMedia)
         }
+
+        scheduleNovelImagePrefetch(cleanContent, chapterId.takeIf { it != -1L }, currentPage?.chapter?.pageLoader)
 
         // Apply user's regex find & replace rules
         cleanContent = applyRegexReplacements(cleanContent)
@@ -1724,11 +1784,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         }
 
         // Build global JS variables for custom scripts
-    val chapterMetaScript = buildTsundokuScript()
+        val chapterMetaScript = buildTsundokuScript()
 
-    // Get theme tokens for CSS variables and JS exposure
-    val theme = preferences.novelTheme.get()
-    val themeTokens = NovelViewerTextUtils.getThemeTokens(activity, preferences, theme)
+        // Get theme tokens for CSS variables and JS exposure
+        val theme = preferences.novelTheme.get()
+        val themeTokens = NovelViewerTextUtils.getThemeTokens(activity, preferences, theme)
 
         var finalContent = cleanContent
         var embeddedHead = ""
@@ -1747,7 +1807,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                 // Note: If keepEmbeddedCss is true, styles were already kept by sanitizeHtmlForWebView
                 // If keepEmbeddedCss is false, styles were already stripped
                 // We don't need to do anything here since sanitization was already done
-                
+
                 // Note: If keepEmbeddedJs is true, scripts were already kept by sanitizeHtmlForWebView
                 // If keepEmbeddedJs is false, scripts were already stripped
                 // We don't need to do anything here since sanitization was already done
@@ -1771,13 +1831,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         } else {
             ""
         }
-        
+
         // Escape theme token CSS variables for safe embedding in HTML
         val escapedThemeCss = themeTokens.cssVariables
             .replace("</style>", "<\\/style>")
             .replace("</Style>", "<\\/Style>")
             .replace("</STYLE>", "<\\/STYLE>")
-        
+
         // Build theme exposure script - escape for safe embedding
         val escapedThemeJson = themeTokens.jsObject
             .replace("\\", "\\\\")
@@ -2248,7 +2308,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
                                 if (window.Android && window.Android.onContentEdited) {
                                     window.Android.onContentEdited();
                                 }
-                            });
+                            };
+                            document.addEventListener('input', inputListener);
+                            window.$TSUNDOKU_OBJECT_NAME.runtime.inputListener = inputListener;
                         }
                     } else {
                         var style = document.getElementById(styleId);
@@ -2431,6 +2493,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
         }
 
         val processedContent = activity.translateContentIfEnabled(content)
+        scheduleNovelImagePrefetch(processedContent, chapterId, page.chapter.pageLoader)
         val plainTextMode = NovelViewerTextUtils.isPlainTextChapter(chapter.chapter.url)
         val renderableContent = if (plainTextMode) {
             NovelViewerTextUtils.normalizePlainTextContent(processedContent)
@@ -2906,10 +2969,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer, TextToSpeech.On
 
         applyTtsSettings()
 
+        pendingTtsText = null
         ttsPaused = false
 
         // Android TTS has a max length limit (~4000 chars), chunk long text
-        val maxLength = TextToSpeech.getMaxSpeechInputLength()
+        val maxLength = TextToSpeech.getMaxSpeechInputLength().takeIf { it > 0 } ?: 4000
 
         val paragraphs = text.split("\n").filter { it.isNotBlank() }
         val chunkParagraphIndexes = mutableListOf<Int>()

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -11,6 +11,7 @@ import tachiyomi.domain.storage.service.StorageManager
 import tachiyomi.domain.translation.model.TranslatedChapter
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import java.io.File
+import java.security.MessageDigest
 
 /**
  * Filesystem-only implementation of [TranslatedChapterRepository].
@@ -129,13 +130,25 @@ class TranslatedChapterRepositoryImpl(
 
     private val META_PREFIX = "<!-- tsundoku-meta:"
     private val META_SUFFIX = " -->"
-    private val META_REGEX = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+) -->\\n?")
+    private val META_REGEX = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+)(?::([a-f0-9]{64}))? -->\\n?")
 
-    private fun buildMetaComment(engineId: String, dateTranslated: Long): String {
-        return "$META_PREFIX$engineId:$dateTranslated$META_SUFFIX\n"
+    private fun buildMetaComment(engineId: String, dateTranslated: Long, sourceContentHash: String? = null): String {
+        val hashPart = if (!sourceContentHash.isNullOrEmpty()) ":$sourceContentHash" else ""
+        return "$META_PREFIX$engineId:$dateTranslated$hashPart$META_SUFFIX\n"
     }
 
-    private data class FileMeta(val engineId: String, val dateTranslated: Long, val content: String)
+    private fun computeSourceHash(content: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(content.toByteArray(Charsets.UTF_8))
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    private data class FileMeta(
+        val engineId: String,
+        val dateTranslated: Long,
+        val sourceHash: String?,
+        val content: String,
+    )
 
     /** Read a translation file, parsing the optional metadata comment from the first line. */
     private fun parseUniFile(file: UniFile): FileMeta? {
@@ -151,10 +164,11 @@ class TranslatedChapterRepositoryImpl(
             FileMeta(
                 engineId = match.groupValues[1],
                 dateTranslated = match.groupValues[2].toLong(),
+                sourceHash = match.groupValues[3].takeIf { it.isNotEmpty() },
                 content = raw.removeRange(match.range).trimStart('\n'),
             )
         } else {
-            FileMeta(engineId = "unknown", dateTranslated = 0L, content = raw)
+            FileMeta(engineId = "unknown", dateTranslated = 0L, sourceHash = null, content = raw)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -109,6 +109,30 @@ class TranslationPreferences(
     )
 
     /**
+     * NVIDIA NIM base URL.
+     */
+    fun nvidiaNimBaseUrl() = preferenceStore.getString(
+        "translation_nvidia_nim_base_url",
+        "http://localhost:8000",
+    )
+
+    /**
+     * NVIDIA NIM API key (optional).
+     */
+    fun nvidiaNimApiKey() = preferenceStore.getString(
+        "translation_nvidia_nim_api_key",
+        "",
+    )
+
+    /**
+     * NVIDIA NIM model name.
+     */
+    fun nvidiaNimModel() = preferenceStore.getString(
+        "translation_nvidia_nim_model",
+        "",
+    )
+
+    /**
      * DeepSeek API key.
      */
     fun deepSeekApiKey() = preferenceStore.getString(


### PR DESCRIPTION

- **Translation Engine**: Adds support for NVIDIA NIM (OpenAI-compatible) translation engine, plus smarter caching, better error handling, and auto-translation of downloaded chapters.



## Changes

### 1. New Translation Engine: NVIDIA NIM
- **`NvidiaNimTranslateEngine.kt`**
  - Implements translation via NVIDIA NIM’s OpenAI‑compatible chat completions API.

### 3. Translation Cache Reliability
- **`TranslationService.kt`** & **`TranslatedChapterRepositoryImpl.kt`**  
  - Cached translations now include a SHA‑256 hash of the source content (hidden in an HTML comment).
  - When retrieving a cached translation, the hash is verified against the current source content to prevent serving stale/outdated translations.

### 4. Auto‑Translation for Downloaded Chapters
- **`ReaderViewModel.kt`**  
  - New `pendingTranslationAheadChapterIds` set to track chapters that need translation after download completes.


### 5. Translation Error Handling & UX
- **`ReaderActivity.kt`**  
  - If translation fails, the activity now disables translation mode and shows a toast with the error message (instead of silently failing).

- **`GeminiTranslateEngine.kt`**  
  - Improved error parsing to extract detailed message from Gemini’s response body.

- **`GoogleTranslateScraperEngine.kt`**  
  - Wrapped translation in `withContext(Dispatchers.IO)` to avoid blocking the main thread.
 - Fixed issue where paragraphs arent preserved due to bad parsing
### 6. Novel Viewer Rendering Improvements
- **`NovelViewer.kt`**  
  - Added `renderGeneration` counter to cancel stale async translation updates when reloading.
  - New `prepareContentForTranslation()` method that applies regex replacements, lowercasing, and optional chapter title stripping before sending text to the translation engine.
  - `setTextViewContent()` now accepts a `processContent` flag – when `false`, it skips regex replacements and directly displays already‑processed content (avoids double‑processing).
- **`NovelViewerTextUtils.kt`**  
  - Cached regex replacements (`regexReplacementsCache`) and int‑map preferences (`intMapJsonCache`) for performance.
  - Improved paragraph detection: uses Jsoup to parse HTML block elements (`p`, `div`, `section`, etc.) instead of naive splitting.
  - Added `normalizeUrl()` helper.
  - Fixed front‑matter stripping (now uses `replaceFirst` instead of `replace`).
