### PR TITLE
fix: ensure library unread counts update when marking chapters as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Improve translation reliability and interactions with images; Bug with short chapters [@mrissaoussama](https://github.com/mrissaoussama) [#232](https://github.com/tsundoku-otaku/tsundoku/pull/232)
 - Make Grid items better respect max lines limits in library [@mrissaoussama](https://github.com/mrissaoussama) [#216](https://github.com/tsundoku-otaku/tsundoku/pull/216)
 - TextView Regex; Short chapter detection false positives [@mrissaoussama](https://github.com/mrissaoussama) [#225](https://github.com/tsundoku-otaku/tsundoku/pull/225)
+- Update library unread counts when marking chapters as read [@mrissaoussama](https://github.com/mrissaoussama) [#240](https://github.com/tsundoku-otaku/tsundoku/pull/240)
 - Fix HTML vs plain text detection [@mrissaoussama](https://github.com/mrissaoussama) [#223](https://github.com/tsundoku-otaku/tsundoku/pull/223)
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -21,10 +21,12 @@ import kotlinx.coroutines.runBlocking
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.model.toChapterUpdate
 import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
@@ -44,7 +46,9 @@ class NotificationReceiver : BroadcastReceiver() {
 
     private val getManga: GetManga by injectLazy()
     private val getChapter: GetChapter by injectLazy()
+    private val getChaptersByMangaId: GetChaptersByMangaId by injectLazy()
     private val updateChapter: UpdateChapter by injectLazy()
+    private val getLibraryManga: GetLibraryManga by injectLazy()
     private val downloadManager: DownloadManager by injectLazy()
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -225,6 +229,13 @@ class NotificationReceiver : BroadcastReceiver() {
                     chapter.toChapterUpdate()
                 }
             updateChapter.awaitAll(toUpdate)
+
+            val chapters = getChaptersByMangaId.await(mangaId)
+            getLibraryManga.applyChapterUpdates(
+                mangaId = mangaId,
+                totalChapters = chapters.size.toLong(),
+                readCount = chapters.count { it.read }.toLong(),
+            )
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -895,8 +895,9 @@ class ReaderViewModel @JvmOverloads constructor(
             // Marking complete via page-index would always fire on selection.
             // Novel completion is handled by saveNovelProgress (marks at >=95%).
             val isNovelChapter = manga?.isNovel == true && (readerChapter.pages?.size ?: 0) <= 1
-            if (!isNovelChapter && readerChapter.pages?.lastIndex == pageIndex) {
-                updateChapterProgressOnComplete(readerChapter)
+            val isComplete = !isNovelChapter && readerChapter.pages?.lastIndex == pageIndex
+            if (isComplete) {
+                readerChapter.chapter.read = true
             }
 
             updateChapter.await(
@@ -906,6 +907,10 @@ class ReaderViewModel @JvmOverloads constructor(
                     lastPageRead = readerChapter.chapter.last_page_read.toLong(),
                 ),
             )
+
+            if (isComplete) {
+                updateChapterProgressOnComplete(readerChapter)
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -44,9 +44,12 @@ import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.launchNonCancellable
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
+import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.domain.source.service.SourceManager
@@ -93,6 +96,8 @@ class UpdatesScreenModel(
     private val clearUpdatesCache: ClearUpdatesCache = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChapter: GetChapter = Injekt.get(),
+    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
+    private val getLibraryManga: GetLibraryManga = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val updatesPreferences: UpdatesPreferences = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
@@ -348,6 +353,20 @@ class UpdatesScreenModel(
                 read = read,
                 chapters = chapters.toTypedArray(),
             )
+
+            // Notify the library of badge changes so unread counts update immediately.
+            // GetLibraryManga is a manual StateFlow that isn't DB-reactive, so each
+            // affected manga's read count must be recomputed and pushed explicitly.
+            val mangaIds = updates.map { it.update.mangaId }.distinct()
+            val batch = mangaIds.associateWith { mangaId ->
+                val mangaChapters = getChaptersByMangaId.await(mangaId)
+                val readCount = mangaChapters.count { it.read }.toLong()
+                val totalCount = mangaChapters.size.toLong();
+                { libraryManga: LibraryManga ->
+                    libraryManga.copy(totalChapters = totalCount, readCount = readCount)
+                }
+            }
+            getLibraryManga.applyBatchChapterUpdates(batch)
         }
         toggleAllSelection(false)
     }


### PR DESCRIPTION
The library's unread badges are powered by a manual StateFlow in `GetLibraryManga` that is not reactive to direct database changes. This change ensures that when chapters are marked as read from screens other than the library, the state is explicitly updated to reflect new unread counts.

* **ReaderViewModel**: Set the chapter's `read` status locally before the database update and move `updateChapterProgressOnComplete` to execute after the update finishes.
* **NotificationReceiver**: After marking chapters as read from a notification, recompute the manga's read count and notify the library state.
* **UpdatesScreenModel**: Implement a batch update for the library state when marking multiple chapters as read to ensure unread badges refresh immediately.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
