### PR TITLE
Open EPUB files from other apps , browse local source improvements, epub parsing/export fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Added
 - Tap zones for novels [@mrissaoussama](https://github.com/mrissaoussama) [#210](https://github.com/tsundoku-otaku/tsundoku/pull/210)
+- Open EPUBs with app, export with CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#227](https://github.com/tsundoku-otaku/tsundoku/pull/227)
 
 ### Changed
 - Novel downloads will be saved as zip format [@mrissaoussama](https://github.com/mrissaoussama) [#202](https://github.com/tsundoku-otaku/tsundoku/pull/202)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,65 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.tachibk" />
             </intent-filter>
 
+            <!-- Open EPUB files via file manager / "Open with…" -->
+            <intent-filter android:label="@string/epub_import_title">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:host="*" />
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/epub" />
+            </intent-filter>
+
+            <!-- Fallback for file managers that report octet-stream / no mime -->
+            <intent-filter android:label="@string/epub_import_title">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:host="*" />
+                <data android:mimeType="*/*" />
+                <!--
+                Work around Android's primitive PatternMatcher implementation
+                that can't cope with finding a . early in the path unless it's
+                explicitly matched. Mirrors the .tachibk handling above.
+                -->
+                <data android:pathPattern=".*\\.epub" />
+                <data android:pathPattern=".*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.epub" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.epub" />
+            </intent-filter>
+
+            <!-- Share-target: a single EPUB sent via the system share sheet -->
+            <intent-filter android:label="@string/epub_import_title">
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/epub" />
+            </intent-filter>
+
+            <!-- Share-target: multiple EPUBs sent via the system share sheet -->
+            <intent-filter android:label="@string/epub_import_title">
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/epub" />
+            </intent-filter>
+
             <!--suppress AndroidDomInspection -->
             <meta-data
                 android:name="android.app.shortcuts"

--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.SnackbarDuration
@@ -31,11 +32,13 @@ import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.EmptyScreenAction
 import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.source.local.LocalNovelSource
 import tachiyomi.source.local.LocalSource
 
 @Composable
@@ -49,6 +52,7 @@ fun BrowseSourceContent(
     onWebViewClick: () -> Unit,
     onHelpClick: () -> Unit,
     onLocalSourceHelpClick: () -> Unit,
+    onOpenFolderClick: () -> Unit = {},
     onMangaClick: (Manga) -> Unit,
     onMangaLongClick: (Manga) -> Unit,
     selectionMode: Boolean = false,
@@ -93,16 +97,32 @@ fun BrowseSourceContent(
                 is LoadState.Error -> getErrorMessage(errorState)
                 else -> stringResource(MR.strings.no_results_found)
             },
-            actions = if (source is LocalSource) {
-                persistentListOf(
+            actions = when {
+                source is LocalNovelSource -> persistentListOf(
+                    EmptyScreenAction(
+                        stringRes = MR.strings.action_retry,
+                        icon = Icons.Outlined.Refresh,
+                        onClick = mangaList::refresh,
+                    ),
+                    EmptyScreenAction(
+                        stringRes = TDMR.strings.local_novel_source_open_folder,
+                        icon = Icons.Outlined.FolderOpen,
+                        onClick = onOpenFolderClick,
+                    ),
+                    EmptyScreenAction(
+                        stringRes = MR.strings.label_help,
+                        icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                        onClick = onLocalSourceHelpClick,
+                    ),
+                )
+                source is LocalSource -> persistentListOf(
                     EmptyScreenAction(
                         stringRes = MR.strings.local_source_help_guide,
                         icon = Icons.AutoMirrored.Outlined.HelpOutline,
                         onClick = onLocalSourceHelpClick,
                     ),
                 )
-            } else {
-                persistentListOf(
+                else -> persistentListOf(
                     EmptyScreenAction(
                         stringRes = MR.strings.action_retry,
                         icon = Icons.Outlined.Refresh,

--- a/app/src/main/java/eu/kanade/presentation/library/components/BatchExportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/BatchExportEpubDialog.kt
@@ -43,6 +43,9 @@ data class EpubExportOptions(
     val includeChapterRange: Boolean = false,
     val includeStatus: Boolean = false,
     val includeVolumeNumber: Boolean = false,
+    // Active reader CSS/JS snippets bundled into the EPUB output.
+    val includeCustomCss: Boolean = false,
+    val includeCustomJs: Boolean = false,
 )
 
 @Composable
@@ -68,6 +71,8 @@ fun BatchExportEpubDialog(
     var includeChapterRange by remember { mutableStateOf(false) }
     var includeStatus by remember { mutableStateOf(false) }
     var includeVolumeNumber by remember { mutableStateOf(false) }
+    var includeCustomCss by remember { mutableStateOf(false) }
+    var includeCustomJs by remember { mutableStateOf(false) }
 
     // "Both" mode produces two EPUBs → always ZIP; multi-novel → always ZIP
     val needsZip = !isSingleNovel || translationMode == TranslationMode.BOTH || !joinVolumes
@@ -87,6 +92,8 @@ fun BatchExportEpubDialog(
                     includeChapterRange = includeChapterRange,
                     includeStatus = includeStatus,
                     includeVolumeNumber = includeVolumeNumber,
+                    includeCustomCss = includeCustomCss,
+                    includeCustomJs = includeCustomJs,
                 ),
             )
             onDismissRequest()
@@ -213,6 +220,35 @@ fun BatchExportEpubDialog(
                     checked = includeVolumeNumber,
                     onClick = { includeVolumeNumber = !includeVolumeNumber },
                 )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(TDMR.strings.epub_include_custom_assets_section),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_custom_css),
+                    checked = includeCustomCss,
+                    onClick = { includeCustomCss = !includeCustomCss },
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_custom_js),
+                    checked = includeCustomJs,
+                    onClick = { includeCustomJs = !includeCustomJs },
+                )
+
+                if (includeCustomCss || includeCustomJs) {
+                    Text(
+                        text = stringResource(TDMR.strings.epub_include_custom_assets_info),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
@@ -48,6 +48,8 @@ fun ExportEpubDialog(
     var includeChapterRange by remember { mutableStateOf(false) }
     var includeStatus by remember { mutableStateOf(false) }
     var includeVolumeNumber by remember { mutableStateOf(false) }
+    var includeCustomCss by remember { mutableStateOf(false) }
+    var includeCustomJs by remember { mutableStateOf(false) }
 
     // "Both" mode produces two EPUB files → request a ZIP container
     val mimeType = if (translationMode == TranslationMode.BOTH || !joinVolumes) {
@@ -70,6 +72,8 @@ fun ExportEpubDialog(
                     includeChapterRange = includeChapterRange,
                     includeStatus = includeStatus,
                     includeVolumeNumber = includeVolumeNumber,
+                    includeCustomCss = includeCustomCss,
+                    includeCustomJs = includeCustomJs,
                 ),
             )
             onDismissRequest()
@@ -178,6 +182,35 @@ fun ExportEpubDialog(
                     checked = includeVolumeNumber,
                     onClick = { includeVolumeNumber = !includeVolumeNumber },
                 )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(TDMR.strings.epub_include_custom_assets_section),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_custom_css),
+                    checked = includeCustomCss,
+                    onClick = { includeCustomCss = !includeCustomCss },
+                )
+
+                CheckboxItem(
+                    label = stringResource(TDMR.strings.epub_include_custom_js),
+                    checked = includeCustomJs,
+                    onClick = { includeCustomJs = !includeCustomJs },
+                )
+
+                if (includeCustomCss || includeCustomJs) {
+                    Text(
+                        text = stringResource(TDMR.strings.epub_include_custom_assets_info),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ExportEpubDialog.kt
@@ -41,7 +41,7 @@ fun ExportEpubDialog(
     onExport: (Uri, EpubExportOptions) -> Unit,
 ) {
     var filename by remember { mutableStateOf(EpubExportNaming.sanitizeFilename(manga.title) + ".epub") }
-    var downloadedOnly by remember { mutableStateOf(false) }
+    var downloadedOnly by remember { mutableStateOf(true) }
     var translationMode by remember { mutableStateOf(TranslationMode.ORIGINAL) }
     var joinVolumes by remember { mutableStateOf(true) }
     var includeChapterCount by remember { mutableStateOf(false) }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -99,6 +99,124 @@ class ChapterContentReader(
         return readContentFromCbz(matchingCbz)
     }
 
+    // ── Image reading ───────────────────────────────────────────────
+
+    /**
+     * Read all embedded images for [chapter] from its downloaded files.
+     * Returns a map of filename → bytes, e.g. `"image_0.jpg" → ByteArray`.
+     */
+    fun readChapterImages(
+        manga: Manga,
+        chapter: Chapter,
+        source: eu.kanade.tachiyomi.source.Source,
+    ): Map<String, ByteArray> {
+        return try {
+            readImagesFromChapterDir(manga, chapter, source)
+                ?: readImagesFromMangaDirCbz(manga, chapter, source)
+                ?: emptyMap()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read images for chapter: ${chapter.name}" }
+            emptyMap()
+        }
+    }
+
+    private fun readImagesFromChapterDir(
+        manga: Manga,
+        chapter: Chapter,
+        source: eu.kanade.tachiyomi.source.Source,
+    ): Map<String, ByteArray>? {
+        val chapterDirOrCbz = downloadProvider.findChapterDir(
+            chapter.name,
+            chapter.scanlator,
+            chapter.url,
+            manga.title,
+            source,
+        ) ?: return null
+
+        val isCbz = chapterDirOrCbz.name?.let { it.endsWith(".cbz") || it.endsWith(".zip") } == true
+        return if (isCbz) readImagesFromCbz(chapterDirOrCbz) else readImagesFromDirectory(chapterDirOrCbz)
+    }
+
+    private fun readImagesFromMangaDirCbz(
+        manga: Manga,
+        chapter: Chapter,
+        source: eu.kanade.tachiyomi.source.Source,
+    ): Map<String, ByteArray>? {
+        val mangaDir = downloadProvider.findMangaDir(manga.title, source) ?: return null
+        val cbzFiles = mangaDir.listFiles()?.filter {
+            it.isFile && (it.name?.endsWith(".cbz") == true || it.name?.endsWith(".zip") == true)
+        } ?: return null
+
+        val validNames = downloadProvider.getValidChapterDirNames(
+            chapter.name,
+            chapter.scanlator,
+            chapter.url,
+        )
+
+        val matchingCbz = cbzFiles.find { cbz ->
+            val base = cbz.name?.substringBeforeLast(".") ?: ""
+            validNames.any { it == base }
+        } ?: return null
+
+        return readImagesFromCbz(matchingCbz)
+    }
+
+    private fun readImagesFromDirectory(dir: UniFile): Map<String, ByteArray>? {
+        val allFiles = dir.listFiles() ?: return null
+        val imageFiles = allFiles.filter { file ->
+            file.isFile && IMAGE_EXTENSIONS.any { ext ->
+                file.name?.lowercase()?.endsWith(ext) == true
+            }
+        }
+        if (imageFiles.isEmpty()) return null
+
+        return imageFiles.mapNotNull { file ->
+            val name = file.name ?: return@mapNotNull null
+            val bytes = context.contentResolver.openInputStream(file.uri)?.use { it.readBytes() }
+                ?: return@mapNotNull null
+            name to bytes
+        }.toMap().ifEmpty { null }
+    }
+
+    private fun readImagesFromCbz(cbzFile: UniFile): Map<String, ByteArray>? {
+        val uri = cbzFile.uri
+        return try {
+            val pfd = context.contentResolver.openFileDescriptor(uri, "r") ?: return null
+            pfd.use { descriptor ->
+                ArchiveReader(descriptor).use { reader ->
+                    val imageFileNames = mutableListOf<String>()
+                    reader.useEntries { seq ->
+                        seq.forEach { entry ->
+                            val name = entry.name.lowercase()
+                            if (entry.isFile && IMAGE_EXTENSIONS.any { name.endsWith(it) }) {
+                                imageFileNames.add(entry.name)
+                            }
+                        }
+                    }
+
+                    val result = mutableMapOf<String, ByteArray>()
+                    imageFileNames.forEach { fileName ->
+                        try {
+                            reader.getInputStream(fileName)?.use { stream ->
+                                result[fileName.substringAfterLast('/')] = stream.readBytes()
+                            }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR, e) { "CBZ: failed to read image $fileName" }
+                        }
+                    }
+                    result.ifEmpty { null }
+                }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "CBZ: failed to read images from $uri" }
+            null
+        }
+    }
+
+    companion object {
+        private val IMAGE_EXTENSIONS = listOf(".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".avif")
+    }
+
     // ── File-type readers ───────────────────────────────────────────
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.fetchNovelPageText
 import eu.kanade.tachiyomi.source.isNovelSource
@@ -26,9 +27,11 @@ import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
+import eu.kanade.presentation.reader.settings.CodeSnippet
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import mihon.core.archive.EpubWriter
 import mihon.core.archive.epubReader
@@ -43,8 +46,9 @@ import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.translation.model.TranslationMode
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
-import tachiyomi.source.local.io.LocalNovelSourceFileSystem
 import tachiyomi.source.local.LocalNovelSource
+import tachiyomi.source.local.groupChaptersByVolume
+import tachiyomi.source.local.io.LocalNovelSourceFileSystem
 import tachiyomi.source.local.isLocal
 import tachiyomi.source.local.isLocalNovel
 import tachiyomi.i18n.novel.TDMR
@@ -68,6 +72,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
     private val downloadPreferences: DownloadPreferences = Injekt.get()
     private val novelDownloadPreferences: NovelDownloadPreferences = Injekt.get()
     private val localNovelFileSystem: LocalNovelSourceFileSystem = Injekt.get()
+    private val readerPreferences: ReaderPreferences = Injekt.get()
 
     private val notificationBuilder = context.notificationBuilder(Notifications.CHANNEL_EPUB_EXPORT) {
         setSmallIcon(android.R.drawable.ic_menu_save)
@@ -90,9 +95,14 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         val includeStatus = inputData.getBoolean(KEY_INCLUDE_STATUS, false)
         val joinVolumes = inputData.getBoolean(KEY_JOIN_VOLUMES, true)
         val includeVolumeNumber = inputData.getBoolean(KEY_INCLUDE_VOLUME_NUMBER, false)
+        val includeCustomCss = inputData.getBoolean(KEY_INCLUDE_CUSTOM_CSS, false)
+        val includeCustomJs = inputData.getBoolean(KEY_INCLUDE_CUSTOM_JS, false)
 
         logcat(LogPriority.INFO) {
-            "EPUB Export starting: ${mangaIds.size} novels, downloadedOnly=$downloadedOnly, translationMode=$translationMode, joinVolumes=$joinVolumes, includeVolumeNumber=$includeVolumeNumber"
+            "EPUB Export starting: ${mangaIds.size} novels, downloadedOnly=$downloadedOnly, " +
+                "translationMode=$translationMode, joinVolumes=$joinVolumes, " +
+                "includeVolumeNumber=$includeVolumeNumber, includeCustomCss=$includeCustomCss, " +
+                "includeCustomJs=$includeCustomJs"
         }
 
         try {
@@ -113,6 +123,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                     includeStatus = includeStatus,
                     joinVolumes = joinVolumes,
                     includeVolumeNumber = includeVolumeNumber,
+                    includeCustomCss = includeCustomCss,
+                    includeCustomJs = includeCustomJs,
                 )
                 Result.success()
             } catch (e: Exception) {
@@ -151,10 +163,15 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         includeStatus: Boolean,
         joinVolumes: Boolean,
         includeVolumeNumber: Boolean,
+        includeCustomCss: Boolean,
+        includeCustomJs: Boolean,
     ) {
         logcat(LogPriority.INFO) {
             "performExport called with ${mangaIds.size} manga IDs, outputUri=$outputUri, translationMode=$translationMode, joinVolumes=$joinVolumes"
         }
+
+        val bundledCss = if (includeCustomCss) collectActiveCustomCss() else null
+        val bundledJs = if (includeCustomJs) collectActiveCustomJs() else null
 
         val mangaList = mangaIds.mapNotNull { mangaRepository.getMangaById(it) }
         if (mangaList.isEmpty()) {
@@ -258,15 +275,20 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                             var originalContent: String? = null
                             var originalImages: Map<String, ByteArray> = emptyMap()
                             if (translationMode != TranslationMode.TRANSLATED && isDownloaded) {
-                                originalContent = if (localContext != null) {
-                                    readLocalEpubContentForExport(
+                                if (localContext != null) {
+                                    val localExport = readLocalEpubChapterForExport(
                                         localContext = localContext,
                                         chapterHref = resolvedLocalChapterHref,
                                         fallbackOrder = localOrderInVolume,
                                     )
-                                        ?: readOriginalContent(manga, chapter, source)
+                                    if (localExport != null) {
+                                        originalContent = localExport.html
+                                        originalImages = localExport.images
+                                    } else {
+                                        originalContent = readOriginalContent(manga, chapter, source)
+                                    }
                                 } else {
-                                    readOriginalContent(manga, chapter, source)
+                                    originalContent = readOriginalContent(manga, chapter, source)
                                 }
                                 if (!isLocalSource && originalContent != null &&
                                     originalContent.contains("tsundoku-novel-image://")
@@ -389,6 +411,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                 metadata = epubMetadata,
                                 chapters = outputChapters,
                                 coverImage = cover,
+                                customCss = bundledCss,
+                                customJs = bundledJs,
                             )
                         }
                     }
@@ -738,11 +762,15 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         return context
     }
 
-    private fun readLocalEpubContentForExport(
+    /**
+     * Reads a single chapter from a local EPUB into the export pipeline. Returns the body
+     * HTML plus the raw bytes of every internal image it references
+     */
+    private fun readLocalEpubChapterForExport(
         localContext: LocalEpubContext,
         chapterHref: String?,
         fallbackOrder: Int?,
-    ): String? {
+    ): mihon.core.archive.EpubReader.ChapterExportData? {
         val reader = localContext.reader
         val tocEntry = findBestTocEntry(localContext.toc, chapterHref, fallbackOrder)
 
@@ -754,24 +782,34 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         }.distinct()
 
         hrefAttempts.forEach { href ->
-            val content = runCatching { reader.getChapterContentForExport(href) }
+            val data = runCatching { reader.extractChapterForExport(href) }
                 .getOrNull()
-                ?.takeIf { it.isNotBlank() }
-            if (content != null) return content
+                ?.takeIf { it.html.isNotBlank() }
+            if (data != null) return data
         }
 
         if (chapterHref.isNullOrBlank()) {
-            val fallbackContent = runCatching {
+            val fallback = runCatching {
                 val packagePath = reader.getPackageHref()
                 val pages = reader.getPagesFromDocument(reader.getPackageDocument(packagePath))
-                pages.mapNotNull { pageHref ->
-                    reader.getChapterContentForExport(pageHref).takeIf { it.isNotBlank() }
-                }.joinToString("\n\n")
-            }.getOrDefault("")
+                val combined = StringBuilder()
+                val mergedImages = linkedMapOf<String, ByteArray>()
+                pages.forEach { pageHref ->
+                    val data = reader.extractChapterForExport(pageHref)
+                    if (data.html.isNotBlank()) {
+                        if (combined.isNotEmpty()) combined.append("\n\n")
+                        combined.append(data.html)
+                        data.images.forEach { (id, bytes) -> mergedImages.putIfAbsent(id, bytes) }
+                    }
+                }
+                if (combined.isNotEmpty()) {
+                    mihon.core.archive.EpubReader.ChapterExportData(combined.toString(), mergedImages)
+                } else {
+                    null
+                }
+            }.getOrNull()
 
-            if (fallbackContent.isNotBlank()) {
-                return fallbackContent
-            }
+            if (fallback != null) return fallback
         }
 
         return null
@@ -972,94 +1010,20 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
     ) {
         if (chapterContents.isEmpty() || localContexts.isEmpty()) return
 
-        val localContextByKey = localContexts.associateBy { it.key }
-        val localDbChapters = chapterContents
-            .filter { chapter ->
-                chapter.volumeKey != null &&
-                    localContextByKey.containsKey(chapter.volumeKey)
-            }
-            .sortedBy { it.order }
+        val knownVolumeKeys = localContexts.mapTo(hashSetOf()) { it.key }
+        val regrouped = groupChaptersByVolume(
+            chapters = chapterContents.toList(),
+            volumeKeyOf = { chapter ->
+                chapter.volumeKey?.takeIf { it in knownVolumeKeys }
+            },
+            orderOf = { it.order },
+            withOrder = { chapter, newOrder -> chapter.copy(order = newOrder) },
+        )
 
-        if (localDbChapters.isEmpty()) return
-
-        val chaptersByHref = linkedMapOf<String, ChapterContent>()
-        localDbChapters.forEach { chapter ->
-            val volumeKey = chapter.volumeKey ?: return@forEach
-            val chapterHref = chapter.chapterHref?.takeIf { it.isNotBlank() } ?: return@forEach
-            val key = buildLocalChapterLookupKey(volumeKey, chapterHref)
-            chaptersByHref.putIfAbsent(key, chapter)
-        }
-
-        val chaptersByVolumeOrder = localDbChapters
-            .groupBy { it.volumeKey }
-            .mapValues { (_, chapters) -> chapters.sortedBy { it.order } }
-
-        val rebuilt = mutableListOf<ChapterContent>()
-        var nextOrder = 0
-
-        localContexts.forEach { localContext ->
-            val toc = localContext.toc.sortedBy { it.order }
-
-            if (toc.isEmpty()) {
-                chaptersByVolumeOrder[localContext.key]
-                    .orEmpty()
-                    .forEach { chapter ->
-                        rebuilt.add(chapter.copy(order = nextOrder++))
-                    }
-                return@forEach
-            }
-
-            toc.forEachIndexed { tocIndex, tocEntry ->
-                val key = buildLocalChapterLookupKey(localContext.key, tocEntry.href)
-                val existing = chaptersByHref[key]
-                    ?: chaptersByVolumeOrder[localContext.key]?.getOrNull(tocIndex)
-
-                val title = existing?.name
-                    ?.takeIf { it.isNotBlank() }
-                    ?: tocEntry.title.trim().ifBlank { "Chapter ${nextOrder + 1}" }
-
-                val originalContent = existing?.originalContent
-                    ?.takeIf { it.isNotBlank() }
-                    ?: readLocalEpubContentForExport(localContext, tocEntry.href, tocEntry.order)
-                        ?.takeIf { it.isNotBlank() }
-
-                rebuilt.add(
-                    ChapterContent(
-                        name = title,
-                        chapterNumber = existing?.chapterNumber ?: 0.0,
-                        order = nextOrder++,
-                        originalContent = originalContent,
-                        translatedContent = existing?.translatedContent?.takeIf { it.isNotBlank() },
-                        volumeKey = localContext.key,
-                        volumeLabel = localContext.volumeLabel,
-                        volumeNumber = localContext.volumeNumber,
-                        chapterHref = tocEntry.href,
-                    ),
-                )
-            }
-        }
-
-        if (rebuilt.isEmpty()) return
-
-        val nonLocalChapters = chapterContents
-            .filterNot { chapter ->
-                chapter.volumeKey != null &&
-                    localContextByKey.containsKey(chapter.volumeKey)
-            }
-            .sortedBy { it.order }
-            .mapIndexed { index, chapter ->
-                chapter.copy(order = rebuilt.size + index)
-            }
+        if (regrouped == chapterContents) return
 
         chapterContents.clear()
-        chapterContents.addAll(rebuilt)
-        chapterContents.addAll(nonLocalChapters)
-    }
-
-    private fun buildLocalChapterLookupKey(volumeKey: String, href: String): String {
-        val path = normalizeHrefPath(href.substringBefore("#"))
-        val fragment = normalizeHrefFragment(href.substringAfter("#", ""))
-        return "$volumeKey|$path#$fragment"
+        chapterContents.addAll(regrouped)
     }
 
     private fun buildExportFilename(
@@ -1257,6 +1221,70 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         )
     }
 
+    /**
+     * Joins every currently enabled CSS source into a single stylesheet body,
+     * separated by `/* @snippet: title */` markers.
+     *
+     * Returns null when there's nothing to bundle.
+     */
+    private fun collectActiveCustomCss(): String? {
+        val pieces = mutableListOf<String>()
+
+        readerPreferences.novelCustomCss.get()
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?.let { pieces += "/* @custom-css */\n$it" }
+
+        decodeSnippets(readerPreferences.novelCustomCssSnippets.get(), "CSS")
+            .filter { it.enabled && it.code.isNotBlank() }
+            .forEach { snippet ->
+                pieces += "/* @snippet: ${snippet.title.ifBlank { "untitled" }} */\n${snippet.code}"
+            }
+
+        return pieces.joinToString("\n\n").takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Joins every currently enabled JS source
+     * into a single script body.
+     *
+     * Returns null when nothing is enabled.
+     */
+    private fun collectActiveCustomJs(): String? {
+        val pieces = mutableListOf<String>()
+
+        readerPreferences.novelCustomJs.get()
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?.let { pieces += wrapJsPiece(title = "custom-js", code = it) }
+
+        decodeSnippets(readerPreferences.novelCustomJsSnippets.get(), "JS")
+            .filter { it.enabled && it.code.isNotBlank() }
+            .forEach { snippet ->
+                pieces += wrapJsPiece(
+                    title = snippet.title.ifBlank { "untitled" },
+                    code = snippet.code,
+                )
+            }
+
+        return pieces.joinToString("\n\n").takeIf { it.isNotBlank() }
+    }
+
+    private fun decodeSnippets(json: String, label: String): List<CodeSnippet> {
+        return try {
+            Json.decodeFromString<List<CodeSnippet>>(json)
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to decode $label snippets for export" }
+            emptyList()
+        }
+    }
+
+    private fun wrapJsPiece(title: String, code: String): String {
+        return "/* @snippet: $title */\n(function () {\n  try {\n$code\n  } catch (e) {\n" +
+            "    if (typeof console !== 'undefined' && console.error) console.error(e);\n" +
+            "  }\n})();"
+    }
+
     private fun showErrorNotification(error: String) {
         context.cancelNotification(Notifications.ID_EPUB_EXPORT_PROGRESS)
         context.notify(
@@ -1281,6 +1309,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         private const val KEY_INCLUDE_STATUS = "include_status"
         private const val KEY_JOIN_VOLUMES = "join_volumes"
         private const val KEY_INCLUDE_VOLUME_NUMBER = "include_volume_number"
+        private const val KEY_INCLUDE_CUSTOM_CSS = "include_custom_css"
+        private const val KEY_INCLUDE_CUSTOM_JS = "include_custom_js"
 
         fun start(
             context: Context,
@@ -1293,6 +1323,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
             includeStatus: Boolean = false,
             joinVolumes: Boolean = true,
             includeVolumeNumber: Boolean = false,
+            includeCustomCss: Boolean = false,
+            includeCustomJs: Boolean = false,
         ) {
             val data = workDataOf(
                 KEY_MANGA_IDS to mangaIds.toLongArray(),
@@ -1304,6 +1336,8 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                 KEY_INCLUDE_STATUS to includeStatus,
                 KEY_JOIN_VOLUMES to joinVolumes,
                 KEY_INCLUDE_VOLUME_NUMBER to includeVolumeNumber,
+                KEY_INCLUDE_CUSTOM_CSS to includeCustomCss,
+                KEY_INCLUDE_CUSTOM_JS to includeCustomJs,
             )
 
             context.notify(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
@@ -9,6 +9,9 @@ import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import eu.kanade.tachiyomi.data.download.ChapterContentReader
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.notification.Notifications
@@ -34,6 +37,7 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
@@ -62,6 +66,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
     private val networkHelper: NetworkHelper = Injekt.get()
     private val translatedChapterRepository: TranslatedChapterRepository = Injekt.get()
     private val downloadPreferences: DownloadPreferences = Injekt.get()
+    private val novelDownloadPreferences: NovelDownloadPreferences = Injekt.get()
     private val localNovelFileSystem: LocalNovelSourceFileSystem = Injekt.get()
 
     private val notificationBuilder = context.notificationBuilder(Notifications.CHANNEL_EPUB_EXPORT) {
@@ -251,6 +256,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
 
                             // Original content
                             var originalContent: String? = null
+                            var originalImages: Map<String, ByteArray> = emptyMap()
                             if (translationMode != TranslationMode.TRANSLATED && isDownloaded) {
                                 originalContent = if (localContext != null) {
                                     readLocalEpubContentForExport(
@@ -261,6 +267,11 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                         ?: readOriginalContent(manga, chapter, source)
                                 } else {
                                     readOriginalContent(manga, chapter, source)
+                                }
+                                if (!isLocalSource && originalContent != null &&
+                                    originalContent.contains("tsundoku-novel-image://")
+                                ) {
+                                    originalImages = readOriginalImages(manga, chapter, source)
                                 }
                             }
 
@@ -306,6 +317,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                         volumeLabel = localContext?.volumeLabel,
                                         volumeNumber = localContext?.volumeNumber,
                                         chapterHref = resolvedLocalChapterHref,
+                                        images = originalImages,
                                     ),
                                 )
                             }
@@ -412,6 +424,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                         title = ch.name,
                                         content = ch.originalContent.orEmpty(),
                                         order = ch.order,
+                                        images = toEmbeddedImages(ch.images),
                                     )
                                 }
 
@@ -475,6 +488,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                         title = ch.name,
                                         content = ch.originalContent.orEmpty(),
                                         order = ch.order,
+                                        images = toEmbeddedImages(ch.images),
                                     )
                                 }
                                 if (originalEpubChapters.isNotEmpty()) {
@@ -633,6 +647,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         val volumeLabel: String?,
         val volumeNumber: Int?,
         val chapterHref: String?,
+        val images: Map<String, ByteArray> = emptyMap(),
     )
 
     private data class LocalEpubReference(
@@ -1084,6 +1099,54 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
 
         filenameBuilder.append(".epub")
         return filenameBuilder.toString()
+    }
+
+    private fun readOriginalImages(
+        manga: Manga,
+        chapter: tachiyomi.domain.chapter.model.Chapter,
+        source: eu.kanade.tachiyomi.source.Source,
+    ): Map<String, ByteArray> {
+        return try {
+            ChapterContentReader(context, downloadProvider).readChapterImages(manga, chapter, source)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read images for chapter: ${chapter.name}" }
+            emptyMap()
+        }
+    }
+
+    private fun toEmbeddedImages(images: Map<String, ByteArray>): List<EpubWriter.EmbeddedImage> {
+        if (images.isEmpty()) return emptyList()
+        val maxSizeKb = novelDownloadPreferences.maxImageSizeKb().get()
+        val quality = novelDownloadPreferences.imageCompressionQuality().get()
+        return images.map { (id, bytes) ->
+            val (mime, ext) = EpubWriter.detectImageType(bytes)
+            val finalBytes = if (maxSizeKb > 0 && bytes.size > maxSizeKb * 1024 && mime != "image/gif") {
+                compressImageForEpub(bytes, quality, maxSizeKb) ?: bytes
+            } else {
+                bytes
+            }
+            val (finalMime, finalExt) = if (finalBytes !== bytes) "image/jpeg" to "jpg" else mime to ext
+            EpubWriter.EmbeddedImage(id = id, bytes = finalBytes, mimeType = finalMime, extension = finalExt)
+        }
+    }
+
+    private fun compressImageForEpub(imageBytes: ByteArray, quality: Int, maxSizeKb: Int): ByteArray? {
+        return try {
+            val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size) ?: return null
+            var currentQuality = quality.coerceIn(10, 100)
+            var outputBytes: ByteArray
+            do {
+                val out = java.io.ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, currentQuality, out)
+                outputBytes = out.toByteArray()
+                currentQuality -= 10
+            } while (outputBytes.size > maxSizeKb * 1024 && currentQuality >= 10)
+            bitmap.recycle()
+            outputBytes
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to compress image for EPUB" }
+            null
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.epub
 import android.content.Context
 import android.net.Uri
 import android.os.Build
+import androidx.core.net.toUri
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
@@ -39,6 +40,7 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.manga.model.Manga
@@ -54,6 +56,7 @@ import tachiyomi.source.local.isLocalNovel
 import tachiyomi.i18n.novel.TDMR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.URLDecoder
 import java.util.zip.ZipEntry
@@ -115,7 +118,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
             try {
                 performExport(
                     mangaIds = mangaIds,
-                    outputUri = Uri.parse(uriString),
+                    outputUri = uriString.toUri(),
                     downloadedOnly = downloadedOnly,
                     translationMode = translationMode,
                     includeChapterCount = includeChapterCount,
@@ -622,7 +625,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                     showErrorNotification(context.stringResource(TDMR.strings.epub_export_job_error_write_output))
                     return
                 }
-            } else if (tempFiles.isNotEmpty()) {
+            } else {
                 // Single file, copy directly
                 logcat(LogPriority.INFO) {
                     "Writing single EPUB to $outputUri (size=${tempFiles.first().length()} bytes)"
@@ -963,7 +966,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
         unit: VolumeUnit,
         includeVolumeNumber: Boolean,
         fallbackIndex: Int,
-    ): String? {
+    ): String {
         if (includeVolumeNumber && unit.number != null) {
             return "v${unit.number}"
         }
@@ -1067,7 +1070,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
 
     private fun readOriginalImages(
         manga: Manga,
-        chapter: tachiyomi.domain.chapter.model.Chapter,
+        chapter: Chapter,
         source: eu.kanade.tachiyomi.source.Source,
     ): Map<String, ByteArray> {
         return try {
@@ -1100,7 +1103,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
             var currentQuality = quality.coerceIn(10, 100)
             var outputBytes: ByteArray
             do {
-                val out = java.io.ByteArrayOutputStream()
+                val out = ByteArrayOutputStream()
                 bitmap.compress(Bitmap.CompressFormat.JPEG, currentQuality, out)
                 outputBytes = out.toByteArray()
                 currentQuality -= 10
@@ -1119,7 +1122,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
      */
     private suspend fun readOriginalContent(
         manga: Manga,
-        chapter: tachiyomi.domain.chapter.model.Chapter,
+        chapter: Chapter,
         source: eu.kanade.tachiyomi.source.Source,
     ): String? {
         return try {
@@ -1127,7 +1130,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                 return source.fetchNovelPageText(Page(0, chapter.url))
             }
 
-            val reader = eu.kanade.tachiyomi.data.download.ChapterContentReader(context, downloadProvider)
+            val reader = ChapterContentReader(context, downloadProvider)
             reader.readDownloadedContent(manga, chapter, source)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Failed to read downloaded chapter: ${chapter.name}" }
@@ -1180,7 +1183,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                     response.body.bytes()
                 }
             } else {
-                context.contentResolver.openInputStream(Uri.parse(url))?.use { stream -> stream.readBytes() }
+                context.contentResolver.openInputStream(url.toUri())?.use { stream -> stream.readBytes() }
             }
         }.getOrNull()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -66,11 +66,7 @@ class AndroidSourceManager(
                             Injekt.get(),
                             Injekt.get(),
                         ),
-                        LocalNovelSource.ID to LocalNovelSource(
-                            context,
-                            Injekt.get(),
-                            Injekt.get(),
-                        ),
+                        LocalNovelSource.ID to LocalNovelSource(),
                     ),
                 )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -399,10 +399,8 @@ data class BrowseSourceScreen(
                                 },
                             )
                         }
-                        // Actions when items are selected
                         if (state.selectionMode && state.selection.isNotEmpty()) {
                             if (source is LocalNovelSource) {
-                                // Add to library
                                 FilterChip(
                                     selected = true,
                                     onClick = { screenModel.showBulkAddLocalNovelsDialog() },
@@ -415,7 +413,6 @@ data class BrowseSourceScreen(
                                     },
                                     label = { Text(text = stringResource(TDMR.strings.local_novel_source_add_to_library)) },
                                 )
-                                // Refresh covers
                                 FilterChip(
                                     selected = true,
                                     onClick = {
@@ -437,7 +434,6 @@ data class BrowseSourceScreen(
                                     },
                                     label = { Text(text = stringResource(TDMR.strings.local_novel_source_refresh_covers)) },
                                 )
-                                // Delete
                                 FilterChip(
                                     selected = true,
                                     onClick = {
@@ -607,7 +603,20 @@ data class BrowseSourceScreen(
                     title = { Text(text = stringResource(TDMR.strings.local_novel_source_delete_title)) },
                     text = { Text(text = stringResource(TDMR.strings.local_novel_source_delete_message)) },
                     confirmButton = {
-                        TextButton(onClick = { screenModel.deleteLocalNovels(dialog.mangas) }) {
+                        TextButton(
+                            onClick = {
+                                screenModel.deleteLocalNovels(dialog.mangas) { _, failed ->
+                                    if (failed > 0) {
+                                        scope.launchIO {
+                                            snackbarHostState.showSnackbar(
+                                                context.stringResource(TDMR.strings.local_novel_source_delete_failed, failed),
+                                                duration = SnackbarDuration.Long,
+                                            )
+                                        }
+                                    }
+                                }
+                            },
+                        ) {
                             Text(text = stringResource(MR.strings.action_delete))
                         }
                     },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
+import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
@@ -10,20 +11,30 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Autorenew
 import androidx.compose.material.icons.outlined.Checklist
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -36,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -44,6 +56,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.presentation.category.visualName
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.MissingSourceScreen
@@ -69,7 +82,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import mihon.feature.migration.dialog.MigrateMangaDialog
 import mihon.presentation.core.util.collectAsLazyPagingItems
 import tachiyomi.core.common.Constants
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
@@ -77,6 +92,7 @@ import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.source.local.LocalNovelSource
 import tachiyomi.source.local.LocalSource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -136,6 +152,7 @@ data class BrowseSourceScreen(
         }
 
         val scope = rememberCoroutineScope()
+        val context = LocalContext.current
         val haptic = LocalHapticFeedback.current
         val uriHandler = LocalUriHandler.current
         val snackbarHostState = remember { SnackbarHostState() }
@@ -179,7 +196,26 @@ data class BrowseSourceScreen(
             }
         }
 
-        val onHelpClick = { uriHandler.openUri(LocalSource.HELP_URL) }
+        val onHelpClick = {
+            val url = if (source is LocalNovelSource) LocalNovelSource.HELP_URL else LocalSource.HELP_URL
+            uriHandler.openUri(url)
+        }
+        val onOpenFolderClick = {
+            val localNovelSource = source as? LocalNovelSource
+            val dirUri = localNovelSource?.getLocalSourceDir()
+            if (dirUri != null) {
+                val intent = Intent(Intent.ACTION_VIEW, dirUri).apply {
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                runCatching { context.startActivity(intent) }.onFailure {
+                    scope.launchIO {
+                        snackbarHostState.showSnackbar(
+                            context.stringResource(TDMR.strings.local_novel_source_open_folder_error),
+                        )
+                    }
+                }
+            }
+        }
         val onWebViewClick = f@{
             val url: String
             val name: String
@@ -363,23 +399,75 @@ data class BrowseSourceScreen(
                                 },
                             )
                         }
-                        // Add to library button when in selection mode with items selected
+                        // Actions when items are selected
                         if (state.selectionMode && state.selection.isNotEmpty()) {
-                            FilterChip(
-                                selected = true,
-                                onClick = { showMassImportDialog = true },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = Icons.Outlined.Favorite,
-                                        contentDescription = null,
-                                        modifier = Modifier
-                                            .size(FilterChipDefaults.IconSize),
-                                    )
-                                },
-                                label = {
-                                    Text(text = stringResource(MR.strings.add_to_library))
-                                },
-                            )
+                            if (source is LocalNovelSource) {
+                                // Add to library
+                                FilterChip(
+                                    selected = true,
+                                    onClick = { screenModel.showBulkAddLocalNovelsDialog() },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Favorite,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                        )
+                                    },
+                                    label = { Text(text = stringResource(TDMR.strings.local_novel_source_add_to_library)) },
+                                )
+                                // Refresh covers
+                                FilterChip(
+                                    selected = true,
+                                    onClick = {
+                                        screenModel.refreshLocalNovelCovers(state.selection) { count ->
+                                            scope.launchIO {
+                                                snackbarHostState.showSnackbar(
+                                                    context.stringResource(TDMR.strings.local_novel_source_covers_refreshed, count),
+                                                    duration = SnackbarDuration.Short,
+                                                )
+                                            }
+                                        }
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Autorenew,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                        )
+                                    },
+                                    label = { Text(text = stringResource(TDMR.strings.local_novel_source_refresh_covers)) },
+                                )
+                                // Delete
+                                FilterChip(
+                                    selected = true,
+                                    onClick = {
+                                        screenModel.setDialog(
+                                            BrowseSourceScreenModel.Dialog.ConfirmDeleteLocalNovels(state.selection),
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Delete,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                        )
+                                    },
+                                    label = { Text(text = stringResource(MR.strings.action_delete)) },
+                                )
+                            } else {
+                                FilterChip(
+                                    selected = true,
+                                    onClick = { showMassImportDialog = true },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Favorite,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                        )
+                                    },
+                                    label = { Text(text = stringResource(MR.strings.add_to_library)) },
+                                )
+                            }
                         }
                     }
 
@@ -398,6 +486,7 @@ data class BrowseSourceScreen(
                 onWebViewClick = onWebViewClick,
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = onHelpClick,
+                onOpenFolderClick = onOpenFolderClick,
                 selectionMode = state.selectionMode,
                 selection = state.selection,
                 translateTitles = state.translateTitles,
@@ -512,6 +601,32 @@ data class BrowseSourceScreen(
                     },
                 )
             }
+            is BrowseSourceScreenModel.Dialog.ConfirmDeleteLocalNovels -> {
+                AlertDialog(
+                    onDismissRequest = onDismissRequest,
+                    title = { Text(text = stringResource(TDMR.strings.local_novel_source_delete_title)) },
+                    text = { Text(text = stringResource(TDMR.strings.local_novel_source_delete_message)) },
+                    confirmButton = {
+                        TextButton(onClick = { screenModel.deleteLocalNovels(dialog.mangas) }) {
+                            Text(text = stringResource(MR.strings.action_delete))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = onDismissRequest) {
+                            Text(text = stringResource(MR.strings.action_cancel))
+                        }
+                    },
+                )
+            }
+            is BrowseSourceScreenModel.Dialog.BulkAddLocalNovels -> {
+                LocalNovelsAddToCategoryDialog(
+                    categories = dialog.categories,
+                    onDismissRequest = onDismissRequest,
+                    onConfirm = { categoryId ->
+                        screenModel.massImportToCategory(categoryId)
+                    },
+                )
+            }
             else -> {}
         }
 
@@ -588,4 +703,67 @@ data class BrowseSourceScreen(
         class Text(txt: String) : SearchType(txt)
         class Genre(txt: String) : SearchType(txt)
     }
+}
+
+@Composable
+private fun LocalNovelsAddToCategoryDialog(
+    categories: List<Category>,
+    onDismissRequest: () -> Unit,
+    onConfirm: (Long?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var selectedCategory by remember { mutableStateOf<Category?>(null) }
+    val noCategoryLabel = stringResource(MR.strings.label_default)
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(TDMR.strings.local_novel_source_add_to_library)) },
+        text = {
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it },
+            ) {
+                OutlinedTextField(
+                    value = selectedCategory?.name ?: noCategoryLabel,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(text = stringResource(TDMR.strings.local_novel_source_select_category)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(text = noCategoryLabel) },
+                        onClick = {
+                            selectedCategory = null
+                            expanded = false
+                        },
+                    )
+                    categories.forEach { category ->
+                        DropdownMenuItem(
+                            text = { Text(text = category.visualName) },
+                            onClick = {
+                                selectedCategory = category
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selectedCategory?.id) }) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -14,6 +14,7 @@ import androidx.paging.map
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.preference.asState
+import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.interactor.ManageFilterPresets
@@ -62,8 +63,10 @@ import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.model.toMangaUpdate
+import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.source.interactor.GetRemoteManga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.source.local.LocalNovelSource
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
 import uy.kohesive.injekt.Injekt
@@ -111,6 +114,9 @@ class BrowseSourceScreenModel(
     // Target end page for page range loading - when set, pages will auto-load until this page is reached
     private val _targetEndPage = MutableStateFlow<Int?>(null)
     val targetEndPage: StateFlow<Int?> = _targetEndPage.asStateFlow()
+
+    // Forces the browse pager to recreate after file-system updates like delete/refresh.
+    private val _refreshGeneration = MutableStateFlow(0L)
 
     /**
      * Jump to a specific page. This recreates the pager starting from that page.
@@ -234,7 +240,8 @@ class BrowseSourceScreenModel(
         state.map { Triple(it.listing.query, it.filters, it.filters.hashCode()) }
             .distinctUntilChanged { old, new -> old.first == new.first && old.third == new.third },
         _initialPage,
-    ) { (query, filters, _), startPage ->
+        _refreshGeneration,
+    ) { (query, filters, _), startPage, _ ->
         logcat(LogPriority.DEBUG) { "Creating new Pager for query='$query', filters=${filters.hashCode()}, startPage=$startPage" }
         // Set both generation and displayed current page to this pager's start page.
         tachiyomi.data.source.BaseSourcePagingSource.setInitialPage(startPage.toInt())
@@ -713,6 +720,8 @@ class BrowseSourceScreenModel(
             val initialSelection: ImmutableList<CheckboxState.State<Category>>,
         ) : Dialog
         data class Migrate(val target: Manga, val current: Manga) : Dialog
+        data class BulkAddLocalNovels(val categories: ImmutableList<Category>) : Dialog
+        data class ConfirmDeleteLocalNovels(val mangas: Set<Manga>) : Dialog
     }
 
     // Translation
@@ -871,7 +880,9 @@ class BrowseSourceScreenModel(
 
     fun selectAll(mangaList: List<Manga>) {
         mutableState.update { state ->
-            state.copy(selection = state.selection + mangaList.filter { !it.favorite })
+            // For local novel source include all items (favorites too, for delete/refresh operations).
+            val candidates = if (source is LocalNovelSource) mangaList else mangaList.filter { !it.favorite }
+            state.copy(selection = state.selection + candidates)
         }
     }
 
@@ -884,6 +895,56 @@ class BrowseSourceScreenModel(
         // Just clear selection and exit, as the library dialog will handle the import flow
         mutableState.update { it.copy(selection = emptySet(), selectionMode = false) }
         setDialog(null)
+    }
+
+    fun showBulkAddLocalNovelsDialog() {
+        screenModelScope.launchIO {
+            val cats = getCategories.await().filter {
+                it.contentType == Category.CONTENT_TYPE_ALL || it.contentType == Category.CONTENT_TYPE_NOVEL
+            }
+            setDialog(Dialog.BulkAddLocalNovels(cats.toImmutableList()))
+        }
+    }
+
+    fun deleteLocalNovels(mangas: Set<Manga>) {
+        val localSource = source as? LocalNovelSource ?: return
+        screenModelScope.launchIO {
+            mangas.forEach { manga ->
+                localSource.deleteNovelDirectory(manga.url)
+                updateManga.await(MangaUpdate(id = manga.id, favorite = false, dateAdded = 0))
+                manga.removeCovers(coverCache)
+            }
+            clearSelection()
+            setDialog(null)
+            refreshBrowseResults()
+        }
+    }
+
+    fun refreshLocalNovelCovers(mangas: Set<Manga>, onComplete: (Int) -> Unit) {
+        val localSource = source as? LocalNovelSource ?: return
+        screenModelScope.launchIO {
+            var refreshed = 0
+            mangas.forEach { manga ->
+                val coverUri = localSource.refreshCover(manga.toSManga())
+                if (coverUri != null) {
+                    updateManga.await(
+                        MangaUpdate(
+                            id = manga.id,
+                            thumbnailUrl = coverUri,
+                            coverLastModified = Instant.now().toEpochMilli(),
+                        ),
+                    )
+                    refreshed++
+                }
+            }
+            clearSelection()
+            refreshBrowseResults()
+            onComplete(refreshed)
+        }
+    }
+
+    fun refreshBrowseResults() {
+        _refreshGeneration.update { it + 1 }
     }
 
     fun massImportToCategory(categoryId: Long?) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -891,8 +891,6 @@ class BrowseSourceScreenModel(
     }
 
     fun openMassImportDialog() {
-        // Use the library's mass import dialog which is comprehensive and handles full URL import
-        // Just clear selection and exit, as the library dialog will handle the import flow
         mutableState.update { it.copy(selection = emptySet(), selectionMode = false) }
         setDialog(null)
     }
@@ -906,17 +904,25 @@ class BrowseSourceScreenModel(
         }
     }
 
-    fun deleteLocalNovels(mangas: Set<Manga>) {
+    fun deleteLocalNovels(mangas: Set<Manga>, onComplete: (deleted: Int, failed: Int) -> Unit = { _, _ -> }) {
         val localSource = source as? LocalNovelSource ?: return
         screenModelScope.launchIO {
+            var deleted = 0
+            var failed = 0
             mangas.forEach { manga ->
-                localSource.deleteNovelDirectory(manga.url)
-                updateManga.await(MangaUpdate(id = manga.id, favorite = false, dateAdded = 0))
-                manga.removeCovers(coverCache)
+                try {
+                    localSource.deleteNovelDirectory(manga.url)
+                    updateManga.await(MangaUpdate(id = manga.id, favorite = false))
+                    manga.removeCovers(coverCache)
+                    deleted++
+                } catch (_: Exception) {
+                    failed++
+                }
             }
             clearSelection()
             setDialog(null)
             refreshBrowseResults()
+            onComplete(deleted, failed)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ImportEpubScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ImportEpubScreen.kt
@@ -95,7 +95,19 @@ import java.util.UUID
 private const val TOC_PREVIEW_SECTION_SIZE = 3
 private const val TOC_PREVIEW_ALL_THRESHOLD = TOC_PREVIEW_SECTION_SIZE * 3
 
-class ImportEpubScreen : Screen() {
+/**
+ * EPUB import screen.
+ *
+ * Accepts an optional list of pre-supplied URIs (as strings, so the Screen
+ * stays Serializable across process death) — used when the OS hands the app
+ * one or more `.epub` files via `ACTION_VIEW` / `ACTION_SEND` /
+ * `ACTION_SEND_MULTIPLE`. When non-empty, the listed files are parsed
+ * automatically on first composition; the user can still add more via the
+ * file picker.
+ */
+class ImportEpubScreen(
+    private val initialUriStrings: List<String> = emptyList(),
+) : Screen() {
 
     @Composable
     override fun Content() {
@@ -133,58 +145,73 @@ class ImportEpubScreen : Screen() {
             }
         }
 
+        // Shared parse routine used by the file-picker AND by the initial-URI
+        // intake path. Persists read permissions, parses on IO, merges results
+        // with anything already loaded, rebuilds volume groups, and reports
+        // back through the snackbar.
+        suspend fun parseAndIngest(uris: List<Uri>) {
+            if (uris.isEmpty()) return
+            persistImportUriPermissions(context, uris)
+
+            isParsing = true
+            importResult = null
+            successfullyImportedUris = emptyList()
+
+            val parsed = withContext(Dispatchers.IO) {
+                parseEpubPreview.parseSelected(context, uris)
+            }
+
+            isParsing = false
+
+            parsed.errors.forEach { snackbarHostState.showSnackbar(it) }
+
+            val parsedFiles = parsed.files.map {
+                EpubFileInfo(
+                    uri = it.uri,
+                    fileName = it.fileName,
+                    title = it.title,
+                    author = it.author,
+                    description = it.description,
+                    coverUri = it.coverUri,
+                    collection = it.collection,
+                    collectionPosition = it.collectionPosition,
+                    genres = it.genres,
+                    tableOfContents = it.tableOfContents,
+                )
+            }
+
+            val existingFiles = volumeGroups.flatMap { group ->
+                group.volumes.map { volume -> volume.file }
+            }
+            val allFiles = (existingFiles + parsedFiles)
+                .distinctBy { file -> "${file.uri}|${file.fileName}" }
+
+            volumeGroups.clear()
+            volumeGroups.addAll(buildVolumeGroups(allFiles))
+            expandedTocByVolume.clear()
+
+            if (allFiles.isNotEmpty()) {
+                snackbarHostState.showSnackbar(
+                    "Loaded ${allFiles.size} EPUB file(s) into ${volumeGroups.size} novel group(s)",
+                )
+            } else if (parsed.errors.isEmpty()) {
+                snackbarHostState.showSnackbar("No valid EPUB files were parsed")
+            }
+        }
+
+        // Auto-load any URIs passed to the screen on first composition (intent-
+        // delivered EPUBs from outside the app). Only fires once per instance.
+        LaunchedEffect(initialUriStrings) {
+            if (initialUriStrings.isEmpty()) return@LaunchedEffect
+            val initialUris = initialUriStrings.mapNotNull { runCatching { Uri.parse(it) }.getOrNull() }
+            parseAndIngest(initialUris)
+        }
+
         val filePickerLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris ->
             if (uris.isEmpty()) return@rememberLauncherForActivityResult
-            persistImportUriPermissions(context, uris)
-
-            scope.launch {
-                isParsing = true
-                importResult = null
-                successfullyImportedUris = emptyList()
-
-                val parsed = withContext(Dispatchers.IO) {
-                    parseEpubPreview.parseSelected(context, uris)
-                }
-
-                isParsing = false
-
-                parsed.errors.forEach { snackbarHostState.showSnackbar(it) }
-
-                val parsedFiles = parsed.files.map {
-                    EpubFileInfo(
-                        uri = it.uri,
-                        fileName = it.fileName,
-                        title = it.title,
-                        author = it.author,
-                        description = it.description,
-                        coverUri = it.coverUri,
-                        collection = it.collection,
-                        collectionPosition = it.collectionPosition,
-                        genres = it.genres,
-                        tableOfContents = it.tableOfContents,
-                    )
-                }
-
-                val existingFiles = volumeGroups.flatMap { group ->
-                    group.volumes.map { volume -> volume.file }
-                }
-                val allFiles = (existingFiles + parsedFiles)
-                    .distinctBy { file -> "${file.uri}|${file.fileName}" }
-
-                volumeGroups.clear()
-                volumeGroups.addAll(buildVolumeGroups(allFiles))
-                expandedTocByVolume.clear()
-
-                if (allFiles.isNotEmpty()) {
-                    snackbarHostState.showSnackbar(
-                        "Loaded ${allFiles.size} EPUB file(s) into ${volumeGroups.size} novel group(s)",
-                    )
-                } else if (parsed.errors.isEmpty()) {
-                    snackbarHostState.showSnackbar("No valid EPUB files were parsed")
-                }
-            }
+            scope.launch { parseAndIngest(uris) }
         }
 
         fun moveGroup(groupId: String, offset: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/ImportEpubScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/ImportEpubScreen.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
+import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.BackHandler
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -107,6 +109,7 @@ private const val TOC_PREVIEW_ALL_THRESHOLD = TOC_PREVIEW_SECTION_SIZE * 3
  */
 class ImportEpubScreen(
     private val initialUriStrings: List<String> = emptyList(),
+    private val closeActivityOnDone: Boolean = false,
 ) : Screen() {
 
     @Composable
@@ -114,6 +117,7 @@ class ImportEpubScreen(
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val scope = rememberCoroutineScope()
+        val finishActivity = { (context as? Activity)?.finish() }
 
         val snackbarHostState = remember { SnackbarHostState() }
         val getCategories = remember { Injekt.get<GetCategories>() }
@@ -133,6 +137,18 @@ class ImportEpubScreen(
         var importResult by remember { mutableStateOf<ImportResult?>(null) }
         var successfullyImportedUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
         var showDeleteImportedConfirm by remember { mutableStateOf(false) }
+
+        fun exitImportScreen() {
+            if (closeActivityOnDone) {
+                finishActivity()
+            } else {
+                navigator.pop()
+            }
+        }
+
+        BackHandler(enabled = closeActivityOnDone) {
+            if (importProgress?.isRunning != true) finishActivity()
+        }
 
         LaunchedEffect(Unit) {
             categories = withContext(Dispatchers.IO) {
@@ -360,9 +376,9 @@ class ImportEpubScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(paddingValues),
-                        canDeleteImportedFiles = successfullyImportedUris.isNotEmpty(),
+                        canDeleteImportedFiles = successfullyImportedUris.isNotEmpty() && successfullyImportedUris.none { it.scheme == "content" },
                         onDeleteImportedFiles = { showDeleteImportedConfirm = true },
-                        onDone = { navigator.pop() },
+                        onDone = { exitImportScreen() },
                     )
 
                     if (showDeleteImportedConfirm) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -13,7 +13,6 @@ import eu.kanade.core.preference.asState
 import eu.kanade.core.util.fastFilterNot
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.chapter.interactor.SetReadStatus
-import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.chapter.model.toSChapter
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.toSManga
@@ -104,7 +103,6 @@ class LibraryScreenModel(
     private val setReadStatus: SetReadStatus = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
-    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get(),
     private val searchChapterNames: SearchChapterNames = Injekt.get(),
     private val preferences: BasePreferences = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
@@ -191,21 +189,19 @@ class LibraryScreenModel(
                 getLibraryManga.isLoading(),
             ) { categories, favorites, tracksAndFilters, itemPreferences, isLoading ->
                 val (tracksMap, trackingFilters) = tracksAndFilters
-                val castTracksMap = tracksMap as Map<Long, List<Track>>
-                val castTrackingFilters = trackingFilters as Map<Long, TriState>
 
                 val showSystemCategory = favorites.any { it.libraryManga.categories.contains(0L) }
 
                 val filteredFavorites = favorites
-                    .applyFilters(castTracksMap, castTrackingFilters, itemPreferences)
+                    .applyFilters(tracksMap, trackingFilters, itemPreferences)
 
                 LibraryData(
                     isInitialized = !isLoading,
                     showSystemCategory = showSystemCategory,
                     categories = categories,
                     favorites = filteredFavorites,
-                    tracksMap = castTracksMap,
-                    loggedInTrackerIds = castTrackingFilters.keys,
+                    tracksMap = tracksMap,
+                    loggedInTrackerIds = trackingFilters.keys,
                 )
             }
 
@@ -374,7 +370,7 @@ class LibraryScreenModel(
             if (!novelPasses) return@fastFilter false
 
             // Tags filter (more expensive, so do it last)
-            val tagsPasses = if (
+            if (
                 normalizedIncluded.isEmpty() &&
                 normalizedExcluded.isEmpty() &&
                 preferences.filterNoTags == TriState.DISABLED
@@ -389,7 +385,6 @@ class LibraryScreenModel(
                     when (noTagsFilter) {
                         TriState.ENABLED_IS -> if (!hasNoTags) return@fastFilter false
                         TriState.ENABLED_NOT -> if (hasNoTags) return@fastFilter false
-                        else -> {}
                     }
                 }
 
@@ -417,7 +412,6 @@ class LibraryScreenModel(
 
                 true
             }
-            if (!tagsPasses) return@fastFilter false
 
             // Chapter count filter
             val chapterCountPasses = applyFilter(preferences.filterChapterCount) {
@@ -863,7 +857,7 @@ class LibraryScreenModel(
                 )
             }
             val updates = selection.associate { manga ->
-                manga.id to { libraryManga: tachiyomi.domain.library.model.LibraryManga ->
+                manga.id to { libraryManga: LibraryManga ->
                     libraryManga.copy(
                         readCount = if (read) libraryManga.totalChapters else 0,
                         lastRead = if (read) System.currentTimeMillis() else libraryManga.lastRead,
@@ -942,47 +936,10 @@ class LibraryScreenModel(
             }
 
             // Refresh library UI after modifications
-            if (deleteFromLibrary) {
-            } else if (deleteChapters || clearChaptersFromDb || deleteTranslations || clearCovers || clearDescriptions || clearTags) {
+            if (!deleteFromLibrary && (deleteChapters || clearChaptersFromDb || deleteTranslations || clearCovers || clearDescriptions || clearTags)) {
                 getLibraryManga.notifyChanged()
             }
         }
-    }
-
-    /**
-     * Clear covers for selected manga.
-     */
-    fun clearCoversForSelection() {
-        val mangas = state.value.selectedManga
-        if (mangas.isEmpty()) return
-
-        val context = Injekt.get<android.app.Application>()
-        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_COVERS)
-        clearSelection()
-    }
-
-    /**
-     * Clear descriptions for selected manga.
-     */
-    fun clearDescriptionsForSelection() {
-        val mangas = state.value.selectedManga
-        if (mangas.isEmpty()) return
-
-        val context = Injekt.get<android.app.Application>()
-        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
-        clearSelection()
-    }
-
-    /**
-     * Clear tags/genres for selected manga.
-     */
-    fun clearTagsForSelection() {
-        val mangas = state.value.selectedManga
-        if (mangas.isEmpty()) return
-
-        val context = Injekt.get<android.app.Application>()
-        LibraryClearJob.start(context, mangas.map { it.id }, LibraryClearJob.OP_CLEAR_TAGS)
-        clearSelection()
     }
 
     /**
@@ -1217,22 +1174,12 @@ class LibraryScreenModel(
         mutableState.update { it.copy(dialog = Dialog.RemoveChapters(state.value.selectedManga)) }
     }
 
-    fun removeChaptersFromSelectedManga(mangaList: List<Manga>) {
-        val context = Injekt.get<android.app.Application>()
-        LibraryClearJob.start(context, mangaList.map { it.id }, LibraryClearJob.OP_CLEAR_CHAPTERS)
-        clearSelection()
-    }
-
     fun closeDialog() {
         mutableState.update { it.copy(dialog = null) }
     }
 
     fun openMassImportDialog() {
         mutableState.update { it.copy(dialog = Dialog.MassImport) }
-    }
-
-    fun openImportEpubDialog() {
-        mutableState.update { it.copy(dialog = Dialog.ImportEpub) }
     }
 
     fun openExportEpubDialog() {
@@ -1410,7 +1357,7 @@ class LibraryScreenModel(
                             // Fetch from source if still no content
                             if (content == null && !options.downloadedOnly) {
                                 try {
-                                    if (source is eu.kanade.tachiyomi.source.online.HttpSource) {
+                                    if (source is HttpSource) {
                                         val pages = source.getPageList(chapter.toSChapter())
                                         if (pages.isNotEmpty()) {
                                             val page = pages.first()
@@ -1634,9 +1581,9 @@ class LibraryScreenModel(
 
     private fun normalizeTitle(title: String): String {
         return title.lowercase()
-            .replace(Regex("[\\[\\(].*?[\\]\\)]"), "") // Remove content in brackets/parentheses
-            .replace(Regex("[^a-z0-9\\s]"), "") // Remove non-alphanumeric except spaces
-            .replace(Regex("\\s+"), " ") // Normalize whitespace
+            .replace(Regex("""[\[\(].*?[\]\)]"""), "") // Remove content in brackets/parentheses
+            .replace(Regex("""[^a-z0-9\s]"""), "") // Remove non-alphanumeric except spaces
+            .replace(Regex("""\s+"""), " ") // Normalize whitespace
             .trim()
     }
 
@@ -1672,26 +1619,6 @@ class LibraryScreenModel(
         return dp[s1.length][s2.length]
     }
 
-    fun openDuplicateDetectionDialog() {
-        val duplicates = findDuplicates()
-        mutableState.update { it.copy(dialog = Dialog.DuplicateDetection(duplicates)) }
-    }
-
-    fun selectDuplicatesExceptFirst(groups: List<DuplicateGroup>) {
-        val toSelect = groups.flatMap { it.items.drop(1) }.map { it.id }.toSet()
-        mutableState.update { state ->
-            state.copy(selection = state.selection + toSelect)
-        }
-        closeDialog()
-    }
-
-    fun selectAllDuplicates(groups: List<DuplicateGroup>) {
-        val toSelect = groups.flatMap { it.items }.map { it.id }.toSet()
-        mutableState.update { state ->
-            state.copy(selection = state.selection + toSelect)
-        }
-        closeDialog()
-    }
 
     data class DuplicateGroup(val items: List<LibraryItem>)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1269,6 +1269,8 @@ class LibraryScreenModel(
             includeChapterRange = options.includeChapterRange,
             includeStatus = options.includeStatus,
             includeVolumeNumber = options.includeVolumeNumber,
+            includeCustomCss = options.includeCustomCss,
+            includeCustomJs = options.includeCustomJs,
         )
 
         screenModelScope.launchIO {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -135,8 +135,9 @@ class MainActivity : BaseActivity() {
 
         val didMigration = Migrator.awaitAndRelease()
 
-        // Do not let the launcher create a new activity http://stackoverflow.com/questions/16283079
-        if (!isTaskRoot) {
+        // Only block duplicate launcher entries. External open/share intents may arrive in a
+        // non-root task and still need to be handled by this activity.
+        if (!isTaskRoot && intent.action == Intent.ACTION_MAIN && intent.hasCategory(Intent.CATEGORY_LAUNCHER)) {
             finish()
             return
         }
@@ -174,7 +175,7 @@ class MainActivity : BaseActivity() {
 
                     if (isLaunch) {
                         // Set start screen
-                        handleIntentAction(intent, navigator)
+                        handleIntentAction(intent, navigator, closeImportScreenOnDone = true)
 
                         // Reset Incognito Mode on relaunch
                         preferences.incognitoMode.set(false)
@@ -295,7 +296,7 @@ class MainActivity : BaseActivity() {
                 componentActivity.addOnNewIntentListener(consumer)
                 awaitClose { componentActivity.removeOnNewIntentListener(consumer) }
             }
-                .collectLatest { handleIntentAction(it, navigator) }
+                .collectLatest { handleIntentAction(it, navigator, closeImportScreenOnDone = false) }
         }
     }
 
@@ -389,7 +390,11 @@ class MainActivity : BaseActivity() {
         }
     }
 
-    private fun handleIntentAction(intent: Intent, navigator: Navigator): Boolean {
+    private fun handleIntentAction(
+        intent: Intent,
+        navigator: Navigator,
+        closeImportScreenOnDone: Boolean,
+    ): Boolean {
         val notificationId = intent.getIntExtra("notificationId", -1)
         if (notificationId > -1) {
             NotificationReceiver.dismissNotification(
@@ -408,7 +413,12 @@ class MainActivity : BaseActivity() {
         if (epubUris.isNotEmpty()) {
             persistEpubReadPermissions(epubUris)
             navigator.popUntilRoot()
-            navigator.push(ImportEpubScreen(epubUris.map { it.toString() }))
+            navigator.push(
+                ImportEpubScreen(
+                    initialUriStrings = epubUris.map { it.toString() },
+                    closeActivityOnDone = closeImportScreenOnDone,
+                ),
+            )
             ready = true
             return true
         }
@@ -504,7 +514,22 @@ class MainActivity : BaseActivity() {
         fun looksLikeEpub(uri: android.net.Uri?): Boolean {
             if (uri == null) return false
             val path = (uri.lastPathSegment ?: uri.path ?: uri.toString()).lowercase()
-            return path.endsWith(".epub")
+            if (path.endsWith(".epub")) return true
+            // Fallback for content URIs where the path has no extension (e.g. Downloads provider
+            // uses numeric IDs like content://…/document/12345). Query the display name instead.
+            if (uri.scheme == "content") {
+                val displayName = runCatching {
+                    contentResolver.query(
+                        uri,
+                        arrayOf(android.provider.OpenableColumns.DISPLAY_NAME),
+                        null, null, null,
+                    )?.use { cursor ->
+                        if (cursor.moveToFirst()) cursor.getString(0) else null
+                    }
+                }.getOrNull()
+                if (displayName?.lowercase()?.endsWith(".epub") == true) return true
+            }
+            return false
         }
 
         return when (intent.action) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -61,6 +61,7 @@ import eu.kanade.presentation.components.IncognitoModeBannerBackgroundColor
 import eu.kanade.presentation.components.IndexingBannerBackgroundColor
 import eu.kanade.presentation.more.settings.screen.browse.ExtensionReposScreen
 import eu.kanade.presentation.more.settings.screen.data.RestoreBackupScreen
+import eu.kanade.tachiyomi.ui.library.ImportEpubScreen
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.DefaultNavigatorScreenTransition
 import eu.kanade.tachiyomi.BuildConfig
@@ -398,6 +399,20 @@ class MainActivity : BaseActivity() {
             )
         }
 
+        // Open / share-target EPUB files from outside the app. Detected by
+        // intent action + MIME (or filename extension) before the regular
+        // action dispatch so an EPUB ACTION_VIEW doesn't fall through to the
+        // backup-file branch and an EPUB ACTION_SEND doesn't trigger the
+        // global-search path.
+        val epubUris = extractIncomingEpubUris(intent)
+        if (epubUris.isNotEmpty()) {
+            persistEpubReadPermissions(epubUris)
+            navigator.popUntilRoot()
+            navigator.push(ImportEpubScreen(epubUris.map { it.toString() }))
+            ready = true
+            return true
+        }
+
         val tabToOpen = when (intent.action) {
             Constants.SHORTCUT_LIBRARY -> HomeScreen.Tab.Library()
             Constants.SHORTCUT_MANGA -> {
@@ -465,6 +480,75 @@ class MainActivity : BaseActivity() {
 
         ready = true
         return true
+    }
+
+    /**
+     * Return the URIs of any EPUB files attached to [intent], or an empty list
+     * when the intent isn't an EPUB open/share request.
+     *
+     * Handles three shapes:
+     *  - `ACTION_VIEW` with a single URI in [Intent.getData]. Triggered by the
+     *    file-manager "open with…" flow.
+     *  - `ACTION_SEND` with one URI under [Intent.EXTRA_STREAM]. Triggered by
+     *    apps that share a single EPUB via the Android share sheet.
+     *  - `ACTION_SEND_MULTIPLE` with a list of URIs under
+     *    [Intent.EXTRA_STREAM]. Same share sheet, multiple files selected.
+     *
+     * The MIME-type check is loose (any type containing `"epub"`) because
+     * different senders report `application/epub+zip`, `application/epub`, or
+     * even `application/octet-stream`. The filename-extension fallback
+     * catches the octet-stream case.
+     */
+    private fun extractIncomingEpubUris(intent: Intent): List<android.net.Uri> {
+        fun isEpubMime(type: String?): Boolean = type?.contains("epub", ignoreCase = true) == true
+        fun looksLikeEpub(uri: android.net.Uri?): Boolean {
+            if (uri == null) return false
+            val path = (uri.lastPathSegment ?: uri.path ?: uri.toString()).lowercase()
+            return path.endsWith(".epub")
+        }
+
+        return when (intent.action) {
+            Intent.ACTION_VIEW -> {
+                val uri = intent.data ?: return emptyList()
+                if (isEpubMime(intent.type) || looksLikeEpub(uri)) listOf(uri) else emptyList()
+            }
+            Intent.ACTION_SEND -> {
+                if (!isEpubMime(intent.type)) return emptyList()
+                val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(Intent.EXTRA_STREAM, android.net.Uri::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra<android.net.Uri>(Intent.EXTRA_STREAM)
+                }
+                listOfNotNull(uri)
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                if (!isEpubMime(intent.type)) return emptyList()
+                val list = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, android.net.Uri::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableArrayListExtra<android.net.Uri>(Intent.EXTRA_STREAM)
+                }
+                list?.toList().orEmpty()
+            }
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * Take a persistable read-permission grant on each URI so the
+     * EPUB-import flow can re-open it across coroutine launches without
+     * `SecurityException`. Sharing-side senders may not have set the
+     * persistable flag, so the call is wrapped in [runCatching] per-URI.
+     */
+    private fun persistEpubReadPermissions(uris: List<android.net.Uri>) {
+        val resolver = contentResolver
+        uris.forEach { uri ->
+            runCatching {
+                resolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1635,6 +1635,8 @@ class MangaScreenModel(
             includeChapterRange = options.includeChapterRange,
             includeStatus = options.includeStatus,
             includeVolumeNumber = options.includeVolumeNumber,
+            includeCustomCss = options.includeCustomCss,
+            includeCustomJs = options.includeCustomJs,
         )
 
         screenModelScope.launchIO {

--- a/app/src/test/java/mihon/core/archive/EpubReaderExportImageIdTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderExportImageIdTest.kt
@@ -1,0 +1,77 @@
+package mihon.core.archive
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+
+class EpubReaderExportImageIdTest {
+
+    private fun id(path: String): String = EpubReader.computeExportImageId(path)
+
+    @Test
+    fun `id preserves the file extension for MIME detection downstream`() {
+        assertTrue(id("OEBPS/Images/insert1.jpg").endsWith(".jpg"))
+        assertTrue(id("OEBPS/Images/insert1.png").endsWith(".png"))
+        assertTrue(id("OEBPS/Images/insert1.webp").endsWith(".webp"))
+        assertTrue(id("OEBPS/Images/insert1.svg").endsWith(".svg"))
+    }
+
+    @Test
+    fun `id squashes path separators to underscores so it is safe as a filename`() {
+        val out = id("OEBPS/Images/insert1.jpg")
+        assertFalse(out.contains("/"), "id must contain no slashes")
+        assertFalse(out.contains("\\"), "id must contain no backslashes")
+        assertTrue(out.contains("OEBPS_Images_insert1"), "id must encode the full path")
+    }
+
+    @Test
+    fun `id normalizes windows-style separators`() {
+        val unix = id("OEBPS/Images/foo.png")
+        val win = id("OEBPS\\Images\\foo.png")
+        assertEquals(unix, win, "Backslashes and forward slashes must produce identical ids")
+    }
+
+    @Test
+    fun `equal source paths produce equal ids for in-chapter deduplication`() {
+        assertEquals(id("a/b/c.jpg"), id("a/b/c.jpg"))
+    }
+
+    @Test
+    fun `different source paths produce different ids`() {
+        assertNotEquals(id("vol1/Images/cover.jpg"), id("vol2/Images/cover.jpg"))
+    }
+
+    @Test
+    fun `id drops disallowed characters so writer filename rules hold`() {
+        val out = id("OEBPS/Some Folder/img (1).jpg")
+        val stem = out.substringBeforeLast('.')
+        assertTrue(
+            stem.all { it.isLetterOrDigit() || it == '_' || it == '-' || it == '.' },
+            "id must contain only filename-safe characters, was: $out",
+        )
+    }
+
+    @Test
+    fun `id truncates extremely long paths so filenames stay reasonable`() {
+        val longPath = "OEBPS/" + "deep/".repeat(50) + "file.jpg"
+        val out = id(longPath)
+        val stem = out.substringBeforeLast('.')
+        assertTrue(stem.length <= 80, "stem should be capped at 80 chars, was ${stem.length}")
+        assertTrue(out.endsWith(".jpg"), "extension must survive truncation")
+    }
+
+    @Test
+    fun `id falls back gracefully for paths with no recognizable extension`() {
+        val out = id("OEBPS/data/weird.NOTANEXTENSION")
+        assertFalse(out.endsWith(".NOTANEXTENSION"), "unrealistic extensions must be folded into the stem")
+    }
+
+    @Test
+    fun `id handles empty input without throwing`() {
+        val out = id("")
+        assertTrue(out.isNotBlank(), "empty path must still produce a usable id")
+    }
+}

--- a/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
@@ -1,0 +1,244 @@
+package mihon.core.archive
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipInputStream
+
+class EpubWriterTest {
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private fun buildEpub(
+        chapters: List<EpubWriter.Chapter> = listOf(
+            EpubWriter.Chapter(title = "Chapter 1", content = "<p>Hello</p>"),
+        ),
+        coverImage: ByteArray? = null,
+        metadata: EpubWriter.Metadata = EpubWriter.Metadata(title = "Test Book"),
+    ): Map<String, ByteArray> {
+        val out = ByteArrayOutputStream()
+        EpubWriter().write(out, metadata, chapters, coverImage)
+        val entries = mutableMapOf<String, ByteArray>()
+        ZipInputStream(out.toByteArray().inputStream()).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                entries[entry.name] = zip.readBytes()
+                entry = zip.nextEntry
+            }
+        }
+        return entries
+    }
+
+    private fun Map<String, ByteArray>.text(key: String): String =
+        this[key]?.decodeToString() ?: error("Entry not found: $key")
+
+    // ── detectImageType ─────────────────────────────────────────────
+
+    @Test
+    fun `detectImageType returns jpeg for JPEG magic bytes`() {
+        val bytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte())
+        assertEquals("image/jpeg" to "jpg", EpubWriter.detectImageType(bytes))
+    }
+
+    @Test
+    fun `detectImageType returns png for PNG magic bytes`() {
+        val bytes = byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte())
+        assertEquals("image/png" to "png", EpubWriter.detectImageType(bytes))
+    }
+
+    @Test
+    fun `detectImageType returns webp for WEBP magic bytes`() {
+        val bytes = ByteArray(12).also { b ->
+            // RIFF
+            b[0] = 0x52; b[1] = 0x49; b[2] = 0x46; b[3] = 0x46
+            // WEBP at bytes 8-11
+            b[8] = 0x57; b[9] = 0x45; b[10] = 0x42; b[11] = 0x50
+        }
+        assertEquals("image/webp" to "webp", EpubWriter.detectImageType(bytes))
+    }
+
+    @Test
+    fun `detectImageType returns gif for GIF magic bytes`() {
+        val bytes = byteArrayOf(0x47.toByte(), 0x49.toByte(), 0x46.toByte(), 0x38.toByte())
+        assertEquals("image/gif" to "gif", EpubWriter.detectImageType(bytes))
+    }
+
+    @Test
+    fun `detectImageType falls back to jpeg for unknown bytes`() {
+        val bytes = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+        assertEquals("image/jpeg" to "jpg", EpubWriter.detectImageType(bytes))
+    }
+
+    @Test
+    fun `detectImageType falls back to jpeg for too-small byte array`() {
+        val bytes = byteArrayOf(0xFF.toByte())
+        assertEquals("image/jpeg" to "jpg", EpubWriter.detectImageType(bytes))
+    }
+
+    // ── Cover MIME detection ────────────────────────────────────────
+
+    @Test
+    fun `PNG cover uses png extension and image mime in manifest`() {
+        val pngBytes = byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte(), 0, 0, 0, 0)
+        val entries = buildEpub(coverImage = pngBytes)
+        assertNotNull(entries["OEBPS/images/cover.png"], "cover.png must be written")
+        assertNull(entries["OEBPS/images/cover.jpg"], "cover.jpg must NOT be written for PNG cover")
+        val opf = entries.text("OEBPS/content.opf")
+        assertTrue(opf.contains("cover.png"), "OPF must reference cover.png")
+        assertTrue(opf.contains("image/png"), "OPF must use image/png mime type")
+    }
+
+    @Test
+    fun `JPEG cover uses jpg extension`() {
+        val jpegBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val entries = buildEpub(coverImage = jpegBytes)
+        assertNotNull(entries["OEBPS/images/cover.jpg"])
+        val opf = entries.text("OEBPS/content.opf")
+        assertTrue(opf.contains("cover.jpg"))
+        assertTrue(opf.contains("image/jpeg"))
+    }
+
+    // ── EPUB 2 compatibility ────────────────────────────────────────
+
+    @Test
+    fun `EPUB 2 cover meta is present when cover provided`() {
+        val jpegBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val opf = buildEpub(coverImage = jpegBytes).text("OEBPS/content.opf")
+        assertTrue(
+            opf.contains("""meta name="cover" content="cover-image""""),
+            "OPF must contain EPUB 2 cover meta",
+        )
+    }
+
+    @Test
+    fun `EPUB 2 cover meta is absent when no cover provided`() {
+        val opf = buildEpub(coverImage = null).text("OEBPS/content.opf")
+        assertFalse(opf.contains("""meta name="cover""""), "OPF must NOT contain cover meta when no cover")
+    }
+
+    // ── EPUB 3 cover-image property ─────────────────────────────────
+
+    @Test
+    fun `EPUB 3 cover-image property is set`() {
+        val jpegBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val opf = buildEpub(coverImage = jpegBytes).text("OEBPS/content.opf")
+        assertTrue(
+            opf.contains("""properties="cover-image""""),
+            "OPF manifest item must have properties=\"cover-image\"",
+        )
+    }
+
+    // ── Chapter image embedding ─────────────────────────────────────
+
+    @Test
+    fun `chapter image is written to correct EPUB path`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(id = "image_0.jpg", bytes = imgBytes, mimeType = "image/jpeg", extension = "jpg")
+        val chapter = EpubWriter.Chapter(title = "Ch 1", content = """<img src="tsundoku-novel-image://image_0.jpg"/>""", images = listOf(img))
+        val entries = buildEpub(chapters = listOf(chapter))
+        assertNotNull(entries["OEBPS/images/chapter0000_image_0.jpg"], "Image must be stored at chapter-scoped path")
+    }
+
+    @Test
+    fun `chapter image is listed in OPF manifest`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(id = "image_0.jpg", bytes = imgBytes, mimeType = "image/jpeg", extension = "jpg")
+        val chapter = EpubWriter.Chapter(title = "Ch 1", content = """<img src="tsundoku-novel-image://image_0.jpg"/>""", images = listOf(img))
+        val opf = buildEpub(chapters = listOf(chapter)).text("OEBPS/content.opf")
+        assertTrue(opf.contains("chapter0000_image_0.jpg"), "Manifest must reference the image file")
+        assertTrue(opf.contains("image/jpeg"), "Manifest must include correct MIME type")
+    }
+
+    // ── HTML rewriting ──────────────────────────────────────────────
+
+    @Test
+    fun `tsundoku-novel-image URLs are rewritten to EPUB-relative paths`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(id = "image_0.jpg", bytes = imgBytes, mimeType = "image/jpeg", extension = "jpg")
+        val chapter = EpubWriter.Chapter(title = "Ch 1", content = """<img src="tsundoku-novel-image://image_0.jpg"/>""", images = listOf(img))
+        val chapterXhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertFalse(chapterXhtml.contains("tsundoku-novel-image://"), "tsundoku-novel-image:// must be rewritten")
+        assertTrue(chapterXhtml.contains("images/chapter0000_image_0.jpg"), "Rewritten path must point to EPUB image")
+    }
+
+    @Test
+    fun `orphan tsundoku-novel-image img tags are removed`() {
+        // Image referenced in HTML but NOT provided in images list
+        val chapter = EpubWriter.Chapter(
+            title = "Ch 1",
+            content = """<img src="tsundoku-novel-image://orphan.jpg"/>""",
+            images = emptyList(),
+        )
+        val chapterXhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertFalse(chapterXhtml.contains("orphan.jpg"), "Orphan img must be removed")
+    }
+
+    @Test
+    fun `picture element sources are stripped and img is kept`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(id = "image_0.jpg", bytes = imgBytes, mimeType = "image/jpeg", extension = "jpg")
+        val chapter = EpubWriter.Chapter(
+            title = "Ch 1",
+            content = """<picture><source srcset="https://cdn.example.com/big.webp" type="image/webp"/><img src="tsundoku-novel-image://image_0.jpg"/></picture>""",
+            images = listOf(img),
+        )
+        val xhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertFalse(xhtml.contains("<source"), "picture <source> must be stripped")
+        assertFalse(xhtml.contains("<picture"), "picture element must be unwrapped")
+        assertTrue(xhtml.contains("images/chapter0000_image_0.jpg"), "img src must be rewritten")
+    }
+
+    @Test
+    fun `picture element with no img fallback is removed`() {
+        val chapter = EpubWriter.Chapter(
+            title = "Ch 1",
+            content = """<picture><source srcset=""/></picture>""",
+            images = emptyList(),
+        )
+        val xhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertFalse(xhtml.contains("<picture"), "picture with no usable img must be removed")
+    }
+
+    @Test
+    fun `images from different chapters use chapter-scoped paths`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(id = "image_0.jpg", bytes = imgBytes, mimeType = "image/jpeg", extension = "jpg")
+        val ch0 = EpubWriter.Chapter(title = "Ch 0", content = """<img src="tsundoku-novel-image://image_0.jpg"/>""", images = listOf(img))
+        val ch1 = EpubWriter.Chapter(title = "Ch 1", content = """<img src="tsundoku-novel-image://image_0.jpg"/>""", images = listOf(img))
+        val entries = buildEpub(chapters = listOf(ch0, ch1))
+
+        assertNotNull(entries["OEBPS/images/chapter0000_image_0.jpg"], "Chapter 0 image must be stored")
+        assertNotNull(entries["OEBPS/images/chapter0001_image_0.jpg"], "Chapter 1 image must be stored separately")
+
+        val xhtml0 = entries.text("OEBPS/chapter0000.xhtml")
+        val xhtml1 = entries.text("OEBPS/chapter0001.xhtml")
+        assertTrue(xhtml0.contains("chapter0000_image_0.jpg"))
+        assertTrue(xhtml1.contains("chapter0001_image_0.jpg"))
+        assertFalse(xhtml0.contains("chapter0001"), "Chapter 0 must not reference chapter 1 images")
+    }
+
+    @Test
+    fun `plain HTML without images is preserved unchanged`() {
+        val chapter = EpubWriter.Chapter(title = "Ch 1", content = "<p>Plain <strong>text</strong> content.</p>")
+        val xhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertTrue(xhtml.contains("Plain"), "Plain text content must be preserved")
+        assertTrue(xhtml.contains("<strong>"), "Inline HTML must be preserved")
+    }
+
+    // ── Required EPUB structure ─────────────────────────────────────
+
+    @Test
+    fun `required EPUB structure entries are present`() {
+        val entries = buildEpub()
+        assertNotNull(entries["mimetype"], "mimetype must be present")
+        assertNotNull(entries["META-INF/container.xml"], "container.xml must be present")
+        assertNotNull(entries["OEBPS/content.opf"], "content.opf must be present")
+        assertNotNull(entries["OEBPS/nav.xhtml"], "nav.xhtml must be present")
+        assertNotNull(entries["OEBPS/chapter0000.xhtml"], "chapter0000.xhtml must be present")
+        assertEquals("application/epub+zip", entries.text("mimetype"))
+    }
+}

--- a/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
@@ -19,9 +19,18 @@ class EpubWriterTest {
         ),
         coverImage: ByteArray? = null,
         metadata: EpubWriter.Metadata = EpubWriter.Metadata(title = "Test Book"),
+        customCss: String? = null,
+        customJs: String? = null,
     ): Map<String, ByteArray> {
         val out = ByteArrayOutputStream()
-        EpubWriter().write(out, metadata, chapters, coverImage)
+        EpubWriter().write(
+            outputStream = out,
+            metadata = metadata,
+            chapters = chapters,
+            coverImage = coverImage,
+            customCss = customCss,
+            customJs = customJs,
+        )
         val entries = mutableMapOf<String, ByteArray>()
         ZipInputStream(out.toByteArray().inputStream()).use { zip ->
             var entry = zip.nextEntry
@@ -238,7 +247,269 @@ class EpubWriterTest {
         assertNotNull(entries["META-INF/container.xml"], "container.xml must be present")
         assertNotNull(entries["OEBPS/content.opf"], "content.opf must be present")
         assertNotNull(entries["OEBPS/nav.xhtml"], "nav.xhtml must be present")
+        assertNotNull(entries["OEBPS/toc.ncx"], "toc.ncx must be present (EPUB 2 fallback)")
         assertNotNull(entries["OEBPS/chapter0000.xhtml"], "chapter0000.xhtml must be present")
         assertEquals("application/epub+zip", entries.text("mimetype"))
+    }
+
+
+    @Test
+    fun `toc ncx has one navPoint per chapter in order`() {
+        val chapters = (1..3).map { idx ->
+            EpubWriter.Chapter(title = "Ch $idx", content = "<p>$idx</p>")
+        }
+        val entries = buildEpub(chapters = chapters)
+        val ncx = entries.text("OEBPS/toc.ncx")
+
+        val navPointCount = "<navPoint ".toRegex().findAll(ncx).count()
+        assertEquals(3, navPointCount)
+        listOf(1, 2, 3).forEach { i ->
+            assertTrue(
+                ncx.contains("""playOrder="$i""""),
+                "playOrder=$i must appear in NCX",
+            )
+            assertTrue(ncx.contains("Ch $i"), "Chapter $i title must appear in NCX")
+            assertTrue(
+                ncx.contains("""src="chapter${(i - 1).toString().padStart(4, '0')}.xhtml""""),
+                "Chapter $i src must reference the correct XHTML file",
+            )
+        }
+    }
+
+    @Test
+    fun `toc ncx uses correct namespace and version`() {
+        val ncx = buildEpub().text("OEBPS/toc.ncx")
+        assertTrue(
+            ncx.contains("""xmlns="http://www.daisy.org/z3986/2005/ncx/""""),
+            "NCX must declare the DAISY namespace",
+        )
+        assertTrue(ncx.contains("""version="2005-1""""), "NCX must declare version 2005-1")
+    }
+
+    @Test
+    fun `toc ncx dtb uid matches package identifier`() {
+        val entries = buildEpub()
+        val opf = entries.text("OEBPS/content.opf")
+        val ncx = entries.text("OEBPS/toc.ncx")
+
+        val packageUid = Regex("""urn:uuid:[0-9a-f-]{36}""").find(opf)?.value
+        assertNotNull(packageUid, "OPF must contain a urn:uuid identifier")
+        assertTrue(
+            ncx.contains(packageUid!!),
+            "NCX dtb:uid must match the OPF identifier so EPUB 2 readers can cross-reference",
+        )
+    }
+
+    @Test
+    fun `OPF references NCX in manifest and spine`() {
+        val opf = buildEpub().text("OEBPS/content.opf")
+        assertTrue(
+            opf.contains("""<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>"""),
+            "Manifest must include NCX item with correct media-type",
+        )
+        assertTrue(
+            opf.contains("""<spine toc="ncx">"""),
+            "Spine must declare toc=\"ncx\" so EPUB 2 readers pick up the NCX",
+        )
+    }
+
+
+    @Test
+    fun `custom CSS body is written as standalone stylesheet entry`() {
+        val css = "body { background: #111; color: #eee; }"
+        val entries = buildEpub(customCss = css)
+
+        val stored = entries["OEBPS/${EpubWriter.CUSTOM_CSS_PATH}"]
+        assertNotNull(stored, "Custom CSS file must be written to the archive")
+        assertEquals(css, stored!!.decodeToString(), "Stored CSS body must match input verbatim")
+    }
+
+    @Test
+    fun `custom CSS manifest entry uses correct media type`() {
+        val opf = buildEpub(customCss = ".a{}").text("OEBPS/content.opf")
+        assertTrue(
+            opf.contains("""href="${EpubWriter.CUSTOM_CSS_PATH}""""),
+            "Manifest must reference stylesheet at the writer's fixed path",
+        )
+        assertTrue(opf.contains("""media-type="text/css""""), "Manifest entry must declare text/css")
+    }
+
+    @Test
+    fun `every chapter links to the custom stylesheet when CSS is embedded`() {
+        val chapters = listOf(
+            EpubWriter.Chapter(title = "A", content = "<p>a</p>"),
+            EpubWriter.Chapter(title = "B", content = "<p>b</p>"),
+        )
+        val entries = buildEpub(chapters = chapters, customCss = ".a{}")
+        val expectedHref = EpubWriter.CUSTOM_CSS_PATH
+        assertTrue(
+            entries.text("OEBPS/chapter0000.xhtml").contains("""href="$expectedHref""""),
+            "Chapter 0 must <link> the bundled stylesheet",
+        )
+        assertTrue(
+            entries.text("OEBPS/chapter0001.xhtml").contains("""href="$expectedHref""""),
+            "Chapter 1 must <link> the bundled stylesheet",
+        )
+    }
+
+    @Test
+    fun `chapter does not reference custom stylesheet when CSS is absent`() {
+        val xhtml = buildEpub(customCss = null).text("OEBPS/chapter0000.xhtml")
+        assertFalse(
+            xhtml.contains(EpubWriter.CUSTOM_CSS_PATH),
+            "Chapter must not link tsundoku-style.css when CSS embedding is disabled",
+        )
+    }
+
+    @Test
+    fun `blank custom CSS is treated as absent`() {
+        val entries = buildEpub(customCss = "   \n  ")
+        assertNull(
+            entries["OEBPS/${EpubWriter.CUSTOM_CSS_PATH}"],
+            "Blank CSS input must not produce a stylesheet entry",
+        )
+        val opf = entries.text("OEBPS/content.opf")
+        assertFalse(opf.contains(EpubWriter.CUSTOM_CSS_PATH), "OPF must omit stylesheet manifest entry")
+    }
+
+    @Test
+    fun `custom JS body is written as standalone script entry`() {
+        val js = "console.log('hi');"
+        val entries = buildEpub(customJs = js)
+
+        val stored = entries["OEBPS/${EpubWriter.CUSTOM_JS_PATH}"]
+        assertNotNull(stored, "Custom JS file must be written to the archive")
+        assertEquals(js, stored!!.decodeToString())
+    }
+
+    @Test
+    fun `custom JS manifest entry uses application javascript media type`() {
+        val opf = buildEpub(customJs = "void 0;").text("OEBPS/content.opf")
+        assertTrue(opf.contains("""href="${EpubWriter.CUSTOM_JS_PATH}""""))
+        assertTrue(opf.contains("""media-type="application/javascript""""))
+    }
+
+    @Test
+    fun `chapters marked scripted in OPF when JS is embedded`() {
+        val opf = buildEpub(customJs = "void 0;").text("OEBPS/content.opf")
+        assertTrue(
+            Regex("""<item id="chapter0000"[^>]*properties="scripted"""").containsMatchIn(opf),
+            "Chapter manifest items must carry properties=\"scripted\" when JS is bundled",
+        )
+    }
+
+    @Test
+    fun `chapters not marked scripted when JS is absent`() {
+        val opf = buildEpub(customJs = null).text("OEBPS/content.opf")
+        assertFalse(opf.contains("properties=\"scripted\""), "No scripted property when JS not bundled")
+    }
+
+    @Test
+    fun `every chapter includes script tag when JS is embedded`() {
+        val chapters = listOf(
+            EpubWriter.Chapter(title = "A", content = "<p>a</p>"),
+            EpubWriter.Chapter(title = "B", content = "<p>b</p>"),
+        )
+        val entries = buildEpub(chapters = chapters, customJs = "void 0;")
+        val expectedHref = EpubWriter.CUSTOM_JS_PATH
+        assertTrue(
+            entries.text("OEBPS/chapter0000.xhtml").contains("""src="$expectedHref""""),
+            "Chapter 0 must reference tsundoku-script.js",
+        )
+        assertTrue(
+            entries.text("OEBPS/chapter0001.xhtml").contains("""src="$expectedHref""""),
+            "Chapter 1 must reference tsundoku-script.js",
+        )
+    }
+
+    @Test
+    fun `script tag is non-self-closing for XHTML compatibility`() {
+        val xhtml = buildEpub(customJs = "void 0;").text("OEBPS/chapter0000.xhtml")
+        assertTrue(xhtml.contains("</script>"), "Script tag must use explicit closing tag")
+    }
+
+    @Test
+    fun `embedding both CSS and JS produces both files and references`() {
+        val entries = buildEpub(customCss = ".a{}", customJs = "void 0;")
+        assertNotNull(entries["OEBPS/${EpubWriter.CUSTOM_CSS_PATH}"])
+        assertNotNull(entries["OEBPS/${EpubWriter.CUSTOM_JS_PATH}"])
+        val xhtml = entries.text("OEBPS/chapter0000.xhtml")
+        assertTrue(xhtml.contains(EpubWriter.CUSTOM_CSS_PATH))
+        assertTrue(xhtml.contains(EpubWriter.CUSTOM_JS_PATH))
+    }
+
+    @Test
+    fun `bundled snippet paths match conventional EPUB layout`() {
+        // Files should land under OEBPS/styles/ and OEBPS/scripts/ — common EPUB convention.
+        assertTrue(EpubWriter.CUSTOM_CSS_PATH.startsWith("styles/"))
+        assertTrue(EpubWriter.CUSTOM_CSS_PATH.endsWith(".css"))
+        assertTrue(EpubWriter.CUSTOM_JS_PATH.startsWith("scripts/"))
+        assertTrue(EpubWriter.CUSTOM_JS_PATH.endsWith(".js"))
+    }
+
+
+    @Test
+    fun `joined multi-volume EPUB embeds CSS and JS for every chapter`() {
+        val chapters = (1..6).map { idx ->
+            EpubWriter.Chapter(title = "ch $idx", content = "<p>$idx</p>")
+        }
+        val entries = buildEpub(chapters = chapters, customCss = ".a{}", customJs = "void 0;")
+
+        assertNotNull(entries["OEBPS/${EpubWriter.CUSTOM_CSS_PATH}"])
+        assertNotNull(entries["OEBPS/${EpubWriter.CUSTOM_JS_PATH}"])
+        repeat(6) { i ->
+            val xhtml = entries.text("OEBPS/chapter${i.toString().padStart(4, '0')}.xhtml")
+            assertTrue(xhtml.contains(EpubWriter.CUSTOM_CSS_PATH), "chapter $i missing CSS link")
+            assertTrue(xhtml.contains(EpubWriter.CUSTOM_JS_PATH), "chapter $i missing JS reference")
+        }
+
+        val opf = entries.text("OEBPS/content.opf")
+        repeat(6) { i ->
+            val id = "chapter${i.toString().padStart(4, '0')}"
+            assertTrue(opf.contains("""<itemref idref="$id""""), "spine must reference $id")
+            assertTrue(
+                Regex("""<item id="$id"[^>]*properties="scripted"""").containsMatchIn(opf),
+                "$id must be marked scripted",
+            )
+        }
+    }
+
+    @Test
+    fun `split-volume export writes one self-contained EPUB per volume with CSS and JS`() {
+        data class Volume(val title: String, val chapters: List<EpubWriter.Chapter>)
+        val volumes = listOf(
+            Volume("Vol 1", listOf(EpubWriter.Chapter("v1c1", "<p>v1c1</p>"), EpubWriter.Chapter("v1c2", "<p>v1c2</p>"))),
+            Volume("Vol 2", listOf(EpubWriter.Chapter("v2c1", "<p>v2c1</p>"))),
+            Volume("Vol 3", listOf(EpubWriter.Chapter("v3c1", "<p>v3c1</p>"), EpubWriter.Chapter("v3c2", "<p>v3c2</p>"))),
+        )
+
+        volumes.forEach { volume ->
+            val entries = buildEpub(
+                chapters = volume.chapters,
+                metadata = EpubWriter.Metadata(title = volume.title),
+                customCss = ".a{}",
+                customJs = "void 0;",
+            )
+
+            assertNotNull(
+                entries["OEBPS/${EpubWriter.CUSTOM_CSS_PATH}"],
+                "${volume.title} must bundle its own CSS file",
+            )
+            assertNotNull(
+                entries["OEBPS/${EpubWriter.CUSTOM_JS_PATH}"],
+                "${volume.title} must bundle its own JS file",
+            )
+
+            val chapterEntryCount = entries.keys.count {
+                it.startsWith("OEBPS/chapter") && it.endsWith(".xhtml")
+            }
+            assertEquals(volume.chapters.size, chapterEntryCount, "${volume.title} chapter count mismatch")
+
+            volume.chapters.indices.forEach { i ->
+                val xhtml = entries.text("OEBPS/chapter${i.toString().padStart(4, '0')}.xhtml")
+                assertTrue(xhtml.contains(EpubWriter.CUSTOM_CSS_PATH))
+                assertTrue(xhtml.contains(EpubWriter.CUSTOM_JS_PATH))
+            }
+        }
     }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -431,22 +431,29 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         )
     }
 
-    /**
-     * Returns chapter content for export.
-     * Internal image assets are converted to data URIs, so written EPUB chapters stay self-contained.
-     */
-    fun getChapterContentForExport(chapterHref: String): String {
-        return getChapterContentInternal(
+    data class ChapterExportData(
+        val html: String,
+        val images: Map<String, ByteArray>,
+    )
+
+
+    fun extractChapterForExport(chapterHref: String): ChapterExportData {
+        val collected = linkedMapOf<String, ByteArray>()
+        val html = getChapterContentInternal(
             chapterHref = chapterHref,
             useReaderImageScheme = false,
             bodyOnly = true,
+            imageCollector = collected,
         )
+        return ChapterExportData(html, collected)
     }
+
 
     private fun getChapterContentInternal(
         chapterHref: String,
         useReaderImageScheme: Boolean,
         bodyOnly: Boolean,
+        imageCollector: MutableMap<String, ByteArray>? = null,
     ): String {
         val pathPart = chapterHref.substringBefore("#").trim().urlDecoded()
         val fragment = chapterHref.substringAfter("#", "").takeIf { it.isNotBlank() }
@@ -463,37 +470,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         return getInputStream(entryPath)?.use { inputStream ->
             val document = Jsoup.parse(inputStream, null, "", Parser.xmlParser())
 
-            // Inline EPUB-internal media.
             val imageBasePath = getParentDirectory(entryPath)
-            document.select("img, image").forEach { img ->
-                val rawSrc = when {
-                    img.hasAttr("src") -> img.attr("src")
-                    img.hasAttr("xlink:href") -> img.attr("xlink:href")
-                    img.hasAttr("href") -> img.attr("href")
-                    else -> return@forEach
-                }
-
-                val src = rawSrc.substringBefore("#").trim().urlDecoded()
-                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:")) {
-                    return@forEach
-                }
-
-                val imagePath = resolveZipPath(imageBasePath, src)
-                val replacement = if (useReaderImageScheme) {
-                    "tsundoku-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
-                } else {
-                    inlineAssetAsDataUri(imagePath) ?: return@forEach
-                }
-
-                when {
-                    img.hasAttr("src") -> img.attr("src", replacement)
-                    img.hasAttr("xlink:href") -> img.attr("xlink:href", replacement)
-                    else -> img.attr("href", replacement)
-                }
-            }
-
-            // TextView-based rendering doesn't reliably support SVG nodes.
-            // Convert simple SVG image containers to regular <img> tags.
             document.select("svg").forEach { svg ->
                 val svgImage =
                     svg.select("image").firstOrNull { it.hasAttr("xlink:href") || it.hasAttr("href") } ?: return@forEach
@@ -508,6 +485,43 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 imgElement.attr("src", imageSrc)
                 imgElement.attr("style", "max-width:100%;height:auto;")
                 svg.replaceWith(imgElement)
+            }
+
+            document.select("img, image").forEach { img ->
+                val rawSrc = when {
+                    img.hasAttr("src") -> img.attr("src")
+                    img.hasAttr("xlink:href") -> img.attr("xlink:href")
+                    img.hasAttr("href") -> img.attr("href")
+                    else -> return@forEach
+                }
+
+                val src = rawSrc.substringBefore("#").trim().urlDecoded()
+                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:")) {
+                    return@forEach
+                }
+
+                val imagePath = resolveZipPath(imageBasePath, src)
+                val replacement = when {
+                    useReaderImageScheme -> {
+                        "tsundoku-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                    }
+                    imageCollector != null -> {
+                        val bytes = runCatching {
+                            getInputStream(imagePath)?.use { it.readBytes() }
+                        }.getOrNull()
+                        if (bytes == null || bytes.isEmpty()) return@forEach
+                        val id = buildExportImageId(imagePath)
+                        imageCollector.putIfAbsent(id, bytes)
+                        "tsundoku-novel-image://$id"
+                    }
+                    else -> inlineAssetAsDataUri(imagePath) ?: return@forEach
+                }
+
+                when {
+                    img.hasAttr("src") -> img.attr("src", replacement)
+                    img.hasAttr("xlink:href") -> img.attr("xlink:href", replacement)
+                    else -> img.attr("href", replacement)
+                }
             }
 
             // Inline EPUB CSS
@@ -572,6 +586,29 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 else -> document.outerHtml()
             }
         } ?: ""
+    }
+
+    private fun buildExportImageId(imagePath: String): String = computeExportImageId(imagePath)
+
+    companion object {
+        fun computeExportImageId(imagePath: String): String {
+            val normalized = imagePath.replace('\\', '/')
+            val tail = normalized.substringAfterLast('.', "")
+            val extension = tail
+                .lowercase()
+                .takeIf { it.isNotBlank() && it.length <= 5 && it.all { c -> c.isLetterOrDigit() } }
+            val stemSource = if (extension != null) {
+                normalized.removeSuffix(".$tail")
+            } else {
+                normalized
+            }
+            val squashed = stemSource
+                .replace(Regex("[^A-Za-z0-9_-]"), "_")
+                .trim('_')
+                .ifBlank { "image" }
+                .take(80)
+            return if (extension != null) "$squashed.$extension" else squashed
+        }
     }
 
     private fun inlineAssetAsDataUri(assetPath: String): String? {

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -2,10 +2,11 @@ package mihon.core.archive
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.DataNode
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
 import org.jsoup.parser.Parser
 import java.io.Closeable
-import java.io.File
 import java.io.InputStream
 import java.net.URLDecoder
 
@@ -63,7 +64,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                         return resolveZipPath(pageBasePath, src)
                     }
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Ignore parsing errors
             }
         }
@@ -547,7 +548,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                                 inlineAssetAsDataUri(assetPath)?.let { "url('$it')" } ?: match.value
                             }
 
-                            val style = org.jsoup.nodes.Element("style")
+                            val style = Element("style")
                             style.attr("data-epub-css", "true")
                             style.attr("data-file", href.substringAfterLast('/'))
                             style.text(cssText)
@@ -565,11 +566,11 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                     try {
                         getInputStream(jsPath)?.use { stream ->
                             val jsText = stream.reader().readText()
-                            val inlineScript = org.jsoup.nodes.Element("script")
+                            val inlineScript = Element("script")
                             inlineScript.attr("data-epub-js", "true")
                             inlineScript.attr("data-file", src.substringAfterLast('/'))
                             // Using dataNode for plain text in script to avoid weird HTML escaping.
-                            inlineScript.appendChild(org.jsoup.nodes.DataNode(jsText))
+                            inlineScript.appendChild(DataNode(jsText))
                             script.replaceWith(inlineScript)
                         }
                     } catch (_: Exception) { }
@@ -579,9 +580,9 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             // Remove title to prevent bleeding into text viewers.
             document.getElementsByTag("title").remove()
 
-            val fragmentHtml = fragment?.let { extractFragmentHtml(document, it) }
+            val fragmentHtml = fragment?.let { extractFragmentHtml(document, it) }.orEmpty()
             when {
-                !fragmentHtml.isNullOrBlank() -> fragmentHtml
+                fragmentHtml.isNotBlank() -> fragmentHtml
                 bodyOnly -> document.body().html().ifBlank { document.outerHtml() }
                 else -> document.outerHtml()
             }
@@ -641,32 +642,34 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             val primary = fragment.substringAfterLast("#").trim().removePrefix("#")
             if (primary.isNotBlank()) {
                 add(primary)
-                val decoded = runCatching { java.net.URLDecoder.decode(primary, "UTF-8") }.getOrNull()
-                if (!decoded.isNullOrBlank() && decoded != primary) {
+                val decoded = runCatching { URLDecoder.decode(primary, "UTF-8") }.getOrDefault("")
+                if (decoded.isNotBlank() && decoded != primary) {
                     add(decoded)
                 }
             }
         }.distinct()
 
         for (candidate in candidates) {
-            document.getElementById(candidate)?.let { element ->
-                materializeFragmentElement(element)?.let { return it }
+            val elementById = document.getElementById(candidate)
+            if (elementById != null) {
+                val materialized = materializeFragmentElement(elementById)
+                if (materialized.isNotBlank()) return materialized
             }
 
             val escaped = candidate
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"")
-            document
-                .selectFirst("*[id=\"$escaped\"], *[name=\"$escaped\"]")
-                ?.let { element ->
-                    materializeFragmentElement(element)?.let { return it }
-                }
+            val elementByName = document.selectFirst("*[id=\"$escaped\"], *[name=\"$escaped\"]")
+            if (elementByName != null) {
+                val materialized = materializeFragmentElement(elementByName)
+                if (materialized.isNotBlank()) return materialized
+            }
         }
 
         return null
     }
 
-    private fun materializeFragmentElement(element: Element): String? {
+    private fun materializeFragmentElement(element: Element): String {
         findHeadingElement(element)?.let { heading ->
             return extractHeadingSectionHtml(heading)
         }
@@ -675,7 +678,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             return element.outerHtml()
         }
 
-        return null
+        return ""
     }
 
     private fun findHeadingElement(element: Element): Element? {
@@ -686,11 +689,11 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
     }
 
-    private fun extractHeadingSectionHtml(heading: Element): String? {
+    private fun extractHeadingSectionHtml(heading: Element): String {
         val headingLevel = heading.tagName().removePrefix("h").toIntOrNull() ?: return heading.outerHtml()
         val section = Element("div")
 
-        var node: org.jsoup.nodes.Node? = heading
+        var node: Node? = heading
         while (node != null) {
             if (node !== heading && node is Element && isHeadingTag(node.tagName())) {
                 val siblingHeadingLevel = node.tagName().removePrefix("h").toIntOrNull() ?: Int.MAX_VALUE

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
@@ -21,6 +21,7 @@ class EpubWriter(
     private val deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
 ) {
 
+    @Suppress("ArrayInDataClass")
     data class EmbeddedImage(
         val id: String,
         val bytes: ByteArray,
@@ -416,29 +417,6 @@ $spineItems
             }
         }
 
-        /**
-         * Convenience method to write EPUB to a file.
-         */
-        fun writeToFile(
-            file: File,
-            metadata: Metadata,
-            chapters: List<Chapter>,
-            coverImage: ByteArray? = null,
-            deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
-            customCss: String? = null,
-            customJs: String? = null,
-        ) {
-            file.outputStream().use { outputStream ->
-                EpubWriter(deflateLevel).write(
-                    outputStream = outputStream,
-                    metadata = metadata,
-                    chapters = chapters,
-                    coverImage = coverImage,
-                    customCss = customCss,
-                    customJs = customJs,
-                )
-            }
-        }
         const val CUSTOM_CSS_PATH = "styles/tsundoku-style.css"
         const val CUSTOM_JS_PATH = "scripts/tsundoku-script.js"
     }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
@@ -50,11 +50,16 @@ class EpubWriter(
         metadata: Metadata,
         chapters: List<Chapter>,
         coverImage: ByteArray? = null,
+        customCss: String? = null,
+        customJs: String? = null,
     ) {
         val bookId = UUID.randomUUID().toString()
 
         val (coverMimeType, coverExtension) = if (coverImage != null) detectImageType(coverImage) else "image/jpeg" to "jpg"
         val coverFileName = "cover.$coverExtension"
+
+        val cssBody = customCss?.takeIf { it.isNotBlank() }
+        val jsBody = customJs?.takeIf { it.isNotBlank() }
 
         ZipOutputStream(outputStream).use { zip ->
             zip.setLevel(deflateLevel)
@@ -63,6 +68,13 @@ class EpubWriter(
 
             if (coverImage != null) {
                 writeEntry(zip, "OEBPS/images/$coverFileName", coverImage)
+            }
+
+            if (cssBody != null) {
+                writeEntry(zip, "OEBPS/$CUSTOM_CSS_PATH", cssBody)
+            }
+            if (jsBody != null) {
+                writeEntry(zip, "OEBPS/$CUSTOM_JS_PATH", jsBody)
             }
 
             chapters.forEachIndexed { chIdx, chapter ->
@@ -74,11 +86,22 @@ class EpubWriter(
             }
 
             chapters.forEachIndexed { index, chapter ->
-                writeChapter(zip, index, chapter)
+                writeChapter(zip, index, chapter, includeCustomCss = cssBody != null, includeCustomJs = jsBody != null)
             }
 
             writeNavDocument(zip, chapters)
-            writePackageDocument(zip, metadata, chapters, coverImage != null, bookId, coverFileName, coverMimeType)
+            writeNcxDocument(zip, metadata, chapters, bookId)
+            writePackageDocument(
+                zip = zip,
+                metadata = metadata,
+                chapters = chapters,
+                hasCover = coverImage != null,
+                bookId = bookId,
+                coverFileName = coverFileName,
+                coverMimeType = coverMimeType,
+                hasCustomCss = cssBody != null,
+                hasCustomJs = jsBody != null,
+            )
         }
     }
 
@@ -105,9 +128,26 @@ class EpubWriter(
         writeEntry(zip, "META-INF/container.xml", content)
     }
 
-    private fun writeChapter(zip: ZipOutputStream, index: Int, chapter: Chapter) {
+    private fun writeChapter(
+        zip: ZipOutputStream,
+        index: Int,
+        chapter: Chapter,
+        includeCustomCss: Boolean,
+        includeCustomJs: Boolean,
+    ) {
         val chapterPrefix = chapterFilePrefix(index)
         val bodyContent = rewriteChapterHtml(chapter.content, chapterPrefix, chapter.images)
+
+        val customCssLink = if (includeCustomCss) {
+            "\n    <link rel=\"stylesheet\" type=\"text/css\" href=\"$CUSTOM_CSS_PATH\"/>"
+        } else {
+            ""
+        }
+        val customJsTag = if (includeCustomJs) {
+            "\n    <script type=\"text/javascript\" src=\"$CUSTOM_JS_PATH\"><!-- --></script>"
+        } else {
+            ""
+        }
 
         val content = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
@@ -121,7 +161,7 @@ class EpubWriter(
         p { margin: 0.5em 0; text-indent: 1em; }
         .chapter-title { text-align: center; margin-bottom: 2em; }
         img { max-width: 100%; height: auto; }
-    </style>
+    </style>$customCssLink$customJsTag
 </head>
 <body>
     <h1 class="chapter-title">${escapeXml(chapter.title)}</h1>
@@ -219,6 +259,36 @@ $tocItems
         writeEntry(zip, "OEBPS/nav.xhtml", content)
     }
 
+    private fun writeNcxDocument(
+        zip: ZipOutputStream,
+        metadata: Metadata,
+        chapters: List<Chapter>,
+        bookId: String,
+    ) {
+        val navPoints = chapters.mapIndexed { index, chapter ->
+            val filename = "${chapterFilePrefix(index)}.xhtml"
+            """        <navPoint id="navpoint-${index + 1}" playOrder="${index + 1}">
+            <navLabel><text>${escapeXml(chapter.title)}</text></navLabel>
+            <content src="$filename"/>
+        </navPoint>"""
+        }.joinToString("\n")
+
+        val content = """<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+    <head>
+        <meta name="dtb:uid" content="urn:uuid:$bookId"/>
+        <meta name="dtb:depth" content="1"/>
+        <meta name="dtb:totalPageCount" content="0"/>
+        <meta name="dtb:maxPageNumber" content="0"/>
+    </head>
+    <docTitle><text>${escapeXml(metadata.title)}</text></docTitle>
+    <navMap>
+$navPoints
+    </navMap>
+</ncx>"""
+        writeEntry(zip, "OEBPS/toc.ncx", content)
+    }
+
     private fun writePackageDocument(
         zip: ZipOutputStream,
         metadata: Metadata,
@@ -227,15 +297,26 @@ $tocItems
         bookId: String,
         coverFileName: String,
         coverMimeType: String,
+        hasCustomCss: Boolean,
+        hasCustomJs: Boolean,
     ) {
+        val chapterProperties = if (hasCustomJs) " properties=\"scripted\"" else ""
+
         val manifestItems = buildString {
             appendLine("""        <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>""")
+            appendLine("""        <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>""")
             if (hasCover) {
                 appendLine("""        <item id="cover-image" href="images/$coverFileName" media-type="$coverMimeType" properties="cover-image"/>""")
             }
+            if (hasCustomCss) {
+                appendLine("""        <item id="tsundoku-style" href="$CUSTOM_CSS_PATH" media-type="text/css"/>""")
+            }
+            if (hasCustomJs) {
+                appendLine("""        <item id="tsundoku-script" href="$CUSTOM_JS_PATH" media-type="application/javascript"/>""")
+            }
             chapters.forEachIndexed { chIdx, chapter ->
                 val prefix = chapterFilePrefix(chIdx)
-                appendLine("""        <item id="$prefix" href="$prefix.xhtml" media-type="application/xhtml+xml"/>""")
+                appendLine("""        <item id="$prefix" href="$prefix.xhtml" media-type="application/xhtml+xml"$chapterProperties/>""")
                 chapter.images.forEach { img ->
                     val epubFileName = chapterImageFileName(prefix, img)
                     val manifestId = "$prefix-img-${img.id.replace('.', '-').replace('_', '-')}"
@@ -274,7 +355,7 @@ $epub2CoverMeta
     <manifest>
 $manifestItems
     </manifest>
-    <spine>
+    <spine toc="ncx">
 $spineItems
     </spine>
 </package>"""
@@ -344,10 +425,21 @@ $spineItems
             chapters: List<Chapter>,
             coverImage: ByteArray? = null,
             deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
+            customCss: String? = null,
+            customJs: String? = null,
         ) {
             file.outputStream().use { outputStream ->
-                EpubWriter(deflateLevel).write(outputStream, metadata, chapters, coverImage)
+                EpubWriter(deflateLevel).write(
+                    outputStream = outputStream,
+                    metadata = metadata,
+                    chapters = chapters,
+                    coverImage = coverImage,
+                    customCss = customCss,
+                    customJs = customJs,
+                )
             }
         }
+        const val CUSTOM_CSS_PATH = "styles/tsundoku-style.css"
+        const val CUSTOM_JS_PATH = "scripts/tsundoku-script.js"
     }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
@@ -1,5 +1,6 @@
 package mihon.core.archive
 
+import org.jsoup.Jsoup
 import java.io.File
 import java.io.OutputStream
 import java.util.UUID
@@ -8,21 +9,30 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 /**
- * EPUB writer for creating EPUB 3.0 files.
- * Creates a valid EPUB with proper structure: mimetype, META-INF/container.xml, content.opf, nav.xhtml, and chapter HTML files.
+ * EPUB writer for creating EPUB 3.0 files (with EPUB 2 compatibility).
+ * Creates a valid EPUB with: mimetype, META-INF/container.xml, content.opf, nav.xhtml, chapter HTML files,
+ * and optionally embedded chapter images.
  *
  * @param deflateLevel Deflate compression level (0-9). 0 = no compression (stored), 9 = max compression.
  *                     Default is [java.util.zip.Deflater.DEFAULT_COMPRESSION] (-1).
- *                     The `mimetype` entry is ALWAYS stored uncompressed per the EPUB spec, regardless of this setting.
+ *                     The `mimetype` entry is ALWAYS stored uncompressed per the EPUB spec.
  */
 class EpubWriter(
     private val deflateLevel: Int = java.util.zip.Deflater.DEFAULT_COMPRESSION,
 ) {
 
+    data class EmbeddedImage(
+        val id: String,
+        val bytes: ByteArray,
+        val mimeType: String,
+        val extension: String,
+    )
+
     data class Chapter(
         val title: String,
         val content: String,
         val order: Int = 0,
+        val images: List<EmbeddedImage> = emptyList(),
     )
 
     data class Metadata(
@@ -35,14 +45,6 @@ class EpubWriter(
         val publisher: String? = null,
     )
 
-    /**
-     * Write an EPUB file to the given output stream.
-     *
-     * @param outputStream The output stream to write to
-     * @param metadata The book metadata
-     * @param chapters The chapters to include
-     * @param coverImage Optional cover image bytes
-     */
     fun write(
         outputStream: OutputStream,
         metadata: Metadata,
@@ -51,30 +53,32 @@ class EpubWriter(
     ) {
         val bookId = UUID.randomUUID().toString()
 
-        ZipOutputStream(outputStream).use { zip ->
-            // Set the compression level for all entries except mimetype
-            zip.setLevel(deflateLevel)
-            // mimetype must be first entry and stored uncompressed
-            writeMimetype(zip)
+        val (coverMimeType, coverExtension) = if (coverImage != null) detectImageType(coverImage) else "image/jpeg" to "jpg"
+        val coverFileName = "cover.$coverExtension"
 
-            // META-INF/container.xml
+        ZipOutputStream(outputStream).use { zip ->
+            zip.setLevel(deflateLevel)
+            writeMimetype(zip)
             writeContainerXml(zip)
 
-            // Cover image (if provided)
             if (coverImage != null) {
-                writeEntry(zip, "OEBPS/images/cover.jpg", coverImage)
+                writeEntry(zip, "OEBPS/images/$coverFileName", coverImage)
             }
 
-            // Chapter files
+            chapters.forEachIndexed { chIdx, chapter ->
+                val chapterPrefix = chapterFilePrefix(chIdx)
+                chapter.images.forEach { img ->
+                    val epubFileName = chapterImageFileName(chapterPrefix, img)
+                    writeEntry(zip, "OEBPS/images/$epubFileName", img.bytes)
+                }
+            }
+
             chapters.forEachIndexed { index, chapter ->
                 writeChapter(zip, index, chapter)
             }
 
-            // Navigation document (EPUB 3)
             writeNavDocument(zip, chapters)
-
-            // Package document (content.opf)
-            writePackageDocument(zip, metadata, chapters, coverImage != null, bookId)
+            writePackageDocument(zip, metadata, chapters, coverImage != null, bookId, coverFileName, coverMimeType)
         }
     }
 
@@ -102,8 +106,8 @@ class EpubWriter(
     }
 
     private fun writeChapter(zip: ZipOutputStream, index: Int, chapter: Chapter) {
-        val safeContent = chapter.content
-            .replace("&(?!amp;|lt;|gt;|quot;|apos;|#\\d+;|#x[0-9a-fA-F]+;)".toRegex(), "&amp;")
+        val chapterPrefix = chapterFilePrefix(index)
+        val bodyContent = rewriteChapterHtml(chapter.content, chapterPrefix, chapter.images)
 
         val content = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
@@ -116,21 +120,83 @@ class EpubWriter(
         h1, h2, h3 { font-family: sans-serif; }
         p { margin: 0.5em 0; text-indent: 1em; }
         .chapter-title { text-align: center; margin-bottom: 2em; }
+        img { max-width: 100%; height: auto; }
     </style>
 </head>
 <body>
     <h1 class="chapter-title">${escapeXml(chapter.title)}</h1>
     <div class="chapter-content">
-        $safeContent
+        $bodyContent
     </div>
 </body>
 </html>"""
-        writeEntry(zip, "OEBPS/chapter${index.toString().padStart(4, '0')}.xhtml", content)
+        writeEntry(zip, "OEBPS/$chapterPrefix.xhtml", content)
+    }
+
+    /**
+     * Rewrites [content] HTML for EPUB embedding:
+     * - Replaces tsundoku-novel-image:// src attributes with relative EPUB image paths.
+     * - Removes orphan tsundoku-novel-image:// img elements (image not in [images]).
+     * - Strips <source> children from <picture>, keeping only the <img> fallback.
+     * - Removes <picture> elements that have no usable <img> fallback.
+     */
+    private fun rewriteChapterHtml(content: String, chapterPrefix: String, images: List<EmbeddedImage>): String {
+        val hasTsundokuPaths = content.contains("tsundoku-novel-image://")
+        val hasPictures = content.contains("<picture")
+        if (images.isEmpty() && !hasTsundokuPaths && !hasPictures) return content
+
+        val imageMap = images.associate { img ->
+            "tsundoku-novel-image://${img.id}" to "images/${chapterImageFileName(chapterPrefix, img)}"
+        }
+
+        val doc = Jsoup.parseBodyFragment(content)
+
+        // Process <picture> elements: strip <source> elements, unwrap to bare <img>
+        doc.select("picture").forEach { picture ->
+            val existingImg = picture.selectFirst("img")
+            val img = existingImg ?: run {
+                // Build an img from the first <source> that has a usable src/srcset
+                val source = picture.selectFirst("source")
+                val src = source?.attr("srcset")
+                    ?.split(",")?.firstOrNull()?.trim()?.split(" ")?.firstOrNull()
+                    ?.takeIf { it.isNotBlank() }
+                    ?: source?.attr("src")?.takeIf { it.isNotBlank() }
+                if (src != null) {
+                    val newImg = doc.createElement("img")
+                    newImg.attr("src", src)
+                    val altText = source?.attr("alt")?.ifBlank { picture.attr("alt") }
+                    if (!altText.isNullOrBlank()) newImg.attr("alt", altText)
+                    newImg
+                } else null
+            }
+
+            if (img != null) {
+                picture.select("source").remove()
+                picture.replaceWith(img)
+            } else {
+                picture.remove()
+            }
+        }
+
+        // Replace / remove tsundoku-novel-image:// src attributes
+        doc.select("img[src]").forEach { imgEl ->
+            val src = imgEl.attr("src")
+            if (src.startsWith("tsundoku-novel-image://")) {
+                val mapped = imageMap[src]
+                if (mapped != null) {
+                    imgEl.attr("src", mapped)
+                } else {
+                    imgEl.remove()
+                }
+            }
+        }
+
+        return doc.body().html()
     }
 
     private fun writeNavDocument(zip: ZipOutputStream, chapters: List<Chapter>) {
         val tocItems = chapters.mapIndexed { index, chapter ->
-            val filename = "chapter${index.toString().padStart(4, '0')}.xhtml"
+            val filename = "${chapterFilePrefix(index)}.xhtml"
             """            <li><a href="$filename">${escapeXml(chapter.title)}</a></li>"""
         }.joinToString("\n")
 
@@ -159,29 +225,37 @@ $tocItems
         chapters: List<Chapter>,
         hasCover: Boolean,
         bookId: String,
+        coverFileName: String,
+        coverMimeType: String,
     ) {
         val manifestItems = buildString {
-            appendLine(
-                """        <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>""",
-            )
+            appendLine("""        <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>""")
             if (hasCover) {
-                appendLine(
-                    """        <item id="cover-image" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>""",
-                )
+                appendLine("""        <item id="cover-image" href="images/$coverFileName" media-type="$coverMimeType" properties="cover-image"/>""")
             }
-            chapters.forEachIndexed { index, _ ->
-                val id = "chapter${index.toString().padStart(4, '0')}"
-                appendLine("""        <item id="$id" href="$id.xhtml" media-type="application/xhtml+xml"/>""")
+            chapters.forEachIndexed { chIdx, chapter ->
+                val prefix = chapterFilePrefix(chIdx)
+                appendLine("""        <item id="$prefix" href="$prefix.xhtml" media-type="application/xhtml+xml"/>""")
+                chapter.images.forEach { img ->
+                    val epubFileName = chapterImageFileName(prefix, img)
+                    val manifestId = "$prefix-img-${img.id.replace('.', '-').replace('_', '-')}"
+                    appendLine("""        <item id="$manifestId" href="images/$epubFileName" media-type="${img.mimeType}"/>""")
+                }
             }
         }.trimEnd()
 
         val spineItems = chapters.mapIndexed { index, _ ->
-            val id = "chapter${index.toString().padStart(4, '0')}"
-            """        <itemref idref="$id"/>"""
+            """        <itemref idref="${chapterFilePrefix(index)}"/>"""
         }.joinToString("\n")
 
         val genresMetadata = metadata.genres.joinToString("\n") { genre ->
             """        <dc:subject>${escapeXml(genre)}</dc:subject>"""
+        }
+
+        val epub2CoverMeta = if (hasCover) {
+            """        <meta name="cover" content="cover-image"/>"""
+        } else {
+            ""
         }
 
         val content = """<?xml version="1.0" encoding="UTF-8"?>
@@ -194,6 +268,7 @@ ${metadata.author?.let { """        <dc:creator>${escapeXml(it)}</dc:creator>"""
 ${metadata.description?.let { """        <dc:description>${escapeXml(it)}</dc:description>""" } ?: ""}
 ${metadata.publisher?.let { """        <dc:publisher>${escapeXml(it)}</dc:publisher>""" } ?: ""}
 $genresMetadata
+$epub2CoverMeta
         <meta property="dcterms:modified">${java.time.Instant.now().toString().substringBefore('.') + "Z"}</meta>
     </metadata>
     <manifest>
@@ -228,7 +303,38 @@ $spineItems
             .replace("'", "&apos;")
     }
 
+    private fun chapterFilePrefix(index: Int) = "chapter${index.toString().padStart(4, '0')}"
+
+    private fun chapterImageFileName(chapterPrefix: String, img: EmbeddedImage): String {
+        val baseName = img.id.substringBeforeLast(".", img.id)
+        return "${chapterPrefix}_${baseName}.${img.extension}"
+    }
+
     companion object {
+        /**
+         * Detects image MIME type and extension from magic bytes.
+         * Returns Pair(mimeType, extension).
+         */
+        fun detectImageType(bytes: ByteArray): Pair<String, String> {
+            if (bytes.size < 4) return "image/jpeg" to "jpg"
+            return when {
+                bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() ->
+                    "image/jpeg" to "jpg"
+                bytes[0] == 0x89.toByte() && bytes[1] == 0x50.toByte() &&
+                    bytes[2] == 0x4E.toByte() && bytes[3] == 0x47.toByte() ->
+                    "image/png" to "png"
+                bytes.size >= 12 &&
+                    bytes[0] == 0x52.toByte() && bytes[1] == 0x49.toByte() &&
+                    bytes[2] == 0x46.toByte() && bytes[3] == 0x46.toByte() &&
+                    bytes[8] == 0x57.toByte() && bytes[9] == 0x45.toByte() &&
+                    bytes[10] == 0x42.toByte() && bytes[11] == 0x50.toByte() ->
+                    "image/webp" to "webp"
+                bytes[0] == 0x47.toByte() && bytes[1] == 0x49.toByte() && bytes[2] == 0x46.toByte() ->
+                    "image/gif" to "gif"
+                else -> "image/jpeg" to "jpg"
+            }
+        }
+
         /**
          * Convenience method to write EPUB to a file.
          */

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -53,6 +53,7 @@
     <string name="local_novel_source_covers_refreshed">Covers refreshed for %d novel(s)</string>
     <string name="local_novel_source_select_category">Select category</string>
     <string name="local_novel_source_open_folder_error">Could not open folder — no file manager found</string>
+    <string name="local_novel_source_delete_failed">Failed to delete %d novel(s) — check permissions</string>
     <!-- History -->
     <string name="pref_clear_cover">Clear cover</string>
     <!-- Downloads activity and service

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -45,6 +45,14 @@
     <string name="delete_local_novel_files">Delete local EPUB/HTML?</string>
     <!-- Browse Source -->
     <string name="local_novel_source">Local novels</string>
+    <string name="local_novel_source_open_folder">Open folder</string>
+    <string name="local_novel_source_refresh_covers">Refresh covers</string>
+    <string name="local_novel_source_delete_title">Delete novels?</string>
+    <string name="local_novel_source_delete_message">This will permanently delete the folder and all files for each selected novel, and remove them from the library. This cannot be undone.</string>
+    <string name="local_novel_source_add_to_library">Add to library</string>
+    <string name="local_novel_source_covers_refreshed">Covers refreshed for %d novel(s)</string>
+    <string name="local_novel_source_select_category">Select category</string>
+    <string name="local_novel_source_open_folder_error">Could not open folder — no file manager found</string>
     <!-- History -->
     <string name="pref_clear_cover">Clear cover</string>
     <!-- Downloads activity and service
@@ -104,7 +112,7 @@
     <string name="mass_import_cd_details">Details</string>
     <string name="mass_import_pending_count">%d URL(s) pending</string>
     <string name="mass_import_toast_error_reading_file">Error reading file: %s</string>
-    <string name="mass_import_toast_added_urls_from_files">Added %d URLs from %d file(s)</string>
+    <string name="mass_import_toast_added_urls_from_files">Added %1$d URLs from %2$d file(s)</string>
     <string name="mass_import_toast_no_readable_urls">No readable URLs found in selected files</string>
     <string name="mass_import_toast_report_saved">Report saved successfully</string>
     <string name="mass_import_toast_error_saving_report">Error saving report: %s</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -327,6 +327,10 @@
     <string name="epub_include_chapter_range">Include chapter range (e.g. [ch1-50])</string>
     <string name="epub_include_status">Include status (e.g. [Completed])</string>
     <string name="epub_include_volume_number">Include volume number (e.g. [v2])</string>
+    <string name="epub_include_custom_css">Embed active CSS snippets</string>
+    <string name="epub_include_custom_js">Embed active JS snippets</string>
+    <string name="epub_include_custom_assets_section">Embedded reader snippets</string>
+    <string name="epub_include_custom_assets_info">Bundles your enabled CSS/JS snippets.</string>
     <string name="epub_downloaded_only_info">Only downloaded chapters will be included.</string>
     <string name="epub_source_info">Downloaded chapters will be used. Undownloaded chapters will be fetched from source.</string>
     <string name="epub_translated_info"> Translated chapters will be used when available.</string>

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -251,31 +251,7 @@ actual class LocalNovelSource(
             if (chapterFile.extension.equals("epub", true)) {
                 try {
                     chapterFile.epubReader(context).use { epub ->
-                        // Try to find and set the cover image if not set yet
-                        if (coverManager.find(manga.url) == null) {
-                            try {
-                                val cover = epub.getCoverImage()
-                                if (cover != null) {
-                                    if (cover.startsWith("http://") || cover.startsWith("https://")) {
-                                        downloadCoverBytes(cover)?.let { bytes ->
-                                            logcat(LogPriority.INFO) {
-                                                "LocalNovelSource: Downloaded external cover $cover"
-                                            }
-                                            coverManager.update(manga, ByteArrayInputStream(bytes))
-                                        }
-                                    } else {
-                                        epub.getInputStream(cover)?.use { stream ->
-                                            logcat(LogPriority.INFO) {
-                                                "LocalNovelSource: Extracted embedded cover $cover"
-                                            }
-                                            coverManager.update(manga, stream)
-                                        }
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                logcat(LogPriority.ERROR, e) { "Error extracting cover from ${chapterFile.name}" }
-                            }
-                        }
+                        extractCoverFromOpenEpub(epub, manga, force = false)
 
                         val tocChapters = epub.getNormalizedTableOfContents()
                         if (tocChapters.isNotEmpty()) {
@@ -326,6 +302,22 @@ actual class LocalNovelSource(
         }
     }
 
+    suspend fun refreshCover(manga: SManga): String? = withIOContext {
+        val novelEntry = resolveNovelEntry(manga.url) ?: return@withIOContext null
+        val epubFile = when {
+            novelEntry.isDirectory -> fileSystem.getFilesInNovelDirectory(manga.url)
+                .firstOrNull { it.extension.equals("epub", true) }
+            novelEntry.extension.equals("epub", true) -> novelEntry
+            else -> null
+        } ?: return@withIOContext null
+
+        if (!extractCoverFromEpub(epubFile, manga, force = true)) {
+            return@withIOContext null
+        }
+
+        coverManager.find(manga.url)?.uri?.toString()
+    }
+
     private fun createSimpleChapter(manga: SManga, chapterFile: UniFile): SChapter {
         return SChapter.create().apply {
             url = "${manga.url}/${chapterFile.name}"
@@ -345,6 +337,36 @@ actual class LocalNovelSource(
         if (file.isDirectory) return true
         val ext = file.extension?.lowercase() ?: return false
         return ext in SUPPORTED_EXTENSIONS
+    }
+
+    private fun extractCoverFromEpub(chapterFile: UniFile, manga: SManga, force: Boolean): Boolean {
+        return try {
+            chapterFile.epubReader(context).use { epub ->
+                extractCoverFromOpenEpub(epub, manga, force)
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Error extracting cover from ${chapterFile.name}" }
+            false
+        }
+    }
+
+    private fun extractCoverFromOpenEpub(epub: EpubReader, manga: SManga, force: Boolean): Boolean {
+        if (!force && coverManager.find(manga.url) != null) return true
+        val cover = epub.getCoverImage() ?: return false
+        return when {
+            cover.startsWith("http://") || cover.startsWith("https://") -> {
+                val bytes = downloadCoverBytes(cover) ?: return false
+                logcat(LogPriority.INFO) { "LocalNovelSource: Downloaded external cover $cover" }
+                coverManager.update(manga, ByteArrayInputStream(bytes))
+                true
+            }
+            else -> {
+                val stream = epub.getInputStream(cover) ?: return false
+                logcat(LogPriority.INFO) { "LocalNovelSource: Extracted embedded cover $cover" }
+                stream.use { coverManager.update(manga, it) }
+                true
+            }
+        }
     }
 
     private fun downloadCoverBytes(url: String): ByteArray? {
@@ -492,9 +514,17 @@ actual class LocalNovelSource(
         }
     }
 
+    fun getLocalSourceDir(): android.net.Uri? = fileSystem.getBaseDirectory()?.uri
+
+    fun deleteNovelDirectory(mangaUrl: String): Boolean =
+        fileSystem.getNovelDirectory(mangaUrl)?.delete() == true
+
+    fun findCoverUri(mangaUrl: String): String? =
+        coverManager.find(mangaUrl)?.uri?.toString()
+
     companion object {
         const val ID = 1L // Different from LocalSource ID (0L)
-        const val HELP_URL = "https://tsundoku-otaku.github.io/docs/guides/local-source/"
+        const val HELP_URL = "https://tsundoku-otaku.github.io/docs/guides/local-source/novels"
 
         private val LATEST_THRESHOLD = 7.days.inWholeMilliseconds
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -246,16 +246,18 @@ actual class LocalNovelSource(
 
         val hasMultipleEpubFiles = chapterFiles.count { it.extension.equals("epub", true) } > 1
 
-        chapterFiles.forEachIndexed { _, chapterFile ->
-            // Check if this is a multi-chapter EPUB
+        var runningChapterNumber = 0f
+        chapterFiles.forEach { chapterFile ->
+            val countBefore = allChapters.size
+
             if (chapterFile.extension.equals("epub", true)) {
                 try {
                     chapterFile.epubReader(context).use { epub ->
                         extractCoverFromOpenEpub(epub, manga, force = false)
 
                         val tocChapters = epub.getNormalizedTableOfContents()
-                        if (tocChapters.isNotEmpty()) {
-                            val spinePageHrefs = epub.getSpinePageHrefs()
+                        val spinePageHrefs = epub.getSpinePageHrefs()
+                        if (tocChapters.isNotEmpty() || spinePageHrefs.isNotEmpty()) {
                             allChapters.addAll(
                                 buildEpubChaptersFromToc(
                                     mangaUrl = manga.url,
@@ -265,32 +267,46 @@ actual class LocalNovelSource(
                                     tocChapters = tocChapters,
                                     spinePageHrefs = spinePageHrefs,
                                     hasMultipleEpubFiles = hasMultipleEpubFiles,
+                                    chapterNumberOffset = if (hasMultipleEpubFiles) runningChapterNumber else 0f,
                                 ),
                             )
-                            return@forEachIndexed
+                            return@use
                         }
 
-                        // Single chapter EPUB - treat as before
                         allChapters.add(
                             SChapter.create().apply {
                                 url = "${manga.url}/${chapterFile.name}"
                                 name = chapterFile.nameWithoutExtension.orEmpty()
                                 date_upload = chapterFile.lastModified()
-                                chapter_number = ChapterRecognition
-                                    .parseChapterNumber(manga.title, this.name, this.chapter_number.toDouble())
-                                    .toFloat()
+                                chapter_number = if (hasMultipleEpubFiles) {
+                                    runningChapterNumber + 1f
+                                } else {
+                                    ChapterRecognition
+                                        .parseChapterNumber(manga.title, this.name, this.chapter_number.toDouble())
+                                        .toFloat()
+                                }
                                 epub.fillMetadata(manga, this)
                             },
                         )
                     }
                 } catch (e: Throwable) {
                     logcat(LogPriority.ERROR, e) { "Error reading epub for ${chapterFile.name}" }
-                    // Fallback: add as single chapter
-                    allChapters.add(createSimpleChapter(manga, chapterFile))
+                    val fallback = createSimpleChapter(manga, chapterFile)
+                    if (hasMultipleEpubFiles) {
+                        fallback.chapter_number = runningChapterNumber + 1f
+                    }
+                    allChapters.add(fallback)
                 }
             } else {
-                // Non-EPUB file/directory
-                allChapters.add(createSimpleChapter(manga, chapterFile))
+                val simple = createSimpleChapter(manga, chapterFile)
+                if (hasMultipleEpubFiles) {
+                    simple.chapter_number = runningChapterNumber + 1f
+                }
+                allChapters.add(simple)
+            }
+
+            if (hasMultipleEpubFiles) {
+                runningChapterNumber += (allChapters.size - countBefore).toFloat()
             }
         }
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalNovelSource.kt
@@ -49,12 +49,11 @@ import java.nio.charset.StandardCharsets
 import kotlin.time.Duration.Companion.days
 import tachiyomi.domain.source.model.Source as DomainSource
 
-actual class LocalNovelSource(
-    private val context: Context,
-    private val fileSystem: LocalNovelSourceFileSystem,
-    private val coverManager: LocalNovelCoverManager,
-) : CatalogueSource, NovelSource, UnmeteredSource {
+actual class LocalNovelSource : CatalogueSource, NovelSource, UnmeteredSource {
 
+    private val context: Context by injectLazy()
+    private val fileSystem: LocalNovelSourceFileSystem by injectLazy()
+    private val coverManager: LocalNovelCoverManager by injectLazy()
     private val json: Json by injectLazy()
     private val xml: XML by injectLazy()
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/MultiVolumeChapterMerger.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/MultiVolumeChapterMerger.kt
@@ -1,0 +1,36 @@
+package tachiyomi.source.local
+
+import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
+
+
+fun <T> groupChaptersByVolume(
+    chapters: List<T>,
+    volumeKeyOf: (T) -> String?,
+    orderOf: (T) -> Int,
+    withOrder: (T, Int) -> T,
+): List<T> {
+    if (chapters.isEmpty()) return chapters
+
+    val (volumeChapters, looseChapters) = chapters.partition { volumeKeyOf(it) != null }
+    if (volumeChapters.isEmpty()) return chapters
+
+    val groupedByVolume = volumeChapters
+        .groupBy { volumeKeyOf(it)!! }
+        .mapValues { (_, items) -> items.sortedBy(orderOf) }
+
+    val sortedVolumeKeys = groupedByVolume.keys.sortedWith { a, b ->
+        a.compareToCaseInsensitiveNaturalOrder(b)
+    }
+
+    val ordered = ArrayList<T>(chapters.size)
+    var nextOrder = 0
+    sortedVolumeKeys.forEach { key ->
+        groupedByVolume[key].orEmpty().forEach { chapter ->
+            ordered.add(withOrder(chapter, nextOrder++))
+        }
+    }
+    looseChapters.sortedBy(orderOf).forEach { chapter ->
+        ordered.add(withOrder(chapter, nextOrder++))
+    }
+    return ordered
+}

--- a/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
+++ b/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/EpubChapterListBuilderTest.kt
@@ -2,6 +2,7 @@ package tachiyomi.source.local
 
 import mihon.core.archive.EpubReader
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class EpubChapterListBuilderTest {
@@ -203,5 +204,126 @@ class EpubChapterListBuilderTest {
         assertEquals(100_002f, volume2[1].chapter_number)
         assertEquals("volume1 - CAPITOLO 1", volume1[0].name)
         assertEquals("volume2 - CAPITOLO 1", volume2[0].name)
+    }
+
+    @Test
+    fun `buildEpubChaptersFromToc three volumes with offsets produce non-colliding chapter numbers`() {
+        fun buildVolume(volumeIndex: Int, fileStem: String): List<eu.kanade.tachiyomi.source.model.SChapter> {
+            val toc = listOf(
+                EpubReader.EpubChapter(title = "Cover", href = "cover.xhtml", order = 0),
+                EpubReader.EpubChapter(title = "Chapter 1", href = "ch1.xhtml", order = 1),
+                EpubReader.EpubChapter(title = "Chapter 2", href = "ch2.xhtml", order = 2),
+            )
+            val spine = listOf(
+                "cover.xhtml",
+                "insert1.xhtml",
+                "ch1.xhtml",
+                "ch1-extra.xhtml",
+                "ch2.xhtml",
+            )
+            return buildEpubChaptersFromToc(
+                mangaUrl = "local-novels/series",
+                chapterFileName = "$fileStem.epub",
+                chapterFileNameWithoutExtension = fileStem,
+                chapterLastModified = 1_000L * (volumeIndex + 1),
+                tocChapters = toc,
+                spinePageHrefs = spine,
+                hasMultipleEpubFiles = true,
+                chapterNumberOffset = volumeIndex * 10_000f,
+            )
+        }
+
+        val volume1 = buildVolume(volumeIndex = 0, fileStem = "001 - Volume 1")
+        val volume2 = buildVolume(volumeIndex = 1, fileStem = "002 - Volume 2")
+        val volume3 = buildVolume(volumeIndex = 2, fileStem = "003 - Volume 3")
+
+        assertEquals(5, volume1.size)
+        assertEquals(5, volume2.size)
+        assertEquals(5, volume3.size)
+
+        val combined = (volume1 + volume2 + volume3)
+        val numbers = combined.map { it.chapter_number }
+        assertEquals(numbers.size, numbers.toSet().size)
+
+        val sortedNames = combined
+            .sortedBy { it.chapter_number }
+            .map { it.name }
+
+        val expected = (volume1 + volume2 + volume3).map { it.name }
+        assertEquals(expected, sortedNames)
+
+        assertTrue(volume1.last().chapter_number < volume2.first().chapter_number)
+        assertTrue(volume2.last().chapter_number < volume3.first().chapter_number)
+    }
+
+    @Test
+    fun `buildEpubChaptersFromToc emits spine pages when toc is empty`() {
+        val chapters = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/no-toc-book",
+            chapterFileName = "novel.epub",
+            chapterFileNameWithoutExtension = "novel",
+            chapterLastModified = 999L,
+            tocChapters = emptyList(),
+            spinePageHrefs = listOf(
+                "front.xhtml",
+                "OEBPS/Text/chapter-01.xhtml",
+                "OEBPS/Text/chapter-02.xhtml",
+                "back-matter.xhtml",
+            ),
+            hasMultipleEpubFiles = false,
+        )
+
+        assertEquals(4, chapters.size)
+        assertEquals("front", chapters[0].name)
+        assertEquals("chapter 01", chapters[1].name)
+        assertEquals("chapter 02", chapters[2].name)
+        assertEquals("back matter", chapters[3].name)
+        assertEquals((1..4).map { it.toFloat() }, chapters.map { it.chapter_number })
+        assertEquals("local-novels/no-toc-book/novel.epub#front.xhtml", chapters[0].url)
+        assertEquals(
+            "local-novels/no-toc-book/novel.epub#OEBPS/Text/chapter-02.xhtml",
+            chapters[2].url,
+        )
+    }
+
+    @Test
+    fun `running offset across volumes produces gapless contiguous chapter numbers`() {
+        fun toc(count: Int): List<EpubReader.EpubChapter> = (1..count).map { i ->
+            EpubReader.EpubChapter(title = "Chapter $i", href = "ch$i.xhtml", order = i - 1)
+        }
+
+        val volume1 = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/series",
+            chapterFileName = "001 - vol1.epub",
+            chapterFileNameWithoutExtension = "001 - vol1",
+            chapterLastModified = 100L,
+            tocChapters = toc(5),
+            hasMultipleEpubFiles = true,
+            chapterNumberOffset = 0f,
+        )
+        val volume2 = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/series",
+            chapterFileName = "002 - vol2.epub",
+            chapterFileNameWithoutExtension = "002 - vol2",
+            chapterLastModified = 200L,
+            tocChapters = toc(7),
+            hasMultipleEpubFiles = true,
+            chapterNumberOffset = volume1.size.toFloat(),
+        )
+        val volume3 = buildEpubChaptersFromToc(
+            mangaUrl = "local-novels/series",
+            chapterFileName = "003 - vol3.epub",
+            chapterFileNameWithoutExtension = "003 - vol3",
+            chapterLastModified = 300L,
+            tocChapters = toc(3),
+            hasMultipleEpubFiles = true,
+            chapterNumberOffset = (volume1.size + volume2.size).toFloat(),
+        )
+
+        val combined = volume1 + volume2 + volume3
+        val numbers = combined.map { it.chapter_number }
+
+        assertEquals((1..15).map { it.toFloat() }, numbers)
+        assertEquals(numbers.size, numbers.toSet().size)
     }
 }

--- a/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/MultiVolumeChapterMergerTest.kt
+++ b/source-local/src/androidUnitTest/kotlin/tachiyomi/source/local/MultiVolumeChapterMergerTest.kt
@@ -1,0 +1,182 @@
+package tachiyomi.source.local
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MultiVolumeChapterMergerTest {
+
+    private data class FakeChapter(
+        val name: String,
+        val volumeKey: String?,
+        val order: Int,
+    )
+
+    private fun regroup(chapters: List<FakeChapter>): List<FakeChapter> {
+        return groupChaptersByVolume(
+            chapters = chapters,
+            volumeKeyOf = { it.volumeKey },
+            orderOf = { it.order },
+            withOrder = { chapter, newOrder -> chapter.copy(order = newOrder) },
+        )
+    }
+
+    @Test
+    fun `regroup keeps single-volume chapters in their original order`() {
+        val chapters = listOf(
+            FakeChapter("A", "novel/vol1.epub", 0),
+            FakeChapter("B", "novel/vol1.epub", 1),
+            FakeChapter("C", "novel/vol1.epub", 2),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(listOf("A", "B", "C"), result.map { it.name })
+        assertEquals(listOf(0, 1, 2), result.map { it.order })
+    }
+
+    @Test
+    fun `regroup splits interleaved volumes into contiguous blocks`() {
+        val chapters = listOf(
+            FakeChapter("vol1-ch1", "novel/001 - vol1.epub", 0),
+            FakeChapter("vol2-ch1", "novel/002 - vol2.epub", 1),
+            FakeChapter("vol3-ch1", "novel/003 - vol3.epub", 2),
+            FakeChapter("vol1-ch2", "novel/001 - vol1.epub", 3),
+            FakeChapter("vol2-ch2", "novel/002 - vol2.epub", 4),
+            FakeChapter("vol3-ch2", "novel/003 - vol3.epub", 5),
+            FakeChapter("vol1-ch3", "novel/001 - vol1.epub", 6),
+            FakeChapter("vol2-ch3", "novel/002 - vol2.epub", 7),
+            FakeChapter("vol3-ch3", "novel/003 - vol3.epub", 8),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(
+            listOf(
+                "vol1-ch1", "vol1-ch2", "vol1-ch3",
+                "vol2-ch1", "vol2-ch2", "vol2-ch3",
+                "vol3-ch1", "vol3-ch2", "vol3-ch3",
+            ),
+            result.map { it.name },
+        )
+        assertEquals((0..8).toList(), result.map { it.order })
+    }
+
+    @Test
+    fun `regroup emits volumes in natural-order regardless of input order`() {
+        val chapters = listOf(
+            FakeChapter("vol3-ch1", "novel/003 - vol3.epub", 0),
+            FakeChapter("vol2-ch1", "novel/002 - vol2.epub", 1),
+            FakeChapter("vol1-ch1", "novel/001 - vol1.epub", 2),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(
+            listOf("vol1-ch1", "vol2-ch1", "vol3-ch1"),
+            result.map { it.name },
+        )
+    }
+
+    @Test
+    fun `regroup uses natural numeric ordering for unpadded volume names`() {
+        val chapters = listOf(
+            FakeChapter("c2", "novel/vol2.epub", 0),
+            FakeChapter("c10", "novel/vol10.epub", 1),
+            FakeChapter("c1", "novel/vol1.epub", 2),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(listOf("c1", "c2", "c10"), result.map { it.name })
+    }
+
+    @Test
+    fun `regroup preserves within-volume order across interleaved blocks`() {
+        val chapters = listOf(
+            FakeChapter("v1-c4", "vol1", 30),
+            FakeChapter("v2-c1", "vol2", 5),
+            FakeChapter("v1-c1", "vol1", 1),
+            FakeChapter("v2-c2", "vol2", 6),
+            FakeChapter("v1-c3", "vol1", 20),
+            FakeChapter("v1-c2", "vol1", 10),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(
+            listOf("v1-c1", "v1-c2", "v1-c3", "v1-c4", "v2-c1", "v2-c2"),
+            result.map { it.name },
+        )
+    }
+
+    @Test
+    fun `regroup appends chapters with null volumeKey after grouped chapters`() {
+        val chapters = listOf(
+            FakeChapter("orphan-a", null, 0),
+            FakeChapter("v1-c1", "vol1", 1),
+            FakeChapter("orphan-b", null, 2),
+            FakeChapter("v1-c2", "vol1", 3),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(
+            listOf("v1-c1", "v1-c2", "orphan-a", "orphan-b"),
+            result.map { it.name },
+        )
+        assertEquals((0..3).toList(), result.map { it.order })
+    }
+
+    @Test
+    fun `regroup returns input unchanged when no chapters have volumeKey`() {
+        val chapters = listOf(
+            FakeChapter("a", null, 0),
+            FakeChapter("b", null, 1),
+        )
+
+        val result = regroup(chapters)
+
+        assertEquals(chapters, result)
+    }
+
+    @Test
+    fun `regroup returns empty list for empty input`() {
+        assertEquals(emptyList<FakeChapter>(), regroup(emptyList()))
+    }
+
+
+    @Test
+    fun `merger output supports both join and split volume export modes`() {
+        val chapters = listOf(
+            FakeChapter("vol1-ch1", "novel/001 - vol1.epub", 0),
+            FakeChapter("vol2-ch1", "novel/002 - vol2.epub", 1),
+            FakeChapter("vol3-ch1", "novel/003 - vol3.epub", 2),
+            FakeChapter("vol1-ch2", "novel/001 - vol1.epub", 3),
+            FakeChapter("vol2-ch2", "novel/002 - vol2.epub", 4),
+            FakeChapter("vol3-ch2", "novel/003 - vol3.epub", 5),
+        )
+
+        val merged = regroup(chapters)
+
+        val joined = merged
+        assertEquals(
+            listOf("vol1-ch1", "vol1-ch2", "vol2-ch1", "vol2-ch2", "vol3-ch1", "vol3-ch2"),
+            joined.map { it.name },
+        )
+
+        val splitByVolume = merged.groupBy { it.volumeKey }
+        assertEquals(3, splitByVolume.size)
+        assertEquals(
+            listOf("vol1-ch1", "vol1-ch2"),
+            splitByVolume["novel/001 - vol1.epub"]?.map { it.name },
+        )
+        assertEquals(
+            listOf("vol2-ch1", "vol2-ch2"),
+            splitByVolume["novel/002 - vol2.epub"]?.map { it.name },
+        )
+        assertEquals(
+            listOf("vol3-ch1", "vol3-ch2"),
+            splitByVolume["novel/003 - vol3.epub"]?.map { it.name },
+        )
+    }
+}


### PR DESCRIPTION
- Add open with option.
- Local browse screen gets multi-select actions: add to library (with category picker), refresh covers(export cover file), and delete.
- Improve cover export compatibility and epub2 export compatibility
- properly export embedded images in epubs, previously they were extracted with the internal uri so other readers couldnt properly render them

- fix local EPUB grouping and numbering so multi-volume chapters stay organized.
- add the options to embed js/css into the epub when exporting.