### PR TITLE
Source tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 - Tap zones for novels [@mrissaoussama](https://github.com/mrissaoussama) [#210](https://github.com/tsundoku-otaku/tsundoku/pull/210)
 - Open EPUBs with app, export with CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#227](https://github.com/tsundoku-otaku/tsundoku/pull/227)
+- Sources can now integrate with SourceTracker, so the sources can add/remove content, or mark it as read, based on tracker [@mrissaoussama](https://github.com/mrissaoussama) [#232](https://github.com/tsundoku-otaku/tsundoku/pull/232)
 
 ### Changed
 - Novel downloads will be saved as zip format [@mrissaoussama](https://github.com/mrissaoussama) [#202](https://github.com/tsundoku-otaku/tsundoku/pull/202)

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -1,6 +1,7 @@
 package eu.kanade.domain.chapter.interactor
 
 import eu.kanade.domain.download.interactor.DeleteDownload
+import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.core.common.util.system.logcat
@@ -11,6 +12,8 @@ import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class SetReadStatus(
     private val downloadPreferences: DownloadPreferences,
@@ -19,6 +22,8 @@ class SetReadStatus(
     private val chapterRepository: ChapterRepository,
     private val translatedChapterRepository: TranslatedChapterRepository,
 ) {
+
+    private val sourceTrackerDispatcher: SourceTrackerDispatcher by lazy { Injekt.get() }
 
     private val mapper = { chapter: Chapter, read: Boolean ->
         ChapterUpdate(
@@ -63,6 +68,19 @@ class SetReadStatus(
                         chapters = chapters.toTypedArray(),
                     )
                 }
+        }
+
+        try {
+            chaptersToUpdate.groupBy { it.mangaId }.forEach { (mangaId, chapters) ->
+                val manga = mangaRepository.getMangaById(mangaId)
+                if (read) {
+                    sourceTrackerDispatcher.notifyChaptersRead(manga, chapters)
+                } else {
+                    sourceTrackerDispatcher.notifyChaptersUnread(manga, chapters)
+                }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "SourceTrackerDispatcher fan-out failed" }
         }
 
         Result.Success

--- a/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
@@ -14,6 +14,8 @@ fun Chapter.toSChapter(): SChapter {
         it.chapter_number = chapterNumber.toFloat()
         it.scanlator = scanlator
         it.locked = locked
+        it.read = read
+        it.last_page_read = lastPageRead.toInt()
     }
 }
 

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
@@ -3,6 +3,7 @@ package eu.kanade.domain.manga.interactor
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import eu.kanade.tachiyomi.source.model.SManga
 import logcat.LogPriority
@@ -10,6 +11,7 @@ import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.FetchInterval
 import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository
@@ -27,6 +29,22 @@ class UpdateManga(
     private val getLibraryManga: GetLibraryManga = Injekt.get(),
 ) {
 
+    private val sourceTrackerDispatcher: SourceTrackerDispatcher by lazy { Injekt.get() }
+    private val getManga: GetManga by lazy { Injekt.get() }
+
+    private suspend fun notifySourceTrackerFavorite(mangaId: Long, favorite: Boolean) {
+        try {
+            val manga = getManga.await(mangaId) ?: return
+            if (favorite) {
+                sourceTrackerDispatcher.notifyFavorited(manga)
+            } else {
+                sourceTrackerDispatcher.notifyUnfavorited(manga)
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "SourceTrackerDispatcher favorite fan-out failed" }
+        }
+    }
+
     suspend fun await(mangaUpdate: MangaUpdate): Boolean {
         return mangaRepository.update(mangaUpdate)
     }
@@ -43,6 +61,8 @@ class UpdateManga(
             if (toRemove.isNotEmpty()) {
                 getLibraryManga.removeFromLibrary(toRemove)
             }
+            toAdd.forEach { notifySourceTrackerFavorite(it, true) }
+            toRemove.forEach { notifySourceTrackerFavorite(it, false) }
         }
         return result
     }
@@ -150,6 +170,7 @@ class UpdateManga(
             } else {
                 getLibraryManga.removeFromLibrary(mangaId)
             }
+            notifySourceTrackerFavorite(mangaId, favorite)
         }
         return result
     }

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -90,4 +90,11 @@ class TrackPreferences(
         "min_chapters_before_tracking_novel",
         "0",
     )
+
+    // Source-defined trackers (SourceTracker interface)
+    val migrationTriggersSourceTracker: Preference<Boolean> = preferenceStore.getBoolean(
+        "source_tracker_run_on_migration",
+        true,
+    )
+
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -274,6 +274,20 @@ object SettingsTrackingScreen : SearchableSettings {
                 ),
             ),
             Preference.PreferenceGroup(
+                title = "Source-defined trackers",
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = trackPreferences.migrationTriggersSourceTracker,
+                        title = "Run source trackers on migration",
+                        subtitle = "Fire source-defined tracker events when migrating or quick-migrating an entry",
+                    ),
+                    Preference.PreferenceItem.InfoPreference(
+                        "Some sources implement their own tracking. They are notified when you mark chapters read, " +
+                            "favorite/unfavorite, or migrate. Failures don't block reading and don't affect the regular trackers above.",
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
                 title = stringResource(MR.strings.enhanced_services),
                 preferenceItems = (
                     enhancedTrackers.first

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -12,11 +12,11 @@ interface Chapter : SChapter, Serializable {
 
     var manga_id: Long?
 
-    var read: Boolean
+    override var read: Boolean
 
     var bookmark: Boolean
 
-    var last_page_read: Int
+    override var last_page_read: Int
 
     var date_fetch: Long
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/source/SourceTrackerDispatcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/source/SourceTrackerDispatcher.kt
@@ -1,0 +1,181 @@
+package eu.kanade.tachiyomi.data.track.source
+
+import android.app.Application
+import eu.kanade.domain.chapter.model.toSChapter
+import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.SourceTrackerMethod
+import eu.kanade.tachiyomi.source.invokeSourceTrackerCallback
+import eu.kanade.tachiyomi.source.isSourceTracker
+import eu.kanade.tachiyomi.source.sourceTrackerBoolean
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Fans out chapter-read / unread / favorite / unfavorite events to sources that
+ * implement [SourceTracker].
+ *
+ * - Per-manga debounce (3 s tail) coalesces bulk operations into one callback.
+ * - Min-chapters preference gates chapter callbacks, as for first-party trackers.
+ * - Failures are logged + toasted; never propagate to callers. UI is never blocked.
+ * - Backup restore bypasses this dispatcher (restore writes the DB directly), so
+ *   callbacks do not fire on restore.
+ */
+class SourceTrackerDispatcher(
+    private val sourceManager: SourceManager,
+    private val getChaptersByMangaId: GetChaptersByMangaId,
+    private val getCategories: GetCategories,
+    private val trackPreferences: TrackPreferences,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private data class PendingChapterEvent(
+        var manga: Manga,
+        var read: Boolean,
+        val changedChapterIds: MutableSet<Long> = mutableSetOf(),
+    )
+
+    // Keyed by manga id: each manga debounces independently, so bulk-marking chapters
+    // across several manga of the same source coalesces per manga without dropping any.
+    private val pendingChapterJobs = ConcurrentHashMap<Long, Job>()
+    private val pendingChapterArgs = ConcurrentHashMap<Long, PendingChapterEvent>()
+
+    fun notifyChaptersRead(manga: Manga, chapters: List<Chapter>) = enqueueChapterEvent(manga, chapters, read = true)
+
+    fun notifyChaptersUnread(manga: Manga, chapters: List<Chapter>) = enqueueChapterEvent(manga, chapters, read = false)
+
+    fun notifyFavorited(manga: Manga) = fireFavoriteEvent(manga, favorite = true)
+
+    fun notifyUnfavorited(manga: Manga) = fireFavoriteEvent(manga, favorite = false)
+
+    private fun enqueueChapterEvent(manga: Manga, chapters: List<Chapter>, read: Boolean) {
+        if (chapters.isEmpty()) return
+        val source = sourceManager.get(manga.source)
+        if (source == null || !source.isSourceTracker()) return
+        if (!source.sourceTrackerBoolean("supportsChapterTracking", default = true)) return
+
+        val mangaId = manga.id
+        pendingChapterArgs.compute(mangaId) { _, existing ->
+            if (existing == null || existing.read != read) {
+                PendingChapterEvent(manga = manga, read = read).also {
+                    it.changedChapterIds += chapters.map { ch -> ch.id }
+                }
+            } else {
+                existing.manga = manga
+                existing.changedChapterIds += chapters.map { ch -> ch.id }
+                existing
+            }
+        }
+
+        pendingChapterJobs[mangaId]?.cancel()
+        pendingChapterJobs[mangaId] = scope.launch {
+            delay(DEBOUNCE_MS)
+            val args = pendingChapterArgs.remove(mangaId) ?: return@launch
+            pendingChapterJobs.remove(mangaId)
+            runChapterEvent(source, args)
+        }
+    }
+
+    private suspend fun runChapterEvent(source: Source, args: PendingChapterEvent) {
+        try {
+            val manga = args.manga
+            val allChapters = getChaptersByMangaId.await(manga.id)
+            if (!passesMinChaptersGate(manga, allChapters)) return
+
+            val changed = allChapters.filter { it.id in args.changedChapterIds }
+            val sourceManga = manga.toSManga()
+            val allSChapters = allChapters.map { it.toSChapter() }
+            val categories = loadCategoryNames(manga.id)
+
+            // On unread, re-point the remote cursor at the highest still-read chapter instead
+            // of un-ticking; only fire a genuine unread when nothing remains read.
+            val (method, changedSChapters) = if (!args.read) {
+                val highestStillRead = allChapters
+                    .filter { it.read && it.chapterNumber > 0.0 }
+                    .maxByOrNull { it.chapterNumber }
+                if (highestStillRead != null) {
+                    SourceTrackerMethod.ON_CHAPTERS_READ to listOf(highestStillRead.toSChapter())
+                } else {
+                    SourceTrackerMethod.ON_CHAPTERS_UNREAD to changed.map { it.toSChapter() }
+                }
+            } else {
+                SourceTrackerMethod.ON_CHAPTERS_READ to changed.map { it.toSChapter() }
+            }
+
+            source.invokeSourceTrackerCallback(method, sourceManga, changedSChapters, allSChapters, categories)
+        } catch (e: Throwable) {
+            reportFailure(source, e)
+        }
+    }
+
+    private fun fireFavoriteEvent(manga: Manga, favorite: Boolean) {
+        val source = sourceManager.get(manga.source)
+        if (source == null || !source.isSourceTracker()) return
+        if (!source.sourceTrackerBoolean("supportsFavoritesTracking", default = false)) return
+        scope.launch {
+            try {
+                val sourceManga = manga.toSManga()
+                val categories = loadCategoryNames(manga.id)
+                val method = if (favorite) SourceTrackerMethod.ON_FAVORITED else SourceTrackerMethod.ON_UNFAVORITED
+                source.invokeSourceTrackerCallback(method, sourceManga, emptyList(), emptyList(), categories)
+            } catch (e: Throwable) {
+                reportFailure(source, e)
+            }
+        }
+    }
+
+    private suspend fun loadCategoryNames(mangaId: Long): List<String> {
+        return try {
+            getCategories.await(mangaId)
+                .filter { it.id != Category.UNCATEGORIZED_ID }
+                .map { it.name }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "SourceTrackerDispatcher: category lookup failed for $mangaId" }
+            emptyList()
+        }
+    }
+
+    private fun passesMinChaptersGate(manga: Manga, allChapters: List<Chapter>): Boolean {
+        val pref = if (manga.isNovel) {
+            trackPreferences.minChaptersBeforeTrackingNovel
+        } else {
+            trackPreferences.minChaptersBeforeTrackingManga
+        }
+        val threshold = pref.get().toIntOrNull() ?: 0
+        if (threshold <= 0) return true
+        val readCount = allChapters.count { it.read }
+        return readCount >= threshold
+    }
+
+    private suspend fun reportFailure(source: Source, e: Throwable) {
+        logcat(LogPriority.ERROR, e) { "SourceTrackerDispatcher: callback failed for ${source::class.java.name}" }
+        runCatching {
+            withUIContext {
+                val app = Injekt.get<Application>()
+                app.toast("${source.name} tracker failed: ${e.message ?: e::class.simpleName}")
+            }
+        }
+    }
+
+    companion object {
+        const val DEBOUNCE_MS = 3_000L
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/source/SourceTrackerDispatcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/source/SourceTrackerDispatcher.kt
@@ -33,11 +33,9 @@ import java.util.concurrent.ConcurrentHashMap
  * Fans out chapter-read / unread / favorite / unfavorite events to sources that
  * implement [SourceTracker].
  *
- * - Per-manga debounce (3 s tail) coalesces bulk operations into one callback.
+ * - Per-manga debounce (3s).
  * - Min-chapters preference gates chapter callbacks, as for first-party trackers.
- * - Failures are logged + toasted; never propagate to callers. UI is never blocked.
- * - Backup restore bypasses this dispatcher (restore writes the DB directly), so
- *   callbacks do not fire on restore.
+ * - Failures are logged + toasted.
  */
 class SourceTrackerDispatcher(
     private val sourceManager: SourceManager,
@@ -53,8 +51,6 @@ class SourceTrackerDispatcher(
         val changedChapterIds: MutableSet<Long> = mutableSetOf(),
     )
 
-    // Keyed by manga id: each manga debounces independently, so bulk-marking chapters
-    // across several manga of the same source coalesces per manga without dropping any.
     private val pendingChapterJobs = ConcurrentHashMap<Long, Job>()
     private val pendingChapterArgs = ConcurrentHashMap<Long, PendingChapterEvent>()
 
@@ -105,8 +101,6 @@ class SourceTrackerDispatcher(
             val allSChapters = allChapters.map { it.toSChapter() }
             val categories = loadCategoryNames(manga.id)
 
-            // On unread, re-point the remote cursor at the highest still-read chapter instead
-            // of un-ticking; only fire a genuine unread when nothing remains read.
             val (method, changedSChapters) = if (!args.read) {
                 val highestStillRead = allChapters
                     .filter { it.read && it.chapterNumber > 0.0 }

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.data.translation.TranslationCache
 import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import eu.kanade.tachiyomi.data.translation.TranslationService
@@ -134,6 +135,7 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingletonFactory { TrackerManager() }
         addSingletonFactory { DelayedTrackingStore(app) }
+        addSingletonFactory { SourceTrackerDispatcher(get(), get(), get(), get()) }
 
         addSingletonFactory { ImageSaver(app) }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isNovelSource
@@ -39,6 +41,9 @@ class MigrateMangaScreenModel(
     private val getCategories: tachiyomi.domain.category.interactor.GetCategories = Injekt.get(),
     private val createCategoryWithName: tachiyomi.domain.category.interactor.CreateCategoryWithName = Injekt.get(),
     private val setMangaCategories: tachiyomi.domain.category.interactor.SetMangaCategories = Injekt.get(),
+    private val sourceTrackerDispatcher: SourceTrackerDispatcher = Injekt.get(),
+    private val trackPreferences: TrackPreferences = Injekt.get(),
+    private val getManga: tachiyomi.domain.manga.interactor.GetManga = Injekt.get(),
 ) : StateScreenModel<MigrateMangaScreenModel.State>(State()) {
 
     private val _events: Channel<MigrationMangaEvent> = Channel()
@@ -155,6 +160,13 @@ class MigrateMangaScreenModel(
                         migratedIds.add(manga.id)
                     } catch (_: Exception) {
                         // If check fails, proceed with migration
+                    }
+                }
+
+                if (migratedIds.isNotEmpty() && trackPreferences.migrationTriggersSourceTracker.get()) {
+                    migratedIds.forEach { id ->
+                        val freshManga = getManga.await(id) ?: return@forEach
+                        sourceTrackerDispatcher.notifyFavorited(freshManga)
                     }
                 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -118,6 +118,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
     private val trackPreferences: TrackPreferences = Injekt.get(),
     private val trackChapter: TrackChapter = Injekt.get(),
+    private val sourceTrackerDispatcher: eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
     private val getNextChapters: GetNextChapters = Injekt.get(),
@@ -1413,13 +1414,25 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     private fun updateTrackChapterRead(readerChapter: ReaderChapter) {
         if (incognitoMode) return
-        if (!trackPreferences.autoUpdateTrack.get()) return
 
         val manga = manga ?: return
+        val chapterId = readerChapter.chapter.id ?: return
         val context = Injekt.get<Application>()
 
         viewModelScope.launchNonCancellable {
-            trackChapter.await(context, manga.id, readerChapter.chapter.chapter_number.toDouble())
+            if (trackPreferences.autoUpdateTrack.get()) {
+                trackChapter.await(context, manga.id, readerChapter.chapter.chapter_number.toDouble())
+            }
+
+            // Fan out to source trackers separately, so they sync even when autoUpdateTrack is off.
+            try {
+                val chapter = getChaptersByMangaId.await(manga.id).find { it.id == chapterId }
+                if (chapter != null) {
+                    sourceTrackerDispatcher.notifyChaptersRead(manga, listOf(chapter))
+                }
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) { "Reader SourceTrackerDispatcher dispatch failed" }
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1424,7 +1424,6 @@ class ReaderViewModel @JvmOverloads constructor(
                 trackChapter.await(context, manga.id, readerChapter.chapter.chapter_number.toDouble())
             }
 
-            // Fan out to source trackers separately, so they sync even when autoUpdateTrack is off.
             try {
                 val chapter = getChaptersByMangaId.await(manga.id).find { it.id == chapterId }
                 if (chapter != null) {

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -5,10 +5,12 @@ import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import kotlinx.coroutines.CancellationException
 import mihon.domain.migration.models.MigrationFlag
 import tachiyomi.domain.category.interactor.GetCategories
@@ -16,11 +18,14 @@ import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.toChapterUpdate
+import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.track.interactor.GetTracks
 import tachiyomi.domain.track.interactor.InsertTrack
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.time.Instant
 
 class MigrateMangaUseCase(
@@ -39,6 +44,10 @@ class MigrateMangaUseCase(
     private val coverCache: CoverCache,
 ) {
     private val enhancedServices by lazy { trackerManager.trackers.filterIsInstance<EnhancedTracker>() }
+
+    private val sourceTrackerDispatcher: SourceTrackerDispatcher by lazy { Injekt.get() }
+    private val trackPreferences: TrackPreferences by lazy { Injekt.get() }
+    private val getMangaInteractor: GetManga by lazy { Injekt.get() }
 
     suspend operator fun invoke(current: Manga, target: Manga, replace: Boolean) {
         val targetSource = sourceManager.get(target.source) ?: return
@@ -136,6 +145,21 @@ class MigrateMangaUseCase(
             )
 
             updateManga.awaitAll(listOfNotNull(currentMangaUpdate, targetMangaUpdate))
+
+            // Dispatch SourceTracker events for the migrated target if the user opted in.
+            if (trackPreferences.migrationTriggersSourceTracker.get()) {
+                val freshTarget = getMangaInteractor.await(target.id)
+                if (freshTarget != null) {
+                    sourceTrackerDispatcher.notifyFavorited(freshTarget)
+                    if (MigrationFlag.CHAPTER in flags) {
+                        val targetChapters = getChaptersByMangaId.await(target.id)
+                        val readChapters = targetChapters.filter { it.read }
+                        if (readChapters.isNotEmpty()) {
+                            sourceTrackerDispatcher.notifyChaptersRead(freshTarget, readChapters)
+                        }
+                    }
+                }
+            }
         } catch (e: Throwable) {
             if (e is CancellationException) {
                 throw e

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -146,7 +146,6 @@ class MigrateMangaUseCase(
 
             updateManga.awaitAll(listOfNotNull(currentMangaUpdate, targetMangaUpdate))
 
-            // Dispatch SourceTracker events for the migrated target if the user opted in.
             if (trackPreferences.migrationTriggersSourceTracker.get()) {
                 val freshTarget = getMangaInteractor.await(target.id)
                 if (freshTarget != null) {

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceTracker.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceTracker.kt
@@ -1,0 +1,214 @@
+package eu.kanade.tachiyomi.source
+
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Optional interface a [Source] can implement to react to user reading/library events.
+ *
+ * The app fans out events to sources that implement this interface for the relevant
+ * manga (matched by [SManga.url] + source id). Callbacks run off the UI thread, are
+ * debounced per-source (3s tail), are gated by the user's "minimum chapters before
+ * tracking" preference, and never block reader/library UI.
+ *
+ * Implementations MUST be idempotent — the same event may be retried. Failures should
+ * be raised as exceptions; the dispatcher logs them and shows a toast. Do NOT swallow
+ * exceptions silently to signal "no-op".
+ *
+ * Most extensions don't need this — only those backed by a remote service that wants
+ * to mirror local reading state (e.g. an OPDS-style hosted library).
+ *
+ * @since extensions-lib 1.6
+ */
+interface SourceTracker {
+
+    /** Whether this source wants chapter read/unread callbacks. Default true. */
+    val supportsChapterTracking: Boolean
+        get() = true
+
+    /** Whether this source wants favorite/unfavorite callbacks. Default false. */
+    val supportsFavoritesTracking: Boolean
+        get() = false
+
+    /**
+     * Called after chapters are marked read.
+     *
+     * @param manga the manga whose chapters were touched.
+     * @param changedChapters chapters whose read state flipped to read in this batch.
+     *                        May contain arbitrary numbers (e.g. 1, 3, 4) — not just the latest.
+     * @param allChapters every chapter the app knows about for this manga, with current
+     *                    [SChapter.read] state populated. Use this if you need full
+     *                    "marked vs unmarked" context.
+     * @param categories names of categories this manga belongs to. Empty list if the
+     *                   manga has no user-named categories (e.g. only in Default).
+     */
+    suspend fun onChaptersRead(
+        manga: SManga,
+        changedChapters: List<SChapter>,
+        allChapters: List<SChapter>,
+        categories: List<String>,
+    ) = Unit
+
+    /** Called after chapters are marked unread. Same parameters as [onChaptersRead]. */
+    suspend fun onChaptersUnread(
+        manga: SManga,
+        changedChapters: List<SChapter>,
+        allChapters: List<SChapter>,
+        categories: List<String>,
+    ) = Unit
+
+    /** Called after the user added this manga to the library. */
+    suspend fun onFavorited(
+        manga: SManga,
+        categories: List<String>,
+    ) = Unit
+
+    /** Called after the user removed this manga from the library. */
+    suspend fun onUnfavorited(
+        manga: SManga,
+        categories: List<String>,
+    ) = Unit
+}
+
+// ============================================================================
+// Cross-classloader helpers
+//
+// Extensions are loaded with a ChildFirstPathClassLoader (see ExtensionLoader),
+// so their bundled copy of `SourceTracker` is a DIFFERENT java.lang.Class than
+// the app's copy. A plain `source is SourceTracker` cast checks identity and
+// returns false. Match the existing NovelSource pattern: detect by interface
+// name, invoke by reflection.
+// ============================================================================
+
+/**
+ * True when [Source] implements [SourceTracker] under either classloader.
+ */
+fun Source.isSourceTracker(): Boolean {
+    if (this is SourceTracker) return true
+    return this::class.java.allInterfaceNames()
+        .contains("eu.kanade.tachiyomi.source.SourceTracker")
+}
+
+/**
+ * Reads a Boolean property on [Source] via reflection. Used for the optional
+ * `supportsChapterTracking` / `supportsFavoritesTracking` flags so the dispatcher
+ * doesn't have to cast the source to its own SourceTracker class.
+ */
+fun Source.sourceTrackerBoolean(propertyName: String, default: Boolean): Boolean {
+    if (this is SourceTracker) {
+        return when (propertyName) {
+            "supportsChapterTracking" -> this.supportsChapterTracking
+            "supportsFavoritesTracking" -> this.supportsFavoritesTracking
+            else -> default
+        }
+    }
+    return try {
+        // Try `getSupportsChapterTracking()` Kotlin property accessor first, then the bare name.
+        val getter = "get" + propertyName.replaceFirstChar { it.uppercase() }
+        val method = runCatching { this::class.java.getMethod(getter) }.getOrNull()
+            ?: runCatching { this::class.java.getMethod(propertyName) }.getOrNull()
+            ?: return default
+        method.invoke(this) as? Boolean ?: default
+    } catch (_: Exception) {
+        default
+    }
+}
+
+/**
+ * Invokes one of the four [SourceTracker] callbacks by reflection so the call
+ * works across classloaders. Same param list as the interface methods.
+ */
+@Suppress("UNCHECKED_CAST")
+suspend fun Source.invokeSourceTrackerCallback(
+    method: SourceTrackerMethod,
+    manga: SManga,
+    changedChapters: List<SChapter>,
+    allChapters: List<SChapter>,
+    categories: List<String>,
+) {
+    if (this is SourceTracker) {
+        when (method) {
+            SourceTrackerMethod.ON_CHAPTERS_READ -> onChaptersRead(manga, changedChapters, allChapters, categories)
+            SourceTrackerMethod.ON_CHAPTERS_UNREAD -> onChaptersUnread(manga, changedChapters, allChapters, categories)
+            SourceTrackerMethod.ON_FAVORITED -> onFavorited(manga, categories)
+            SourceTrackerMethod.ON_UNFAVORITED -> onUnfavorited(manga, categories)
+        }
+        return
+    }
+    suspendCoroutine<Unit> { continuation ->
+        try {
+            val cls = this::class.java
+            val reflectMethod = when (method) {
+                SourceTrackerMethod.ON_CHAPTERS_READ,
+                SourceTrackerMethod.ON_CHAPTERS_UNREAD,
+                -> cls.getMethod(
+                    method.methodName,
+                    SManga::class.java,
+                    List::class.java,
+                    List::class.java,
+                    List::class.java,
+                    Continuation::class.java,
+                )
+
+                SourceTrackerMethod.ON_FAVORITED,
+                SourceTrackerMethod.ON_UNFAVORITED,
+                -> cls.getMethod(
+                    method.methodName,
+                    SManga::class.java,
+                    List::class.java,
+                    Continuation::class.java,
+                )
+            }
+            val callback = object : Continuation<Any?> {
+                override val context = continuation.context
+                override fun resumeWith(result: Result<Any?>) {
+                    result.fold(
+                        onSuccess = { continuation.resume(Unit) },
+                        onFailure = { continuation.resumeWithException(it) },
+                    )
+                }
+            }
+            val args: Array<Any?> = when (method) {
+                SourceTrackerMethod.ON_CHAPTERS_READ,
+                SourceTrackerMethod.ON_CHAPTERS_UNREAD,
+                -> arrayOf(manga, changedChapters, allChapters, categories, callback)
+
+                SourceTrackerMethod.ON_FAVORITED,
+                SourceTrackerMethod.ON_UNFAVORITED,
+                -> arrayOf(manga, categories, callback)
+            }
+            val result = reflectMethod.invoke(this, *args)
+            if (result != kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED) {
+                continuation.resume(Unit)
+            }
+        } catch (e: Exception) {
+            continuation.resumeWithException(e)
+        }
+    }
+}
+
+enum class SourceTrackerMethod(val methodName: String) {
+    ON_CHAPTERS_READ("onChaptersRead"),
+    ON_CHAPTERS_UNREAD("onChaptersUnread"),
+    ON_FAVORITED("onFavorited"),
+    ON_UNFAVORITED("onUnfavorited"),
+}
+
+private fun Class<*>.allInterfaceNames(): List<String> {
+    val result = mutableListOf<String>()
+    var current: Class<*>? = this
+    while (current != null) {
+        current.interfaces.forEach { collectInterfaces(it, result) }
+        current = current.superclass
+    }
+    return result
+}
+
+private fun collectInterfaces(iface: Class<*>, out: MutableList<String>) {
+    out += iface.name
+    iface.interfaces.forEach { collectInterfaces(it, out) }
+}

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceTracker.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceTracker.kt
@@ -10,17 +10,12 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * Optional interface a [Source] can implement to react to user reading/library events.
  *
- * The app fans out events to sources that implement this interface for the relevant
- * manga (matched by [SManga.url] + source id). Callbacks run off the UI thread, are
- * debounced per-source (3s tail), are gated by the user's "minimum chapters before
- * tracking" preference, and never block reader/library UI.
- *
- * Implementations MUST be idempotent — the same event may be retried. Failures should
- * be raised as exceptions; the dispatcher logs them and shows a toast. Do NOT swallow
- * exceptions silently to signal "no-op".
+ * These are gated by the user's "minimum chapters before
+ * tracking" preference.
+ * Failures should be raised as exceptions; the dispatcher logs them and shows a toast.
  *
  * Most extensions don't need this — only those backed by a remote service that wants
- * to mirror local reading state (e.g. an OPDS-style hosted library).
+ * to mirror local reading state.
  *
  * @since extensions-lib 1.6
  */
@@ -73,16 +68,6 @@ interface SourceTracker {
         categories: List<String>,
     ) = Unit
 }
-
-// ============================================================================
-// Cross-classloader helpers
-//
-// Extensions are loaded with a ChildFirstPathClassLoader (see ExtensionLoader),
-// so their bundled copy of `SourceTracker` is a DIFFERENT java.lang.Class than
-// the app's copy. A plain `source is SourceTracker` cast checks identity and
-// returns false. Match the existing NovelSource pattern: detect by interface
-// name, invoke by reflection.
-// ============================================================================
 
 /**
  * True when [Source] implements [SourceTracker] under either classloader.

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SChapter.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SChapter.kt
@@ -18,6 +18,22 @@ interface SChapter : Serializable {
 
     var locked: Boolean
 
+    /**
+     * Local read state. Source implementations should NOT set this — it is populated
+     * by the app only when delivering SChapter instances to [SourceTracker] callbacks.
+     */
+    var read: Boolean
+        get() = false
+        set(_) {}
+
+    /**
+     * Local last-page-read position. Source implementations should NOT set this — it is
+     * populated by the app only when delivering SChapter instances to [SourceTracker] callbacks.
+     */
+    var last_page_read: Int
+        get() = 0
+        set(_) {}
+
     fun copyFrom(other: SChapter) {
         name = other.name
         url = other.url

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SChapterImpl.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SChapterImpl.kt
@@ -15,4 +15,8 @@ class SChapterImpl : SChapter {
     override var scanlator: String? = null
 
     override var locked: Boolean = false
+
+    override var read: Boolean = false
+
+    override var last_page_read: Int = 0
 }


### PR DESCRIPTION
Sources can now implement SourceTracker to be notified of:

    Chapters being marked read/unread

    Manga being added to or removed from the library

Event delivery uses a central dispatcher with basic safeguards (debouncing, minimum-chapters before tracking).

New settings option to enable/disable source trackers when migrating manga.

Integration with read/unread actions, favorite toggles, migration flows, and the reader.