### PR TITLE
feat(extension): tsundoku novel extensions will not appear as manga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Internationalize mass-import strings, add confirmation dialogues [@mrissaoussama](https://github.com/mrissaoussama) [#206](https://github.com/tsundoku-otaku/tsundoku/pull/206)
+- Added tsundoku specific extensions, so apps can avoid appearing as manga sources in other apps [@mrissaoussama](https://github.com/mrissaoussama) [#238](https://github.com/tsundoku-otaku/tsundoku/pull/238)
 
 
 ## [v0.1.4] - 2026-05-09

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -48,6 +48,8 @@ internal object ExtensionLoader {
     }
 
     private const val EXTENSION_FEATURE = "tachiyomi.extension"
+    private const val EXTENSION_FEATURE_NOVEL = "app.tsundoku.extension.novel"
+    private val EXTENSION_FEATURES = setOf(EXTENSION_FEATURE, EXTENSION_FEATURE_NOVEL)
     private const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
     private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"
     private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
@@ -420,9 +422,10 @@ internal object ExtensionLoader {
      * @param pkgInfo The package info of the application.
      */
     private fun isPackageAnExtension(pkgInfo: PackageInfo): Boolean {
-        val hasFeature = pkgInfo.reqFeatures.orEmpty().any { it.name == EXTENSION_FEATURE }
+        val hasFeature = pkgInfo.reqFeatures.orEmpty().any { it.name in EXTENSION_FEATURES }
         if (pkgInfo.packageName.contains("extension", ignoreCase = true) ||
-            pkgInfo.packageName.contains("mihon", ignoreCase = true)
+            pkgInfo.packageName.contains("mihon", ignoreCase = true) ||
+            pkgInfo.packageName.contains("tsundoku", ignoreCase = true)
         ) {
             android.util.Log.d(
                 "ExtensionLoader",

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -48,7 +48,7 @@ internal object ExtensionLoader {
     }
 
     private const val EXTENSION_FEATURE = "tachiyomi.extension"
-    private const val EXTENSION_FEATURE_NOVEL = "app.tsundoku.extension.novel"
+    private const val EXTENSION_FEATURE_NOVEL = "tachiyomi.novelextension"
     private val EXTENSION_FEATURES = setOf(EXTENSION_FEATURE, EXTENSION_FEATURE_NOVEL)
     private const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
     private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"


### PR DESCRIPTION
isPackageAnExtension now accepts the app.tsundoku.extension.novel feature alongside tachiyomi.extension, and matches packages whose name contains tsundoku.

Novel sources should exclusively use this feature to not appear in other apps as manga sources