### PR TITLE
fix(novel): enhance translation reliability and image caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)
 - Correctly recognize .zip archives [@mrissaoussama](https://github.com/mrissaoussama) [#226](https://github.com/tsundoku-otaku/tsundoku/pull/226)
+- Improve translation reliability and interactions with images; Bug with short chapters [@mrissaoussama](https://github.com/mrissaoussama) [#232](https://github.com/tsundoku-otaku/tsundoku/pull/232)
 - Make Grid items better respect max lines limits in library [@mrissaoussama](https://github.com/mrissaoussama) [#216](https://github.com/tsundoku-otaku/tsundoku/pull/216)
 - TextView Regex; Short chapter detection false positives [@mrissaoussama](https://github.com/mrissaoussama) [#225](https://github.com/tsundoku-otaku/tsundoku/pull/225)
 - Fix HTML vs plain text detection [@mrissaoussama](https://github.com/mrissaoussama) [#223](https://github.com/tsundoku-otaku/tsundoku/pull/223)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -724,7 +724,19 @@ class TranslationService(
         val engine = translationEngineManager.getEngine()
             ?: return TranslationResult.Error("No translation engine available")
 
-        return engine.translateSingle(text, sourceLanguage, targetLanguage)
+        logcat(LogPriority.DEBUG) {
+            "Translation: sending ${text.length} chars via ${engine.name} ($sourceLanguage → $targetLanguage)"
+        }
+        val result = engine.translateSingle(text, sourceLanguage, targetLanguage)
+        when (result) {
+            is TranslationResult.Success -> logcat(LogPriority.DEBUG) {
+                "Translation: received ${result.translatedTexts.firstOrNull()?.length ?: 0} chars"
+            }
+            is TranslationResult.Error -> logcat(LogPriority.WARN) {
+                "Translation: engine error — ${result.message}"
+            }
+        }
+        return result
     }
 
     /**
@@ -765,6 +777,10 @@ class TranslationService(
 
         // Extract plain text from HTML for translation
         val plainText = TranslationHtmlUtils.extractTextFromHtml(contentWithoutImages)
+
+        logcat(LogPriority.DEBUG) {
+            "translateChapterContent: chapterId=$chapterId srcLang=$srcLang tgtLang=$tgtLang plainText=${plainText.length} chars"
+        }
 
         // Translate the plain text
         return when (val result = translateText(plainText, srcLang, tgtLang)) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
@@ -128,7 +128,8 @@ Rules:
 - Preserve paragraph structure (keep empty lines between paragraphs)
 - Maintain the author's writing style and tone
 - Keep character names consistent
-- Do not add explanations or notes"""
+- Do not add explanations or notes
+- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
 
         val request = ChatRequest(
             messages = listOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
@@ -125,6 +125,7 @@ class GeminiTranslateEngine(
     - Keep character names consistent
     - Every line break in the input MUST be preserved exactly in the output.
     - Do NOT wrap lines.
+    - Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them.
     Text:
     $text
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
@@ -2,17 +2,18 @@ package eu.kanade.tachiyomi.data.translation.engine
 
 import eu.kanade.tachiyomi.data.translation.TranslationHtmlUtils
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.NetworkHelper
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import uy.kohesive.injekt.injectLazy
-import java.net.URLEncoder
 
 class GoogleTranslateScraperEngine : TranslationEngine {
     override val id = 999L // Custom ID for scraper
@@ -154,69 +155,11 @@ class GoogleTranslateScraperEngine : TranslationEngine {
     }
 
     private suspend fun translateSingleInternal(text: String, source: String, target: String): String {
-        try {
-            val normalizedText = TranslationHtmlUtils.normalizeLineBreaks(text)
-            val paragraphs = TranslationHtmlUtils.splitParagraphsPreserving(normalizedText)
-
-            if (paragraphs.size > 1) {
-                val translatedParagraphs = mutableListOf<String>()
-                for (paragraph in paragraphs) {
-                    translatedParagraphs += translateRawText(paragraph, source, target)
-                }
-                return translatedParagraphs.joinToString("\n\n")
-            }
-
-            val token = calculateToken(normalizedText)
-            val url = "https://translate.google.com/translate_a/single".toHttpUrl().newBuilder()
-                .addQueryParameter("client", "gtx")
-                .addQueryParameter("sl", source)
-                .addQueryParameter("tl", target)
-                .addQueryParameter("hl", target)
-                .addQueryParameter("dt", "at")
-                .addQueryParameter("dt", "bd")
-                .addQueryParameter("dt", "ex")
-                .addQueryParameter("dt", "ld")
-                .addQueryParameter("dt", "md")
-                .addQueryParameter("dt", "qca")
-                .addQueryParameter("dt", "rw")
-                .addQueryParameter("dt", "rm")
-                .addQueryParameter("dt", "ss")
-                .addQueryParameter("dt", "t")
-                .addQueryParameter("ie", "UTF-8")
-                .addQueryParameter("oe", "UTF-8")
-                .addQueryParameter("otf", "1")
-                .addQueryParameter("ssel", "0")
-                .addQueryParameter("tsel", "0")
-                .addQueryParameter("kc", "7")
-                .addQueryParameter("tk", token)
-                .addQueryParameter("q", normalizedText)
-                .build()
-
-            val request = GET(url)
-            val response = client.newCall(request).execute()
-            val body = response.use { it.body.string() }
-
-            if (!response.isSuccessful) {
-                return normalizedText
-            }
-
-            val jsonArray = json.parseToJsonElement(body).jsonArray
-
-            val result = StringBuilder()
-            val sentences = jsonArray[0].jsonArray
-
-            for (sentence in sentences) {
-                val sentenceArray = sentence.jsonArray
-                if (sentenceArray.isNotEmpty()) {
-                    val translatedPart = sentenceArray[0].jsonPrimitive.content
-                    result.append(translatedPart)
-                }
-            }
-
-            return result.toString()
+        return try {
+            translateRawText(TranslationHtmlUtils.normalizeLineBreaks(text), source, target)
         } catch (e: Exception) {
             e.printStackTrace()
-            return text
+            text
         }
     }
 
@@ -244,10 +187,10 @@ class GoogleTranslateScraperEngine : TranslationEngine {
             .addQueryParameter("tsel", "0")
             .addQueryParameter("kc", "7")
             .addQueryParameter("tk", token)
-            .addQueryParameter("q", text)
             .build()
 
-        val request = GET(url)
+        val formBody = FormBody.Builder().add("q", text).build()
+        val request = POST(url.toString(), body = formBody)
         val response = client.newCall(request).execute()
         val body = response.use { it.body.string() }
 
@@ -262,10 +205,13 @@ class GoogleTranslateScraperEngine : TranslationEngine {
 
         for (sentence in sentences) {
             val sentenceArray = sentence.jsonArray
-            if (sentenceArray.isNotEmpty()) {
-                val translatedPart = sentenceArray[0].jsonPrimitive.content
-                result.append(translatedPart)
+            if (sentenceArray.isEmpty()) continue
+            val translatedPart = try {
+                sentenceArray[0].jsonPrimitive.content
+            } catch (_: Exception) {
+                continue
             }
+            result.append(translatedPart)
         }
 
         return result.toString()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
@@ -138,7 +138,8 @@ Rules:
 - Preserve paragraph structure
 - Maintain the author's writing style and tone
 - Keep character names consistent
-- Do not add explanations or notes"""
+- Do not add explanations or notes
+- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
 
         val request = ChatRequest(
             model = model,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
@@ -138,6 +138,7 @@ Rules:
 - Maintain the author's writing style and tone
 - Keep character names consistent
 - Do not add explanations or notes
+- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them
 
 Text to translate:
 $text

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
@@ -128,7 +128,8 @@ Rules:
 - Preserve paragraph structure (keep empty lines between paragraphs)
 - Maintain the author's writing style and tone
 - Keep character names consistent
-- Do not add explanations or notes"""
+- Do not add explanations or notes
+- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
 
         val request = ChatRequest(
             messages = listOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1517,17 +1517,19 @@ class ReaderActivity : BaseActivity() {
      * Returns translated text if translation is enabled and successful,
      * otherwise returns original text.
      */
-    suspend fun translateContentIfEnabled(content: String): String {
+    suspend fun translateContentIfEnabled(content: String, chapterId: Long? = null): String {
         if (!isTranslationEnabled()) return content
         return try {
-            viewModel.translateContent(content)
+            viewModel.translateContent(content, chapterId)
         } catch (e: CancellationException) {
             logcat(LogPriority.DEBUG) { "Translation was cancelled" }
             content
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Translation failed" }
-            viewModel.disableTranslation()
-            toast(e.message ?: "Translation failed")
+            runOnUiThread {
+                viewModel.disableTranslation()
+                toast(e.message ?: "Translation failed")
+            }
             content
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1128,16 +1128,21 @@ class ReaderViewModel @JvmOverloads constructor(
     /**
      * Translate text content using the translation service.
      */
-    suspend fun translateContent(content: String): String {
+    suspend fun translateContent(content: String, overrideChapterId: Long? = null): String {
         val chapter = getCurrentChapter()
-        val chapterId = chapter?.chapter?.id
+        val chapterId = overrideChapterId ?: chapter?.chapter?.id
         val mangaId = manga?.id
 
         if (translationPreferences.smartAutoTranslate().get()) {
             val detected = translationService.detectLanguage(content, mangaId)
             val target = translationPreferences.targetLanguage().get()
 
+            logcat(LogPriority.DEBUG) {
+                "translateContent: smartAutoTranslate detected=$detected target=$target chapterId=$chapterId"
+            }
+
             if (detected != null && detected.equals(target, ignoreCase = true)) {
+                logcat(LogPriority.DEBUG) { "translateContent: skipping — source lang matches target ($detected)" }
                 return content
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -395,6 +395,12 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         lastSavedProgress = 1f
         saveProgress(1f)
         activity.onNovelProgressChanged(1f)
+
+        // Trigger infinite scroll append manually.
+        val onLastLoaded = currentChapterIndex == (loadedChapters.size - 1).coerceAtLeast(0)
+        if (preferences.novelInfiniteScroll.get() && !ttsController.isTtsAutoPlay && onLastLoaded) {
+            loadNextChapterIfAvailable()
+        }
     }
 
     private fun updateCurrentChapterFromScroll(scrollY: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
@@ -1,8 +1,7 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
 
-import android.content.Context
-import android.net.Uri
 import android.webkit.WebResourceResponse
+import java.net.URLDecoder
 import eu.kanade.tachiyomi.ui.reader.loader.PageLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -10,13 +9,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
 import logcat.logcat
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
 internal class NovelWebViewImageCache(
-    private val context: Context,
+    private val cacheDir: File,
     private val scope: CoroutineScope,
 ) {
 
@@ -26,7 +26,7 @@ internal class NovelWebViewImageCache(
 
     fun intercept(url: String, fallbackChapterId: Long?, fallbackLoader: PageLoader?): WebResourceResponse? {
         if (!url.startsWith(URL_SCHEME_NOVEL_IMAGE)) return null
-        val rawPath = Uri.decode(url.removePrefix(URL_SCHEME_NOVEL_IMAGE))
+        val rawPath = URLDecoder.decode(url.removePrefix(URL_SCHEME_NOVEL_IMAGE), "UTF-8")
 
         val slashIdx = rawPath.indexOf('/')
         val (chapterId, imagePath) = if (slashIdx > 0) {
@@ -40,24 +40,35 @@ internal class NovelWebViewImageCache(
             fallbackChapterId to rawPath
         }
 
-        val loader = chapterLoaderMap[chapterId] ?: fallbackLoader
+        val loader = chapterId?.let { chapterLoaderMap[it] } ?: fallbackLoader
         val cacheKey = buildCacheKey(chapterId, imagePath)
         cache[cacheKey]?.takeIf { it.exists() }?.let { cachedFile ->
             return WebResourceResponse(
                 guessMimeType(imagePath),
                 "UTF-8",
-                cachedFile.inputStream(),
+                cachedFile.readBytes().inputStream(),
             )
         }
-        if (loader != null && chapterId != null) prefetch(chapterId, imagePath, loader)
-        return null
+
+        if (loader == null) return null
+        prefetchJobs.remove(cacheKey)?.cancel()
+        return try {
+            val bytes = runBlocking { loader.getPageDataStream(imagePath)?.use { it.readBytes() } } ?: return null
+            val cachedFile = makeCachedFile(cacheKey, imagePath)
+            cachedFile.writeBytes(bytes)
+            cache[cacheKey] = cachedFile
+            WebResourceResponse(guessMimeType(imagePath), "UTF-8", bytes.inputStream())
+        } catch (e: Exception) {
+            logcat(LogPriority.DEBUG) { "NovelWebViewImageCache: sync load $imagePath failed: ${e.message}" }
+            null
+        }
     }
 
     fun schedulePrefetch(content: String, chapterId: Long?, loader: PageLoader?) {
         if (chapterId == null || loader == null) return
         chapterLoaderMap[chapterId] = loader
         IMAGE_URL_PATTERN.findAll(content)
-            .mapNotNull { match -> runCatching { Uri.decode(match.groupValues[1]) }.getOrNull() }
+            .mapNotNull { match -> runCatching { URLDecoder.decode(match.groupValues[1], "UTF-8") }.getOrNull() }
             .distinct()
             .forEach { rawPath ->
                 val imagePath = if (rawPath.startsWith("$chapterId/")) {
@@ -84,12 +95,7 @@ internal class NovelWebViewImageCache(
         val job = scope.launch(start = CoroutineStart.LAZY, context = Dispatchers.IO) {
             try {
                 val stream = loader.getPageDataStream(imagePath) ?: return@launch
-                val fileSuffix = imagePath.substringAfterLast('.', "bin").ifBlank { "bin" }
-                val keyHash = java.security.MessageDigest.getInstance("SHA-256")
-                    .digest(cacheKey.toByteArray())
-                    .take(16)
-                    .joinToString("") { "%02x".format(it) }
-                val cachedFile = File(context.cacheDir, "novel-image-$keyHash.$fileSuffix")
+                val cachedFile = makeCachedFile(cacheKey, imagePath)
                 stream.use { input ->
                     cachedFile.outputStream().use { output -> input.copyTo(output) }
                 }
@@ -110,6 +116,15 @@ internal class NovelWebViewImageCache(
 
     private fun buildCacheKey(chapterId: Long?, imagePath: String): String =
         "${chapterId ?: -1L}:$imagePath"
+
+    private fun makeCachedFile(cacheKey: String, imagePath: String): File {
+        val fileSuffix = imagePath.substringAfterLast('.', "bin").ifBlank { "bin" }
+        val keyHash = java.security.MessageDigest.getInstance("SHA-256")
+            .digest(cacheKey.toByteArray())
+            .take(16)
+            .joinToString("") { "%02x".format(it) }
+        return File(cacheDir, "novel-image-$keyHash.$fileSuffix")
+    }
 
     private fun guessMimeType(imagePath: String): String =
         when (imagePath.substringAfterLast('.', "").lowercase()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority
 import logcat.logcat
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.novel.TDMR
 import uy.kohesive.injekt.injectLazy
 import eu.kanade.tachiyomi.ui.reader.viewer.text.NovelConfig
@@ -86,7 +85,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private lateinit var webView: WebView
     private var loadingIndicator: ReaderProgressIndicator? = null
     private val preferences: ReaderPreferences by injectLazy()
-    private val translationPreferences: TranslationPreferences by injectLazy()
     private val libraryPreferences: tachiyomi.domain.library.service.LibraryPreferences by injectLazy()
     private val contentPipeline = ContentPipeline(preferences)
 
@@ -94,7 +92,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var loadJob: Job? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
-    private val imageCache = NovelWebViewImageCache(activity, scope)
+    private val imageCache = NovelWebViewImageCache(activity.cacheDir, scope)
 
     private var lastSavedProgress = 0f
 
@@ -894,20 +892,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         val chapterId = chapter.chapter.id ?: return
 
-        val translator: (suspend (String) -> String)? = run {
-            val shouldTranslate = if (isAppendOrPrepend) {
-                translationPreferences.realTimeTranslation().get()
-            } else {
-                activity.isTranslationEnabled()
-            }
-            if (shouldTranslate) { c -> activity.translateContentIfEnabled(c) } else null
-        }
+        val translator: (suspend (String) -> String)? =
+            if (activity.isTranslationEnabled()) { c -> activity.translateContentIfEnabled(c, chapterId) } else null
         val cfg = ContentConfig.from(
             preferences,
             RenderTarget.WEB_VIEW,
             chapter.chapter.url,
             chapter.chapter.name,
         )
+
+        if (!isAppendOrPrepend && translator != null) {
+            showLoadingIndicator(activity.stringResource(TDMR.strings.novel_chapter_translating))
+        }
 
         scope.launch {
             val processed = withContext(Dispatchers.Default) {
@@ -1134,7 +1130,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         evaluateJavascriptSafe("(function(){$js})();", null)
     }
 
-    private fun showLoadingIndicator() {
+    private fun showLoadingIndicator(message: String = "Loading...") {
         val theme = preferences.novelTheme.get()
         val backgroundColor = preferences.novelBackgroundColor.get()
         val fontColor = preferences.novelFontColor.get()
@@ -1166,7 +1162,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 </style>
             </head>
             <body>
-                <div>Loading...</div>
+                <div>${message.replace("<", "&lt;").replace(">", "&gt;")}</div>
             </body>
             </html>
         """.trimIndent()
@@ -1528,6 +1524,20 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 saveProgress()
                 activity.onNovelProgressChanged(1f)
                 logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Chapter marked as short (fits in viewport)" }
+
+                // Chapter fits in viewport → no scroll events fire → threshold never reached.
+                // Trigger infinite scroll append manually.
+                if (preferences.novelInfiniteScroll.get() && !isLoadingNext && !ttsController.isTtsAutoPlay) {
+                    isLoadingNext = true
+                    scope.launch {
+                        try {
+                            appendNextChapterIfAvailable()
+                        } finally {
+                            isLoadingNext = false
+                            setJsLoadingNext()
+                        }
+                    }
+                }
             }
         }
 
@@ -1579,13 +1589,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             chapter.chapter.url,
             chapter.chapter.name,
         )
-        val shouldTranslate = if (isAppendOrPrepend) {
-            translationPreferences.realTimeTranslation().get()
-        } else {
-            true
-        }
         val translator: (suspend (String) -> String)? =
-            if (shouldTranslate) { c -> activity.translateContentIfEnabled(c) } else null
+            if (activity.isTranslationEnabled()) { c -> activity.translateContentIfEnabled(c, chapterId) } else null
         val processed = withContext(Dispatchers.Default) {
             contentPipeline.process(rawContent, cfg, translator)
         }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCacheTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCacheTest.kt
@@ -1,0 +1,195 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
+
+import eu.kanade.tachiyomi.ui.reader.loader.PageLoader
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.file.Path
+
+class NovelWebViewImageCacheTest {
+
+    private fun makeCache(
+        tempDir: File,
+        scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
+    ) = NovelWebViewImageCache(tempDir, scope)
+
+    private fun fakeLoader(vararg files: Pair<String, ByteArray>): PageLoader {
+        val fileMap = mapOf(*files)
+        return object : PageLoader() {
+            override var isLocal = true
+            override suspend fun getPages(): List<ReaderPage> = emptyList()
+            override suspend fun getPageDataStream(url: String): java.io.InputStream? =
+                fileMap[url]?.let { ByteArrayInputStream(it.copyOf()) }
+        }
+    }
+
+
+    @Test
+    fun `intercept returns null for https URL`(@TempDir tempDir: Path) {
+        val cache = makeCache(tempDir.toFile())
+        assertNull(cache.intercept("https://example.com/image.jpg", null, null))
+    }
+
+    @Test
+    fun `intercept returns null for data URI`(@TempDir tempDir: Path) {
+        val cache = makeCache(tempDir.toFile())
+        assertNull(cache.intercept("data:image/png;base64,abc", null, null))
+    }
+
+
+    @Test
+    fun `intercept loads JPEG synchronously when not in cache`(@TempDir tempDir: Path) {
+        val imageBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+        val loader = fakeLoader("cover.jpg" to imageBytes)
+        val cache = makeCache(tempDir.toFile())
+
+        val response = cache.intercept(
+            url = "tsundoku-novel-image://cover.jpg",
+            fallbackChapterId = 1L,
+            fallbackLoader = loader,
+        )
+
+        assertNotNull(response)
+        val cachedFiles = tempDir.toFile().listFiles { f -> f.extension == "jpg" }
+        assertNotNull(cachedFiles)
+        assertArrayEquals(imageBytes, cachedFiles!!.first().readBytes())
+    }
+
+    @Test
+    fun `intercept loads PNG synchronously when not in cache`(@TempDir tempDir: Path) {
+        val imageBytes = byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte())
+        val loader = fakeLoader("figure.png" to imageBytes)
+        val cache = makeCache(tempDir.toFile())
+
+        val response = cache.intercept(
+            url = "tsundoku-novel-image://figure.png",
+            fallbackChapterId = 2L,
+            fallbackLoader = loader,
+        )
+
+        assertNotNull(response)
+        val cachedFiles = tempDir.toFile().listFiles { f -> f.extension == "png" }
+        assertNotNull(cachedFiles)
+        assertArrayEquals(imageBytes, cachedFiles!!.first().readBytes())
+    }
+
+
+    @Test
+    fun `intercept serves from cache on second request without calling loader again`(@TempDir tempDir: Path) {
+        val imageBytes = byteArrayOf(0x47.toByte(), 0x49.toByte(), 0x46.toByte())
+        var loadCount = 0
+        val loader = object : PageLoader() {
+            override var isLocal = true
+            override suspend fun getPages(): List<ReaderPage> = emptyList()
+            override suspend fun getPageDataStream(url: String): java.io.InputStream? {
+                loadCount++
+                return ByteArrayInputStream(imageBytes.copyOf())
+            }
+        }
+        val cache = makeCache(tempDir.toFile())
+
+        cache.intercept("tsundoku-novel-image://anim.gif", 1L, loader)
+        cache.intercept("tsundoku-novel-image://anim.gif", 1L, loader)
+
+        assert(loadCount == 1) { "Loader should only be called once; second hit should come from cache" }
+    }
+
+
+    @Test
+    fun `intercept returns null when no loader is available`(@TempDir tempDir: Path) {
+        val cache = makeCache(tempDir.toFile())
+        assertNull(cache.intercept("tsundoku-novel-image://cover.jpg", null, null))
+    }
+
+    @Test
+    fun `intercept returns null when loader has no image for path`(@TempDir tempDir: Path) {
+        val loader = fakeLoader()
+        val cache = makeCache(tempDir.toFile())
+        assertNull(cache.intercept("tsundoku-novel-image://missing.jpg", 1L, loader))
+    }
+
+
+    @Test
+    fun `intercept resolves chapterId-prefixed URL and uses matching chapter loader`(@TempDir tempDir: Path) {
+        val imageBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte())
+        val loader = fakeLoader("img.jpg" to imageBytes)
+        val cache = makeCache(tempDir.toFile())
+
+        val response = cache.intercept(
+            url = "tsundoku-novel-image://42/img.jpg",
+            fallbackChapterId = null,
+            fallbackLoader = loader,
+        )
+
+        assertNotNull(response)
+        val cachedFiles = tempDir.toFile().listFiles { f -> f.extension == "jpg" }
+        assertNotNull(cachedFiles)
+        assertArrayEquals(imageBytes, cachedFiles!!.first().readBytes())
+    }
+
+    @Test
+    fun `different chapters with same filename load independently`(@TempDir tempDir: Path) {
+        val ch3Bytes = byteArrayOf(0x01.toByte())
+        val ch4Bytes = byteArrayOf(0x02.toByte())
+        val loader3 = fakeLoader("image_0.jpg" to ch3Bytes)
+        val loader4 = fakeLoader("image_0.jpg" to ch4Bytes)
+        val cache = makeCache(tempDir.toFile())
+
+        val r3 = cache.intercept("tsundoku-novel-image://3/image_0.jpg", null, loader3)
+        val r4 = cache.intercept("tsundoku-novel-image://4/image_0.jpg", null, loader4)
+
+        assertNotNull(r3)
+        assertNotNull(r4)
+        val cachedFiles = tempDir.toFile().listFiles { f -> f.extension == "jpg" }
+        assertNotNull(cachedFiles)
+        assert(cachedFiles!!.size == 2) { "Expected 2 distinct cache files, got ${cachedFiles.size}" }
+        val allBytes = cachedFiles.map { it.readBytes() }.sortedWith(compareBy { it[0] })
+        assertArrayEquals(ch3Bytes, allBytes[0])
+        assertArrayEquals(ch4Bytes, allBytes[1])
+    }
+
+
+    @Test
+    fun `schedulePrefetch populates cache so intercept is a hit`(@TempDir tempDir: Path) = runBlocking {
+        val imageBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte())
+        val loader = fakeLoader("hero.jpg" to imageBytes)
+        val scope = CoroutineScope(Dispatchers.IO)
+        val cache = makeCache(tempDir.toFile(), scope)
+
+        cache.schedulePrefetch(
+            content = """<img src="tsundoku-novel-image://hero.jpg"/>""",
+            chapterId = 5L,
+            loader = loader,
+        )
+
+        delay(300)
+
+        var loadCount = 0
+        val countingLoader = object : PageLoader() {
+            override var isLocal = true
+            override suspend fun getPages(): List<ReaderPage> = emptyList()
+            override suspend fun getPageDataStream(url: String): java.io.InputStream? {
+                loadCount++
+                return null
+            }
+        }
+
+        val response = cache.intercept(
+            url = "tsundoku-novel-image://5/hero.jpg",
+            fallbackChapterId = 5L,
+            fallbackLoader = countingLoader,
+        )
+
+        assertNotNull(response, "Prefetched image must be served from cache")
+        assert(loadCount == 0) { "Counting loader must not be called when cache is warm" }
+    }
+}


### PR DESCRIPTION

Translation Engines:
- Switch Google Translate scraper from GET to POST to bypass URL length limits for large text blocks.
- Update system prompts for LLM engines (Gemini, OpenAI, DeepSeek, Nvidia NIM, Ollama) to ensure `[IMG_PLACEHOLDER_X]` tokens are preserved.
- Fix thread-safety issue in `ReaderActivity` where translation error toasts were triggered from background coroutines.

Novel Viewer & Image Cache:
- NovelWebViewImageCache: Implement synchronous loading on cache miss within `intercept`. 
- NovelWebViewViewer: Add "Translating..." status message to the loading indicator when real-time translation is active.
- Fix infinite scroll bug where chapters shorter than the viewport height never triggered the "next chapter" append due to lack of scroll events.
