### PR TITLE
Fix/source url normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fix
 - Make JS scripts regardless of inf scroll [@mrissaoussama](https://github.com/mrissaoussama) [#220](https://github.com/tsundoku-otaku/tsundoku/pull/220)
+- JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)
 - Encoding issues when parsing jssource chapters [@mrissaoussama](https://github.com/mrissaoussama) [#224](https://github.com/tsundoku-otaku/tsundoku/pull/224)
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -88,6 +88,7 @@ fun MassImportDialog(
     onImportComplete: (added: Int, skipped: Int, errored: Int) -> Unit,
     initialText: String = "",
     isNovelMode: Boolean = true, // Default to novel mode for backward compatibility
+    preferredSourceId: Long? = null,
 ) {
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
@@ -627,6 +628,7 @@ fun MassImportDialog(
                                     categoryId = selectedCategoryId ?: 0L,
                                     fetchChapters = syncChapterList,
                                     rawText = combinedRawText,
+                                    preferredSourceId = preferredSourceId,
                                 )
                             } else {
                                 val uniqueUrls = LinkedHashSet<String>()
@@ -644,6 +646,7 @@ fun MassImportDialog(
                                     fetchDetails = fetchDetails,
                                     categoryId = selectedCategoryId ?: 0L,
                                     fetchChapters = syncChapterList,
+                                    preferredSourceId = preferredSourceId,
                                 )
                             }
                             urlText = ""

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -106,6 +106,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             .toSet()
 
         val urls = urlsArray?.toList()
+        val preferredSourceId = inputData.getLong(KEY_PREFERRED_SOURCE_ID, -1L).takeIf { it != -1L }
         // Shared host->source cache for the whole job to avoid repeated matching across chunks
         // Use canonical host keys (lowercase, no www.)
         val hostSourceCache = ConcurrentHashMap<String, CatalogueSource>()
@@ -138,6 +139,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                 excludedHostsSet,
                                 hostSourceCache,
                                 missingSourceHosts,
+                                preferredSourceId,
                             )
                             buffer.clear()
                         }
@@ -155,6 +157,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                         excludedHostsSet,
                         hostSourceCache,
                         missingSourceHosts,
+                        preferredSourceId,
                     )
                     buffer.clear()
                 }
@@ -206,6 +209,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     excludedHostsSet,
                     hostSourceCache,
                     missingSourceHosts,
+                    preferredSourceId,
                 )
                 Result.success()
             } catch (e: Exception) {
@@ -247,6 +251,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         excludedHosts: Set<String> = emptySet(),
         hostSourceCache: ConcurrentHashMap<String, CatalogueSource> = ConcurrentHashMap(),
         missingSourceHosts: MutableSet<String> = ConcurrentHashMap.newKeySet(),
+        preferredSourceId: Long? = null,
     ): ImportResult {
         updateBatchStatus(batchId, BatchStatus.Running)
 
@@ -273,7 +278,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             sourceCache[host]?.let { return it }
             if (host in missingSourceHosts) return null
 
-            val matched = runCatching { findMatchingSource("https://$host/", importSources) }.getOrNull()
+            val matched = runCatching { findMatchingSource("https://$host/", importSources, preferredSourceId) }.getOrNull()
             if (matched != null) {
                 sourceCache[host] = matched
             } else {
@@ -939,7 +944,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
      * Find source that matches the given URL.
      * Prioritizes Kotlin extensions over JS plugins when multiple sources match the same URL.
      */
-    private fun findMatchingSource(url: String, sources: List<CatalogueSource>): CatalogueSource? {
+    private fun findMatchingSource(url: String, sources: List<CatalogueSource>, preferredSourceId: Long? = null): CatalogueSource? {
         val urlHost = try {
             URI(url).host?.lowercase()?.removePrefix("www.")
         } catch (_: Exception) {
@@ -976,6 +981,12 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
         if (matchingSources.isEmpty()) return null
         if (matchingSources.size == 1) return matchingSources.first()
+
+        // If the caller has a preferred source (e.g. the currently browsed source) and it
+        // matches, use it — avoids picking KT source when user is browsing via JsSource.
+        if (preferredSourceId != null) {
+            matchingSources.firstOrNull { it.id == preferredSourceId }?.let { return it }
+        }
 
         val enabledLanguages = sourcePreferences.enabledLanguages.get()
         val disabledSources = sourcePreferences.disabledSources.get()
@@ -1048,6 +1059,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         const val KEY_FETCH_CHAPTERS = "fetchChapters"
         const val KEY_BATCH_ID = "batchId"
         const val KEY_EXCLUDED_HOSTS = "excludedHosts"
+        const val KEY_PREFERRED_SOURCE_ID = "preferredSourceId"
 
         // Shared state for UI to observe
         private val _sharedResult = MutableStateFlow<ImportResult?>(null)
@@ -1145,6 +1157,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             fetchChapters: Boolean = false,
             excludedHosts: List<String> = emptyList(),
             rawText: String? = null,
+            preferredSourceId: Long? = null,
         ) {
             val batchId = java.util.UUID.randomUUID().toString()
             // If offloading to file, avoid storing the full URL list in memory inside the Batch.
@@ -1202,6 +1215,9 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                 // Normalize excluded hosts before passing to worker
                 val normalized = excludedHosts.map { it.trim().lowercase().removePrefix("www.") }
                 payload += KEY_EXCLUDED_HOSTS to normalized.joinToString(",")
+            }
+            if (preferredSourceId != null) {
+                payload += KEY_PREFERRED_SOURCE_ID to preferredSourceId
             }
 
             val workRequest = OneTimeWorkRequestBuilder<MassImportJob>()

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -796,7 +796,7 @@ class JsSource(
                     val obj = item.jsonObject
                     SManga.create().apply {
                         title = obj["name"]?.jsonPrimitive?.content?.decodeEntities() ?: return@mapNotNull null
-                        url = obj["path"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                        url = (obj["path"]?.jsonPrimitive?.content ?: return@mapNotNull null).let { if (it.startsWith("/")) it else "/$it" }
                         // Ensure thumbnail_url is a valid URL or null
                         val coverUrl = obj["cover"]?.jsonPrimitive?.content
                         thumbnail_url = when {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -521,14 +521,17 @@ data class BrowseSourceScreen(
             val selected = screenModel.state.value.selection
             val initialText = selected.joinToString("\n") { manga ->
                 when (val resolvedSource = screenModel.source) {
-                    is eu.kanade.tachiyomi.jsplugin.source.JsSource -> manga.url
+                    is eu.kanade.tachiyomi.jsplugin.source.JsSource -> resolveRelativeUrl(resolvedSource.baseUrl, manga.url)
                     is HttpSource -> resolveRelativeUrl(resolvedSource.baseUrl, manga.url)
                     else -> manga.url
                 }
             }
 
             MassImportDialog(
-                onDismissRequest = { showMassImportDialog = false },
+                onDismissRequest = {
+                    showMassImportDialog = false
+                    screenModel.clearSelection()
+                },
                 onImportComplete = { added, skipped, errored ->
                     // Clear selection after import
                     screenModel.clearSelection()
@@ -537,6 +540,7 @@ data class BrowseSourceScreen(
                 },
                 initialText = initialText,
                 isNovelMode = screenModel.source.isNovelSource(),
+                preferredSourceId = screenModel.source.id,
             )
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -222,11 +222,13 @@ class BrowseSourceScreenModel(
      */
     private val hideInLibraryItems = sourcePreferences.hideInLibraryItems.get()
     private fun normalizeUrl(url: String): String = url.trimEnd('/').substringBefore('#')
+    private fun normalizeUrlForLookup(url: String): String =
+        normalizeUrl(eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, url))
 
     // Cached library manga for this source - single subscription instead of per-item
     private val libraryMangaForSource: StateFlow<Map<String, Manga>> = getFavoritesEntry.subscribe(sourceId)
         .map { favorites ->
-            favorites.associateBy { normalizeUrl(it.url) }
+            favorites.associateBy { normalizeUrlForLookup(it.url) }
         }
         .stateIn(ioCoroutineScope, SharingStarted.Eagerly, emptyMap())
 
@@ -246,7 +248,7 @@ class BrowseSourceScreenModel(
         }.flow.map { pagingData ->
             pagingData.map { manga ->
                 // Normalize URL to prevent duplicates from trailing slashes/fragments
-                val normalizedUrl = normalizeUrl(manga.url)
+                val normalizedUrl = normalizeUrlForLookup(manga.url)
                 val normalizedManga = if (normalizedUrl != manga.url) {
                     manga.copy(url = normalizedUrl)
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -423,6 +423,14 @@ class MangaScreenModel(
                 val categories = allCategories.filter {
                     it.contentType == contentType || it.contentType == Category.CONTENT_TYPE_ALL
                 }
+                // Normalize URL to ensure leading slash for JsSource/HttpSource
+                state.source?.let { src ->
+                    val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
+                    if (normalizedUrl != manga.url) {
+                        updateManga.awaitUpdateUrl(manga.id, normalizedUrl)
+                    }
+                }
+
                 val defaultCategoryId = libraryPreferences.defaultCategory.get().toLong()
                 val defaultCategory = categories.find { it.id == defaultCategoryId }
                 when {

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1428,7 +1428,7 @@ class MangaRepositoryImpl(
                     version = it.version,
                     isNovel = it.isNovel,
                     updateTitle = it.title.isNotBlank(),
-                    updateCover = !it.thumbnailUrl.isNullOrBlank(),
+                    updateCover = !it.thumbnailUrl.isNullOrBlank() && it.thumbnailUrl!!.contains("://"),
                     updateDetails = it.initialized,
                     mapper = MangaMapper::mapMangaFull,
                 )


### PR DESCRIPTION
fix js sources not being imported in mass import by prepending a / when js source returns results.
made mass import receive a preferred source id in the case the user has multiple sources that share the same base url