### PR TITLE
fix(download): recognize .zip archives alongside .cbz for novel downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Make JS scripts regardless of inf scroll [@mrissaoussama](https://github.com/mrissaoussama) [#220](https://github.com/tsundoku-otaku/tsundoku/pull/220)
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)
+- Correctly recognize .zip archives [@mrissaoussama](https://github.com/mrissaoussama) [#226](https://github.com/tsundoku-otaku/tsundoku/pull/226)
 - Make Grid items better respect max lines limits in library [@mrissaoussama](https://github.com/mrissaoussama) [#216](https://github.com/tsundoku-otaku/tsundoku/pull/216)
 - Fix HTML vs plain text detection [@mrissaoussama](https://github.com/mrissaoussama) [#223](https://github.com/tsundoku-otaku/tsundoku/pull/223)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -62,7 +62,7 @@ class ChapterContentReader(
             source,
         ) ?: return null
 
-        val isCbz = chapterDirOrCbz.name?.endsWith(".cbz") == true
+        val isCbz = chapterDirOrCbz.name?.let { it.endsWith(".cbz") || it.endsWith(".zip") } == true
 
         return if (isCbz) {
             readContentFromCbz(chapterDirOrCbz)
@@ -82,7 +82,7 @@ class ChapterContentReader(
     ): String? {
         val mangaDir = downloadProvider.findMangaDir(manga.title, source) ?: return null
         val cbzFiles = mangaDir.listFiles()?.filter {
-            it.isFile && it.name?.endsWith(".cbz") == true
+            it.isFile && (it.name?.endsWith(".cbz") == true || it.name?.endsWith(".zip") == true)
         } ?: return null
 
         val validNames = downloadProvider.getValidChapterDirNames(
@@ -92,7 +92,7 @@ class ChapterContentReader(
         )
 
         val matchingCbz = cbzFiles.find { cbz ->
-            val base = cbz.name?.removeSuffix(".cbz") ?: ""
+            val base = cbz.name?.substringBeforeLast(".") ?: ""
             validNames.any { it == base }
         } ?: return null
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -415,7 +415,7 @@ class DownloadCache(
                                         // Folder of images
                                         it.isDirectory -> it.name
                                         // CBZ files
-                                        it.isFile && it.extension == "cbz" -> it.nameWithoutExtension
+                                        it.isFile && (it.extension == "cbz" || it.extension == "zip") -> it.nameWithoutExtension
                                         // Anything else is irrelevant
                                         else -> null
                                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -434,8 +434,8 @@ class DownloadManager(
             .firstOrNull() ?: return
 
         var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator, newChapter.url)
-        if (oldDownload.isFile && oldDownload.extension == "cbz") {
-            newName += ".cbz"
+        if (oldDownload.isFile && (oldDownload.extension == "cbz" || oldDownload.extension == "zip")) {
+            newName += ".${oldDownload.extension}"
         }
 
         if (oldDownload.name == newName) return


### PR DESCRIPTION

- DownloadCache: index .zip files so novel downloads show as downloaded
- ChapterContentReader: detect and read .zip archives (not just .cbz)
- DownloadManager: preserve original extension when renaming chapters
