### PR TITLE
 JS plugin runtime: timers, safe writes, single chapter fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)
 - Novel description screen now supports novel searches when tapping novel title [@mrissaoussama](https://github.com/mrissaoussama) [#207](https://github.com/tsundoku-otaku/tsundoku/pull/207)
 - Webview constants refactor, also fixes (non-infinite) scroll having dividers - Changes that affect custom CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#209](https://github.com/tsundoku-otaku/tsundoku/pull/209)
+- JS Plugin runtime, writes improved [@mrissaoussama](https://github.com/mrissaoussama) [#245](https://github.com/tsundoku-otaku/tsundoku/pull/245)
 - Added support for missing wrap function for JS plugins, and native cheerio support [@mrissaoussama](https://github.com/mrissaoussama) [#239](https://github.com/tsundoku-otaku/tsundoku/pull/239)
 - Mass import chunks to avoid memory errors, has better caching and redundancy checking, improve UI [@mrissaoussama](https://github.com/mrissaoussama) [#214](https://github.com/tsundoku-otaku/tsundoku/pull/214)
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,7 +14,9 @@
 -keep,allowoptimization class okio.** { public protected *; }
 -keep,allowoptimization class org.jsoup.** { public protected *; }
 -keep,allowoptimization class rx.** { public protected *; }
--keep,allowoptimization class app.cash.quickjs.** { public protected *; }
+-keep,allowoptimization class com.dokar.quickjs.** { public protected *; }
+-keep class com.dokar.quickjs.MemoryUsage { *; }
+-keepclassmembers class kotlin.UByteArray { <init>(...); }
 -keep,allowoptimization class uy.kohesive.injekt.** { public protected *; }
 
 # From extensions-lib

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -483,7 +483,6 @@ class JsPluginManager(
                                     if (resp.isSuccessful) {
                                         val fresh = resp.body?.string().orEmpty()
                                         if (fresh.isNotBlank() && fresh.contains("exports.default")) {
-                                            // Delete-then-create: SAF "w" mode may not truncate
                                             dir.replaceFile("$nameWithoutExtension.js")?.writeUtf8(fresh)
                                             code = fresh
                                             logcat(LogPriority.INFO) {
@@ -680,7 +679,6 @@ class JsPluginManager(
                 logcat(LogPriority.WARN) { "Plugins directory not available for saving repositories.json" }
                 return
             }
-            // replaceFile: non-truncating overwrite produced the concatenated JSON loadRepositories() repairs
             val reposFile = dir.replaceFile("repositories.json")
             if (reposFile == null) {
                 logcat(LogPriority.ERROR) { "Failed to create repositories.json file" }

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -553,8 +553,7 @@ class JsPluginManager(
     private fun rebuildSources() {
         val oldSources = _jsSources.value.filterIsInstance<JsSource>()
         val oldById = oldSources.associateBy { it.id }
-        // Reuse sources whose plugin didn't change: rebuilds fire on every storage change, and
-        // recreating (then releasing) untouched sources would kill their in-flight calls.
+        // Rebuilds fire on every storage change; recreating untouched sources kills their in-flight calls.
         val sources = _installedPlugins.value.map { installedPlugin ->
             val existing = oldById[installedPlugin.plugin.sourceId()]
             if (existing != null && existing.isSamePlugin(installedPlugin)) {
@@ -574,8 +573,7 @@ class JsPluginManager(
             "JsPluginManager: rebuildSources() - _jsSources.value updated, new count: ${_jsSources.value.size}"
         }
 
-        // Free native QuickJS runtimes held by the replaced sources only. Screens still holding
-        // an old reference keep working — the runtime is recreated on demand.
+        // Release only replaced runtimes; old references keep working, the runtime recreates on demand.
         val kept = sources.toHashSet()
         val replaced = oldSources.filterNot { it in kept }
         if (replaced.isNotEmpty()) {
@@ -682,8 +680,7 @@ class JsPluginManager(
                 logcat(LogPriority.WARN) { "Plugins directory not available for saving repositories.json" }
                 return
             }
-            // replaceFile: non-truncating SAF overwrite is what produced the concatenated-JSON
-            // repositories.json files that loadRepositories() has to repair.
+            // replaceFile: non-truncating overwrite produced the concatenated JSON loadRepositories() repairs
             val reposFile = dir.replaceFile("repositories.json")
             if (reposFile == null) {
                 logcat(LogPriority.ERROR) { "Failed to create repositories.json file" }
@@ -780,10 +777,8 @@ class JsPluginManager(
     // UniFile helpers
 
     /**
-     * Delete-then-create to guarantee truncation. SAF's openOutputStream uses "w" mode, which
-     * many document providers do NOT truncate: overwriting a file with shorter content leaves
-     * stale tail bytes from the old version. For plugin .js files that yields a permanent
-     * SyntaxError after updates (and reinstalls over the same file never heal it).
+     * Delete-then-create to guarantee truncation. SAF "w" mode does not truncate on many
+     * providers, so a shorter overwrite leaves stale tail bytes (permanent SyntaxError for .js).
      */
     private fun UniFile.replaceFile(name: String): UniFile? {
         findFile(name)?.delete()

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -225,11 +225,11 @@ class JsPluginManager(
             }
 
             // Save to disk
-            val pluginFile = dir.createFile("${plugin.id}.js") ?: throw Exception("Failed to create plugin file")
+            val pluginFile = dir.replaceFile("${plugin.id}.js") ?: throw Exception("Failed to create plugin file")
             pluginFile.writeUtf8(code)
 
             // Save metadata
-            val metadataFile = dir.createFile("${plugin.id}.json") ?: throw Exception("Failed to create metadata file")
+            val metadataFile = dir.replaceFile("${plugin.id}.json") ?: throw Exception("Failed to create metadata file")
             val installedPlugin = InstalledJsPlugin(
                 plugin = plugin,
                 code = code,
@@ -321,10 +321,10 @@ class JsPluginManager(
                 return@withContext false
             }
 
-            val pluginFile = dir.createFile("${plugin.id}.js") ?: throw Exception("Failed to create plugin file")
+            val pluginFile = dir.replaceFile("${plugin.id}.js") ?: throw Exception("Failed to create plugin file")
             pluginFile.writeUtf8(code)
 
-            val metadataFile = dir.createFile("${plugin.id}.json") ?: throw Exception("Failed to create metadata file")
+            val metadataFile = dir.replaceFile("${plugin.id}.json") ?: throw Exception("Failed to create metadata file")
             val metadataJson = json.encodeToString(plugin)
             metadataFile.writeText(metadataJson)
 
@@ -483,7 +483,8 @@ class JsPluginManager(
                                     if (resp.isSuccessful) {
                                         val fresh = resp.body?.string().orEmpty()
                                         if (fresh.isNotBlank() && fresh.contains("exports.default")) {
-                                            file.writeUtf8(fresh)
+                                            // Delete-then-create: SAF "w" mode may not truncate
+                                            dir.replaceFile("$nameWithoutExtension.js")?.writeUtf8(fresh)
                                             code = fresh
                                             logcat(LogPriority.INFO) {
                                                 "Re-downloaded plugin '$nameWithoutExtension' successfully (len=${fresh.length})"
@@ -550,8 +551,17 @@ class JsPluginManager(
     }
 
     private fun rebuildSources() {
+        val oldSources = _jsSources.value.filterIsInstance<JsSource>()
+        val oldById = oldSources.associateBy { it.id }
+        // Reuse sources whose plugin didn't change: rebuilds fire on every storage change, and
+        // recreating (then releasing) untouched sources would kill their in-flight calls.
         val sources = _installedPlugins.value.map { installedPlugin ->
-            JsSource(installedPlugin)
+            val existing = oldById[installedPlugin.plugin.sourceId()]
+            if (existing != null && existing.isSamePlugin(installedPlugin)) {
+                existing
+            } else {
+                JsSource(installedPlugin)
+            }
         }
         logcat(LogPriority.INFO) {
             "JsPluginManager: rebuildSources() - emitting ${sources.size} sources to jsSources StateFlow"
@@ -562,6 +572,18 @@ class JsPluginManager(
         _jsSources.value = sources
         logcat(LogPriority.INFO) {
             "JsPluginManager: rebuildSources() - _jsSources.value updated, new count: ${_jsSources.value.size}"
+        }
+
+        // Free native QuickJS runtimes held by the replaced sources only. Screens still holding
+        // an old reference keep working — the runtime is recreated on demand.
+        val kept = sources.toHashSet()
+        val replaced = oldSources.filterNot { it in kept }
+        if (replaced.isNotEmpty()) {
+            scope.launch {
+                replaced.forEach { source ->
+                    runCatching { source.releaseRuntime() }
+                }
+            }
         }
     }
 
@@ -660,7 +682,9 @@ class JsPluginManager(
                 logcat(LogPriority.WARN) { "Plugins directory not available for saving repositories.json" }
                 return
             }
-            val reposFile = dir.createFile("repositories.json")
+            // replaceFile: non-truncating SAF overwrite is what produced the concatenated-JSON
+            // repositories.json files that loadRepositories() has to repair.
+            val reposFile = dir.replaceFile("repositories.json")
             if (reposFile == null) {
                 logcat(LogPriority.ERROR) { "Failed to create repositories.json file" }
                 return
@@ -754,6 +778,18 @@ class JsPluginManager(
     }
 
     // UniFile helpers
+
+    /**
+     * Delete-then-create to guarantee truncation. SAF's openOutputStream uses "w" mode, which
+     * many document providers do NOT truncate: overwriting a file with shorter content leaves
+     * stale tail bytes from the old version. For plugin .js files that yields a permanent
+     * SyntaxError after updates (and reinstalls over the same file never heal it).
+     */
+    private fun UniFile.replaceFile(name: String): UniFile? {
+        findFile(name)?.delete()
+        return createFile(name)
+    }
+
     private fun UniFile.readText(): String {
         return this.openInputStream().use { it.reader().readText() }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
@@ -188,7 +188,8 @@ class JSLibraryProvider(
             val priority = when (level) {
                 "ERROR" -> LogPriority.ERROR
                 "WARN" -> LogPriority.WARN
-                else -> LogPriority.DEBUG
+                "DEBUG" -> LogPriority.DEBUG
+                else -> LogPriority.INFO
             }
             logcat(priority) { "[$pluginId] $message" }
         }
@@ -662,6 +663,24 @@ class JSLibraryProvider(
             val html = args.getOrNull(1)?.toString() ?: ""
             cheerioWrap(handle, html)
         }
+
+        // Outer HTML of first element ($.html(el) support)
+        runtime.function("__cheerioOuterHtml") { args ->
+            val handle = args.getOrNull(0)?.toString()?.toIntOrNull() ?: -1
+            cheerioOuterHtml(handle)
+        }
+
+        // Lowercase tag name of first element
+        runtime.function("__cheerioTagName") { args ->
+            val handle = args.getOrNull(0)?.toString()?.toIntOrNull() ?: -1
+            cheerioTagName(handle)
+        }
+
+        // Child nodes (including text/comment nodes) as JSON for contents() support
+        runtime.function("__cheerioContents") { args ->
+            val handle = args.getOrNull(0)?.toString()?.toIntOrNull() ?: -1
+            cheerioContents(handle)
+        }
     }
 
     private fun cheerioLoad(html: String): Int {
@@ -696,25 +715,20 @@ class JSLibraryProvider(
     }
 
     private fun cheerioText(handle: Int): String {
+        // Cheerio .text() concatenates raw text nodes without whitespace normalization; Jsoup
+        // .text() normalizes, which breaks plugins that split on newline sequences.
         fun elementText(el: Element): String {
             val tagName = el.tagName().lowercase()
             return if (tagName == "script" || tagName == "style") {
                 el.data()
             } else {
-                el.text()
+                el.wholeText()
             }
         }
         return when (val el = elementCache[handle]) {
-            is Document -> el.text()
+            is Document -> el.wholeText()
             is Element -> elementText(el)
-            is Elements -> {
-                if (el.size == 1) {
-                    elementText(el.first()!!)
-                } else {
-                    // For multi-element sets, concatenate text with spaces (Cheerio behavior)
-                    el.joinToString(" ") { elementText(it) }
-                }
-            }
+            is Elements -> el.joinToString("") { elementText(it) }
             else -> ""
         }
     }
@@ -769,14 +783,21 @@ class JSLibraryProvider(
         sb.append('[')
         elements.forEachIndexed { idx, elem ->
             if (idx > 0) sb.append(',')
-            appendDomNode(sb, elem)
+            // Live handle so $(node) from toArray() resolves back to the real element
+            val nodeHandle = ++handleCounter
+            elementCache[nodeHandle] = elem
+            appendDomNode(sb, elem, nodeHandle)
         }
         sb.append(']')
         return sb.toString()
     }
 
-    private fun appendDomNode(sb: StringBuilder, element: Element) {
-        sb.append("{\"type\":\"tag\",\"name\":")
+    private fun appendDomNode(sb: StringBuilder, element: Element, handle: Int? = null) {
+        sb.append("{\"type\":\"tag\",")
+        if (handle != null) {
+            sb.append("\"_h\":").append(handle).append(',')
+        }
+        sb.append("\"name\":")
         sb.append('"').append(escapeJsonString(element.tagName().lowercase())).append('"')
         sb.append(",\"attribs\":{")
         element.attributes().forEachIndexed { i, attr ->
@@ -870,6 +891,69 @@ class JSLibraryProvider(
             sb.append(escapeJsonString(attr.value)).append("\"")
         }
         sb.append("}")
+        return sb.toString()
+    }
+
+    private fun cheerioOuterHtml(handle: Int): String = when (val el = elementCache[handle]) {
+        is Element -> el.outerHtml()
+        is Elements -> el.firstOrNull()?.outerHtml() ?: ""
+        else -> ""
+    }
+
+    private fun cheerioTagName(handle: Int): String = when (val el = elementCache[handle]) {
+        is Element -> el.tagName().lowercase()
+        is Elements -> el.firstOrNull()?.tagName()?.lowercase() ?: ""
+        else -> ""
+    }
+
+    /**
+     * Child nodes of each element in the set, including text and comment nodes, as a JSON array
+     * of DOM-like nodes. Element nodes get a live `_h` handle so $(node) and $.html(node) resolve
+     * back to the real Jsoup element. Backs cheerio's contents().
+     */
+    private fun cheerioContents(handle: Int): String {
+        val el = elementCache[handle] ?: return "[]"
+        val elements = when (el) {
+            is Element -> listOf(el)
+            is Elements -> el.toList()
+            else -> emptyList()
+        }
+        val sb = StringBuilder("[")
+        var first = true
+        for (elem in elements) {
+            for (node in elem.childNodes()) {
+                val piece = StringBuilder()
+                when (node) {
+                    is TextNode -> {
+                        piece.append("{\"type\":\"text\",\"data\":\"")
+                        piece.append(escapeJsonString(node.wholeText))
+                        piece.append("\",\"children\":[]}")
+                    }
+                    is org.jsoup.nodes.Comment -> {
+                        piece.append("{\"type\":\"comment\",\"data\":\"")
+                        piece.append(escapeJsonString(node.data))
+                        piece.append("\",\"children\":[]}")
+                    }
+                    is org.jsoup.nodes.DataNode -> {
+                        piece.append("{\"type\":\"text\",\"data\":\"")
+                        piece.append(escapeJsonString(node.wholeData))
+                        piece.append("\",\"children\":[]}")
+                    }
+                    is Element -> {
+                        val nodeHandle = ++handleCounter
+                        elementCache[nodeHandle] = node
+                        appendDomNode(piece, node, nodeHandle)
+                    }
+                    else -> {}
+                }
+                if (piece.isNotEmpty()) {
+                    if (!first) sb.append(',')
+                    first = false
+                    sb.append(piece)
+                }
+            }
+        }
+        sb.append(']')
         return sb.toString()
     }
 
@@ -1225,7 +1309,8 @@ class JSLibraryProvider(
             var id = __timerSeq++;
             var args = Array.prototype.slice.call(arguments, 2);
             function tick() {
-                __delay(ms > 0 ? ms : 0).then(function() {
+                // Clamp like browsers; ms=0 would recurse with no delay and starve the job queue
+                __delay(ms >= 4 ? ms : 4).then(function() {
                     if (__cancelledTimers[id]) { delete __cancelledTimers[id]; return; }
                     try { cb.apply(null, args); } catch (e) { console.error('setInterval callback: ' + e); }
                     tick();
@@ -1407,13 +1492,51 @@ class JSLibraryProvider(
         globalThis.Blob = Blob;
 
         // Cheerio wrapper - minimal JS, logic in Kotlin
+
+        // DOM-node-like shim for $(sel)[i] / toArray() interop, backed by a live handle
+        function __nodeAt(h, idx) {
+            var eh = __cheerioEq(h, idx);
+            if (eh < 0) return undefined;
+            var node = { _h: eh, type: 'tag' };
+            Object.defineProperty(node, 'name', {
+                get: function() { return __cheerioTagName(eh); },
+                enumerable: false, configurable: true
+            });
+            Object.defineProperty(node, 'attribs', {
+                get: function() { try { return JSON.parse(__cheerioGetAttrs(eh)); } catch (e) { return {}; } },
+                enumerable: false, configurable: true
+            });
+            return node;
+        }
+
+        // Serialize a plain DOM-tree JSON node (no live handle) back to HTML
+        function __domNodeHtml(node) {
+            if (!node) return '';
+            if (node.type === 'text') return node.data || '';
+            if (node.type === 'comment') return '';
+            if (node.type === 'tag') {
+                var attrs = '';
+                if (node.attribs) {
+                    for (var k in node.attribs) {
+                        attrs += ' ' + k + '="' + String(node.attribs[k]).replace(/"/g, '&quot;') + '"';
+                    }
+                }
+                var inner = '';
+                if (node.children) {
+                    for (var i = 0; i < node.children.length; i++) inner += __domNodeHtml(node.children[i]);
+                }
+                return '<' + node.name + attrs + '>' + inner + '</' + node.name + '>';
+            }
+            return '';
+        }
+
         function __wrapHandle(h) {
             if (h < 0) return __emptySelection();
-            return {
+            var obj = {
                 _h: h,
                 find: function(s) {
-                    // If s is a wrapped cheerio object, return it directly
-                    if (s && s._h !== undefined) return s;
+                    // Wrapped cheerio object or DOM-node shim: resolve to a wrapper
+                    if (s && s._h !== undefined) return (typeof s.find === 'function') ? s : __wrapHandle(s._h);
                     var next = __wrapHandle(__cheerioSelect(h, typeof s === 'string' ? s : ''));
                     next._prev = this;
                     return next;
@@ -1497,7 +1620,12 @@ class JSLibraryProvider(
                 prop: function(n) { var v = __cheerioAttr(h, n); return v === null ? undefined : v; },
                 val: function() { var v = __cheerioAttr(h, 'value'); return v === null ? undefined : v; },
                 trim: function() { return (__cheerioText(h) || '').trim(); },
-                contents: function() { return this.children(''); },
+                contents: function() {
+                    // Real cheerio contents() includes text/comment nodes, not just elements
+                    var nodes;
+                    try { nodes = JSON.parse(__cheerioContents(h)); } catch (e) { nodes = []; }
+                    return __arrayToCheerio(nodes);
+                },
                 siblings: function(s) {
                     var p = this.parent();
                     return s ? p.children(s).not(this) : p.children().not(this);
@@ -1535,6 +1663,16 @@ class JSLibraryProvider(
                     return -1;
                 }
             };
+            // Numeric indexing parity: $(sel)[0] returns a DOM-node-like shim
+            var __len = __cheerioLength(h);
+            for (var __i = 0; __i < __len; __i++) (function(idx) {
+                Object.defineProperty(obj, idx, {
+                    get: function() { return __nodeAt(h, idx); },
+                    enumerable: false,
+                    configurable: true
+                });
+            })(__i);
+            return obj;
         }
 
         // Helper to convert array of cheerio objects back to cheerio-like object
@@ -1562,7 +1700,13 @@ class JSLibraryProvider(
                 first: function() { return arr[0] || __emptySelection(); },
                 last: function() { return arr[arr.length - 1] || __emptySelection(); },
                 each: function(cb) { arr.forEach(function(el, i) { cb.call(el, i, el); }); return this; },
-                map: function(cb) { return arr.map(function(el, i) { return cb.call(el, i, el); }); },
+                map: function(cb) {
+                    var results = arr.map(function(el, i) { return cb.call(el, i, el); });
+                    results.get = function(idx) { return typeof idx === 'undefined' ? results.slice() : results[idx]; };
+                    results.toArray = function() { return results.slice(); };
+                    results.text = function() { return results.join(''); };
+                    return results;
+                },
                 toArray: function() { return arr.slice(); },
                 get: function(i) { return typeof i === 'undefined' ? arr.slice() : arr[i]; },
                 parent: function() {
@@ -1604,7 +1748,8 @@ class JSLibraryProvider(
                     return arr.map(function(el) {
                         if (!el) return '';
                         if (typeof el.text === 'function') return el.text();
-                        if (typeof el.toString === 'function') return el.toString();
+                        if (el._h !== undefined) return __cheerioText(el._h);
+                        if (typeof el.data === 'string') return el.data;
                         return '';
                     }).join('');
                 },
@@ -1674,6 +1819,8 @@ class JSLibraryProvider(
                 empty: function() { arr.forEach(function(el) { if (el && el.empty) el.empty(); }); return this; },
                 wrap: function(content) { arr.forEach(function(el) { if (el && el.wrap) el.wrap(content); }); return this; }
             };
+            // Numeric indexing parity with __wrapHandle
+            for (var __i = 0; __i < arr.length; __i++) obj[__i] = arr[__i];
             return obj;
         }
 
@@ -1716,13 +1863,24 @@ class JSLibraryProvider(
                         load: function(html) {
                             var docId = __cheerioLoad(html);
                             var $ = function(arg1, arg2) {
-                                if (arg1 && arg1._h !== undefined) return arg1; // $(wrapper)
-                                if (arg2 && arg2._h !== undefined) return arg2.find(arg1); // $(selector, wrapper)
+                                if (arg1 && arg1._h !== undefined) {
+                                    // $(wrapper) or $(domNode) from toArray()/contents()/[i]
+                                    return (typeof arg1.find === 'function') ? arg1 : __wrapHandle(arg1._h);
+                                }
+                                if (arg2 && arg2._h !== undefined) {
+                                    var ctx = (typeof arg2.find === 'function') ? arg2 : __wrapHandle(arg2._h);
+                                    return ctx.find(arg1); // $(selector, context)
+                                }
                                 if (typeof arg1 === 'string') return __wrapHandle(__cheerioSelect(docId, arg1)); // $(selector)
-                                if (!arg1) return __wrapHandle(docId);
-                                return __emptySelection(); // Unknown arg type
+                                // cheerio: $(), $(undefined), $(null) = empty selection, never the document
+                                return __emptySelection();
                             };
-                            $.html = function() { return __cheerioHtml(docId); };
+                            $.html = function(el) {
+                                if (el === undefined || el === null) return __cheerioHtml(docId);
+                                if (el._h !== undefined) return __cheerioOuterHtml(el._h); // $.html(el) = outer HTML
+                                if (typeof el === 'object') return __domNodeHtml(el);
+                                return '';
+                            };
                             $.text = function() { return __cheerioText(docId); };
                             $.root = function() { return __wrapHandle(docId); };
                             return $;

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
@@ -77,6 +77,7 @@ class JSLibraryProvider(
     suspend fun setup(runtime: QuickJs) {
         setupLogging(runtime)
         setupFetch(runtime)
+        setupTimers(runtime)
         setupCrypto(runtime)
         setupCheerio(runtime)
         setupStorage(runtime)
@@ -204,6 +205,22 @@ class JSLibraryProvider(
             val result = doFetch(url, init)
             // Convert to JSON string for reliable JS parsing
             kotlinx.serialization.json.Json.encodeToString(result)
+        }
+    }
+
+    // ============ Timers ============
+
+    private suspend fun setupTimers(runtime: QuickJs) {
+        // Backs the JS setTimeout/setInterval polyfills. Capped so a long timer can't hold
+        // the evaluate() job queue past the executePluginMethod poll timeout.
+        runtime.asyncFunction("__delay") { args ->
+            val ms = (args.getOrNull(0) as? Number)?.toLong()
+                ?: args.getOrNull(0)?.toString()?.toDoubleOrNull()?.toLong()
+                ?: 0L
+            if (ms > 0) {
+                kotlinx.coroutines.delay(ms.coerceAtMost(MAX_TIMER_DELAY_MS))
+            }
+            true
         }
     }
 
@@ -1121,9 +1138,10 @@ class JSLibraryProvider(
     // ============ Cleanup ============
 
     fun cleanup() {
+        val cleared = elementCache.size
         elementCache.clear()
         handleCounter = 0
-        logcat(LogPriority.DEBUG) { "[$pluginId] JSLibraryProvider cleanup: cleared ${elementCache.size} cached elements" }
+        logcat(LogPriority.DEBUG) { "[$pluginId] JSLibraryProvider cleanup: cleared $cleared cached elements" }
     }
 
     /**
@@ -1186,6 +1204,44 @@ class JSLibraryProvider(
             return arr;
         };
 
+        // Timers backed by Kotlin __delay (QuickJS has no event-loop timers)
+        var __timerSeq = 1;
+        var __cancelledTimers = {};
+        function setTimeout(cb, ms) {
+            if (typeof cb !== 'function') return 0;
+            var id = __timerSeq++;
+            var args = Array.prototype.slice.call(arguments, 2);
+            __delay(ms > 0 ? ms : 0).then(function() {
+                var cancelled = __cancelledTimers[id];
+                delete __cancelledTimers[id];
+                if (cancelled) return;
+                try { cb.apply(null, args); } catch (e) { console.error('setTimeout callback: ' + e); }
+            });
+            return id;
+        }
+        function clearTimeout(id) { if (id) __cancelledTimers[id] = true; }
+        function setInterval(cb, ms) {
+            if (typeof cb !== 'function') return 0;
+            var id = __timerSeq++;
+            var args = Array.prototype.slice.call(arguments, 2);
+            function tick() {
+                __delay(ms > 0 ? ms : 0).then(function() {
+                    if (__cancelledTimers[id]) { delete __cancelledTimers[id]; return; }
+                    try { cb.apply(null, args); } catch (e) { console.error('setInterval callback: ' + e); }
+                    tick();
+                });
+            }
+            tick();
+            return id;
+        }
+        function clearInterval(id) { clearTimeout(id); }
+        function queueMicrotask(fn) { Promise.resolve().then(fn); }
+        globalThis.setTimeout = setTimeout;
+        globalThis.clearTimeout = clearTimeout;
+        globalThis.setInterval = setInterval;
+        globalThis.clearInterval = clearInterval;
+        globalThis.queueMicrotask = queueMicrotask;
+
         // TextDecoder polyfill for encoding support
         function TextDecoder(encoding) {
             this.encoding = (encoding || 'utf-8').toLowerCase();
@@ -1194,25 +1250,44 @@ class JSLibraryProvider(
             // For ArrayBuffer or Uint8Array
             var bytes = buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer;
             if (!bytes || !bytes.length) return '';
-            // Simple UTF-8 decoding
-            var result = '';
-            for (var i = 0; i < bytes.length; i++) {
-                result += String.fromCharCode(bytes[i]);
+            // UTF-8 decoding
+            var result = '', i = 0;
+            while (i < bytes.length) {
+                var b = bytes[i++], cp, extra;
+                if (b < 0x80) { cp = b; extra = 0; }
+                else if ((b & 0xE0) === 0xC0) { cp = b & 0x1F; extra = 1; }
+                else if ((b & 0xF0) === 0xE0) { cp = b & 0x0F; extra = 2; }
+                else if ((b & 0xF8) === 0xF0) { cp = b & 0x07; extra = 3; }
+                else { cp = 0xFFFD; extra = 0; }
+                while (extra-- > 0 && i < bytes.length) {
+                    cp = (cp << 6) | (bytes[i++] & 0x3F);
+                }
+                if (cp > 0xFFFF) {
+                    cp -= 0x10000;
+                    result += String.fromCharCode(0xD800 + (cp >> 10), 0xDC00 + (cp & 0x3FF));
+                } else {
+                    result += String.fromCharCode(cp);
+                }
             }
             return result;
         };
         globalThis.TextDecoder = TextDecoder;
 
-        // TextEncoder polyfill
+        // TextEncoder polyfill (UTF-8)
         function TextEncoder() {
             this.encoding = 'utf-8';
         }
         TextEncoder.prototype.encode = function(str) {
-            var arr = [];
+            var out = [];
             for (var i = 0; i < str.length; i++) {
-                arr.push(str.charCodeAt(i) & 0xff);
+                var cp = str.codePointAt(i);
+                if (cp > 0xFFFF) i++;
+                if (cp < 0x80) { out.push(cp); }
+                else if (cp < 0x800) { out.push(0xC0 | (cp >> 6), 0x80 | (cp & 63)); }
+                else if (cp < 0x10000) { out.push(0xE0 | (cp >> 12), 0x80 | ((cp >> 6) & 63), 0x80 | (cp & 63)); }
+                else { out.push(0xF0 | (cp >> 18), 0x80 | ((cp >> 12) & 63), 0x80 | ((cp >> 6) & 63), 0x80 | (cp & 63)); }
             }
-            return new Uint8Array(arr);
+            return new Uint8Array(out);
         };
         globalThis.TextEncoder = TextEncoder;
 
@@ -1421,10 +1496,6 @@ class JSLibraryProvider(
                 get: function(i) { return typeof i === 'undefined' ? this.toArray() : __wrapHandle(__cheerioEq(h, i)); },
                 prop: function(n) { var v = __cheerioAttr(h, n); return v === null ? undefined : v; },
                 val: function() { var v = __cheerioAttr(h, 'value'); return v === null ? undefined : v; },
-                parent: function() { return __wrapHandle(__cheerioParent(h)); },
-                children: function(s) { return __wrapHandle(__cheerioChildren(h, s || '')); },
-                next: function() { return __wrapHandle(__cheerioNext(h)); },
-                prev: function() { return __wrapHandle(__cheerioPrev(h)); },
                 trim: function() { return (__cheerioText(h) || '').trim(); },
                 contents: function() { return this.children(''); },
                 siblings: function(s) {
@@ -2261,6 +2332,10 @@ class JSLibraryProvider(
     """.trimIndent()
 
     companion object {
+        // Longest single setTimeout/setInterval delay honored. Keeps a stray long timer from
+        // blocking evaluate() job-draining longer than the 30s executePluginMethod poll window.
+        private const val MAX_TIMER_DELAY_MS = 15_000L
+
         // Real-cheerio bundle string, read from assets once and reused across plugin runtimes.
         @Volatile
         private var cachedCheerioBundle: String? = null

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -313,7 +313,7 @@ class JsSource(
                     """.trimIndent(),
                 )
             }
-            logcat(LogPriority.DEBUG) { "JsSource[$pluginId]: Executing: $methodCall" }
+            logcat(LogPriority.INFO) { "JsSource[$pluginId]: Executing: $methodCall" }
 
             // Store result in global variable, handle Promise resolution in JS
             instance.execute(
@@ -383,7 +383,7 @@ class JsSource(
                 throw Exception("Plugin error while executing [$methodCall]: $error")
             }
 
-            logcat(LogPriority.DEBUG) { "JsSource[$pluginId]: Result: ${jsonResult?.take(200)}" }
+            logcat(LogPriority.INFO) { "JsSource[$pluginId]: Result: ${jsonResult?.take(200)}" }
             return jsonResult ?: "null"
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "JsSource[$pluginId]: Error executing: $methodCall" }

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -71,21 +71,20 @@ class JsSource(
     private val instanceMutex = kotlinx.coroutines.sync.Mutex()
     private var lastUsed = System.currentTimeMillis()
 
-    // Kept (unlike the removed details cache) because the chapter list may aggregate
-    // parseNovel + N parsePage calls; re-deriving it would refetch every page.
+    // Chapter list may aggregate parseNovel + N parsePage calls; re-deriving it would refetch every page.
     private val chaptersCache = java.util.concurrent.ConcurrentHashMap<String, Pair<List<SChapter>, Long>>()
-    private val cacheTimeout = 300_000L // 5 minutes
 
-    // The Source API forces separate getMangaDetails/getChapterList calls, but both map to one
-    // plugin.parseNovel; likewise parseChapter serves the reader and the translation/download
-    // paths. One fetch per path serves all consumers; the mutex makes concurrent callers share it.
+    // Short so a manual details/chapter-list refresh actually refetches.
+    private val cacheTimeout = 60_000L
+
+    // getMangaDetails and getChapterList both map to one plugin.parseNovel; parseChapter serves
+    // reader, translation and download paths. Mutex makes concurrent callers share one fetch.
     private val parseNovelCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
     private val parseNovelMutex = kotlinx.coroutines.sync.Mutex()
     private val chapterTextCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
     private val chapterTextMutex = kotlinx.coroutines.sync.Mutex()
 
-    // Holds the result of an inferHasNextPage probe so the user actually paging forward
-    // reuses it instead of refetching the same page.
+    // inferHasNextPage probe result, reused when the user pages forward.
     private val browseProbeCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
 
     // Raw JSON of plugin.filters / plugin.pluginSettings. Static per plugin version; caching it
@@ -181,10 +180,8 @@ class JsSource(
     private suspend fun getOrCreateInstance(): eu.kanade.tachiyomi.jsplugin.runtime.PluginInstance = withContext(
         jsDispatcher,
     ) {
-        // Mutex serializes the whole check-create-assign so concurrent callers can't
-        // both build a runtime while one is suspended in executePlugin(). All reads/writes
-        // of cachedInstance additionally go through instanceLock so invalidateInstance()
-        // (callable from any thread) stays mutually exclusive with them.
+        // instanceMutex serializes check-create-assign; instanceLock additionally guards
+        // cachedInstance so invalidateInstance (any thread) can't race these accesses.
         instanceMutex.withLock {
             val now = System.currentTimeMillis()
             val existing = synchronized(instanceLock) {
@@ -247,8 +244,7 @@ class JsSource(
 
     /**
      * Close the cached QuickJS runtime to free native memory without killing the executor.
-     * Safe while the source may still be referenced (e.g. an open screen after a plugin
-     * update replaced it) — the next call simply recreates the runtime.
+     * Safe while the source may still be referenced; the next call recreates the runtime.
      */
     suspend fun releaseRuntime() = withContext(jsDispatcher) {
         invalidateInstance()
@@ -284,8 +280,7 @@ class JsSource(
             executePluginMethodAttempt(methodCall)
         } catch (e: Exception) {
             // The runtime can be closed under an in-flight call (releaseRuntime after a plugin
-            // update, instance timeout). The attempt already invalidated it — retry once on a
-            // fresh runtime instead of surfacing the error.
+            // update, instance timeout); the attempt already invalidated it, so retry once.
             if (e.message.orEmpty().contains("context is destroyed", ignoreCase = true)) {
                 logcat(LogPriority.WARN) { "JsSource[$pluginId]: runtime closed mid-call, retrying: $methodCall" }
                 executePluginMethodAttempt(methodCall)
@@ -681,17 +676,14 @@ class JsSource(
             logcat(LogPriority.ERROR) { "[$id] getPageList: chapter.url is blank, cannot parse chapter" }
             return emptyList()
         }
-        // A novel chapter is always a single page; no network here. The one fetch happens in
-        // fetchPageText, which every consumer (reader, translator, downloader, EPUB export)
-        // goes through — parseChapterCached then dedupes them onto the same result.
+        // A novel chapter is always one page; the single fetch happens in fetchPageText.
         return listOf(Page(0, chapter.url, ""))
     }
 
     override fun getFilterList(): FilterList {
         return try {
-            // The interface is synchronous, so the first call must runBlocking into JS.
-            // Cache the raw JSON (static per plugin version) and re-parse per call —
-            // Filter instances are stateful and must stay fresh per invocation.
+            // Synchronous interface, so the first call must runBlocking into JS. Cache the raw
+            // JSON but re-parse per call; Filter instances are stateful.
             val result = filtersJsonCache
                 ?: runBlocking { executePluginMethod("plugin.filters || {}") }
                     .also { filtersJsonCache = it }
@@ -843,7 +835,7 @@ class JsSource(
         }
     }
 
-    /** Keep raw caches small — chapter HTML payloads can be large. */
+    /** Keep raw caches small; chapter HTML payloads can be large. */
     private fun trimRawCache(cache: java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>) {
         val maxEntries = 8
         if (cache.size <= maxEntries) return

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -21,6 +21,7 @@ import eu.kanade.tachiyomi.util.lang.normalizeHtmlDescription
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -67,15 +68,34 @@ class JsSource(
     // Cached runtime instance to avoid recreating for every method call
     @Volatile private var cachedInstance: eu.kanade.tachiyomi.jsplugin.runtime.PluginInstance? = null
     private val instanceLock = Any()
+    private val instanceMutex = kotlinx.coroutines.sync.Mutex()
     private var lastUsed = System.currentTimeMillis()
 
-    // Cache manga details and chapters to prevent re-fetching
-    private val detailsCache = java.util.concurrent.ConcurrentHashMap<String, Pair<SManga, Long>>()
+    // Kept (unlike the removed details cache) because the chapter list may aggregate
+    // parseNovel + N parsePage calls; re-deriving it would refetch every page.
     private val chaptersCache = java.util.concurrent.ConcurrentHashMap<String, Pair<List<SChapter>, Long>>()
     private val cacheTimeout = 300_000L // 5 minutes
 
+    // The Source API forces separate getMangaDetails/getChapterList calls, but both map to one
+    // plugin.parseNovel; likewise parseChapter serves the reader and the translation/download
+    // paths. One fetch per path serves all consumers; the mutex makes concurrent callers share it.
+    private val parseNovelCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
+    private val parseNovelMutex = kotlinx.coroutines.sync.Mutex()
+    private val chapterTextCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
+    private val chapterTextMutex = kotlinx.coroutines.sync.Mutex()
+
+    // Holds the result of an inferHasNextPage probe so the user actually paging forward
+    // reuses it instead of refetching the same page.
+    private val browseProbeCache = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
+
+    // Raw JSON of plugin.filters / plugin.pluginSettings. Static per plugin version; caching it
+    // limits the runBlocking JS execution in getFilterList/setupPreferenceScreen to the first call.
+    @Volatile private var filtersJsonCache: String? = null
+    @Volatile private var pluginSettingsJsonCache: String? = null
+
     companion object {
         private const val INSTANCE_TIMEOUT_MS = 60_000L // 1 minute timeout
+        private const val BROWSE_PROBE_TTL_MS = 60_000L
 
         private val HTML_TAG_REGEX = Regex(
             "<(?:p|div|br|span|h[1-6]|ul|ol|li|a|img|table|blockquote|strong|em|b|i|code)\\b",
@@ -161,68 +181,77 @@ class JsSource(
     private suspend fun getOrCreateInstance(): eu.kanade.tachiyomi.jsplugin.runtime.PluginInstance = withContext(
         jsDispatcher,
     ) {
-        synchronized(instanceLock) {
+        // Mutex serializes the whole check-create-assign so concurrent callers can't
+        // both build a runtime while one is suspended in executePlugin(). All reads/writes
+        // of cachedInstance additionally go through instanceLock so invalidateInstance()
+        // (callable from any thread) stays mutually exclusive with them.
+        instanceMutex.withLock {
             val now = System.currentTimeMillis()
-            val existing = cachedInstance
-
-            // Return existing instance if still valid
-            if (existing != null && (now - lastUsed) < INSTANCE_TIMEOUT_MS) {
-                lastUsed = now
-                return@withContext existing
-            }
-
-            // Close old instance if timed out
-            existing?.close()
-            cachedInstance = null
-        }
-
-        // Create new instance outside lock to avoid blocking
-        val codeToUse = jsCode
-        val runtime = PluginRuntime(pluginId, context, jsDispatcher, baseUrl)
-        val newInstance = try {
-            runtime.executePlugin(codeToUse)
-        } catch (e: Exception) {
-            // If plugin execution fails, log and rethrow
-            logcat(LogPriority.ERROR, e) { "JsSource[$pluginId]: Failed to execute plugin" }
-            throw e
-        }
-
-        if (!siteOverride.isNullOrBlank()) {
-            val escapedSiteOverride = siteOverride
-                .replace("\\", "\\\\")
-                .replace("'", "\\'")
-            newInstance.execute(
-                """
-                if (globalThis.plugin) {
-                    globalThis.plugin.site = '$escapedSiteOverride';
-                    globalThis.plugin.sourceSite = globalThis.plugin.site;
+            val existing = synchronized(instanceLock) {
+                val current = cachedInstance
+                when {
+                    current == null -> null
+                    (now - lastUsed) < INSTANCE_TIMEOUT_MS -> {
+                        lastUsed = now
+                        current
+                    }
+                    else -> {
+                        runCatching { current.close() }
+                        cachedInstance = null
+                        null
+                    }
                 }
-                """.trimIndent(),
-            )
-        }
+            }
+            if (existing != null) return@withLock existing
 
-        synchronized(instanceLock) {
-            // Double-check: another thread might have created one
-            val existing = cachedInstance
-            if (existing != null) {
-                newInstance.close()
-                lastUsed = System.currentTimeMillis()
-                return@withContext existing
+            val runtime = PluginRuntime(pluginId, context, jsDispatcher, baseUrl)
+            val newInstance = try {
+                runtime.executePlugin(jsCode)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "JsSource[$pluginId]: Failed to execute plugin" }
+                throw e
             }
 
-            cachedInstance = newInstance
+            if (!siteOverride.isNullOrBlank()) {
+                val escapedSiteOverride = escapeJsString(siteOverride)
+                newInstance.execute(
+                    """
+                    if (globalThis.plugin) {
+                        globalThis.plugin.site = '$escapedSiteOverride';
+                        globalThis.plugin.sourceSite = globalThis.plugin.site;
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            synchronized(instanceLock) {
+                lastUsed = System.currentTimeMillis()
+                cachedInstance = newInstance
+            }
             newInstance
         }
     }
 
     /**
      * Invalidate the cached instance (call on errors).
+     * [expected] guards against closing a runtime that was already replaced: a failing call
+     * holding an old instance must not kill the fresh one a concurrent caller created.
      */
-    private fun invalidateInstance() {
+    private fun invalidateInstance(expected: eu.kanade.tachiyomi.jsplugin.runtime.PluginInstance? = null) {
         synchronized(instanceLock) {
-            cachedInstance?.close()
+            if (expected != null && cachedInstance !== expected) return
+            runCatching { cachedInstance?.close() }
             cachedInstance = null
         }
+    }
+
+    /**
+     * Close the cached QuickJS runtime to free native memory without killing the executor.
+     * Safe while the source may still be referenced (e.g. an open screen after a plugin
+     * update replaced it) — the next call simply recreates the runtime.
+     */
+    suspend fun releaseRuntime() = withContext(jsDispatcher) {
+        invalidateInstance()
     }
 
     /**
@@ -237,6 +266,11 @@ class JsSource(
         return JsSource(installedPlugin, site)
     }
 
+    /** True when this source was built from the same plugin version and code. */
+    fun isSamePlugin(other: InstalledJsPlugin): Boolean =
+        installedPlugin.installedVersion == other.installedVersion &&
+            installedPlugin.code == other.code
+
     /**
      * Execute a plugin method and return JSON result.
      * All JS execution happens on jsDispatcher to ensure JNI environment is consistent.
@@ -246,6 +280,22 @@ class JsSource(
      * We use a global variable approach to store the result after Promise resolution.
      */
     private suspend fun executePluginMethod(methodCall: String): String = withContext(jsDispatcher) {
+        try {
+            executePluginMethodAttempt(methodCall)
+        } catch (e: Exception) {
+            // The runtime can be closed under an in-flight call (releaseRuntime after a plugin
+            // update, instance timeout). The attempt already invalidated it — retry once on a
+            // fresh runtime instead of surfacing the error.
+            if (e.message.orEmpty().contains("context is destroyed", ignoreCase = true)) {
+                logcat(LogPriority.WARN) { "JsSource[$pluginId]: runtime closed mid-call, retrying: $methodCall" }
+                executePluginMethodAttempt(methodCall)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private suspend fun executePluginMethodAttempt(methodCall: String): String {
         val instance = try {
             getOrCreateInstance()
         } catch (e: Exception) {
@@ -256,8 +306,7 @@ class JsSource(
         val token = "tsundoku_${System.nanoTime()}"
         val escapedSiteOverride = siteOverride
             ?.takeIf { it.isNotBlank() }
-            ?.replace("\\", "\\\\")
-            ?.replace("'", "\\'")
+            ?.let { escapeJsString(it) }
         try {
             if (escapedSiteOverride != null) {
                 instance.execute(
@@ -340,18 +389,32 @@ class JsSource(
             }
 
             logcat(LogPriority.DEBUG) { "JsSource[$pluginId]: Result: ${jsonResult?.take(200)}" }
-            jsonResult ?: "null"
+            return jsonResult ?: "null"
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "JsSource[$pluginId]: Error executing: $methodCall" }
-            // Invalidate on SyntaxError or critical errors
+            // Invalidate on critical errors so the dead runtime isn't reused
             val message = e.message.orEmpty()
             if (message.contains("SyntaxError", ignoreCase = true) ||
-                message.contains("vm is not cached", ignoreCase = true)
+                message.contains("vm is not cached", ignoreCase = true) ||
+                message.contains("context is destroyed", ignoreCase = true)
             ) {
-                invalidateInstance()
+                invalidateInstance(expected = instance)
             }
             throw e
         }
+    }
+
+    /**
+     * Execute a browse method call, consuming a matching inferHasNextPage probe result if one
+     * is pending so paging forward doesn't refetch the page the probe already pulled.
+     */
+    private suspend fun executeBrowseMethod(methodCall: String): String {
+        browseProbeCache.remove(methodCall)?.let { (cached, ts) ->
+            if (System.currentTimeMillis() - ts < BROWSE_PROBE_TTL_MS) {
+                return cached
+            }
+        }
+        return executePluginMethod(methodCall)
     }
 
     // CatalogueSource implementation
@@ -359,7 +422,7 @@ class JsSource(
     override suspend fun getPopularManga(page: Int): MangasPage = withContext(Dispatchers.IO) {
         try {
             val currentResult =
-                executePluginMethod("plugin.popularNovels($page, { showLatestNovels: false, filters: plugin.filters })")
+                executeBrowseMethod("plugin.popularNovels($page, { showLatestNovels: false, filters: plugin.filters })")
             val parsed = parseMangasPage(currentResult, page)
             inferHasNextPage(
                 currentPage = page,
@@ -377,7 +440,7 @@ class JsSource(
     override suspend fun getLatestUpdates(page: Int): MangasPage = withContext(Dispatchers.IO) {
         try {
             val currentResult =
-                executePluginMethod("plugin.popularNovels($page, { showLatestNovels: true, filters: plugin.filters })")
+                executeBrowseMethod("plugin.popularNovels($page, { showLatestNovels: true, filters: plugin.filters })")
             val parsed = parseMangasPage(currentResult, page)
             inferHasNextPage(
                 currentPage = page,
@@ -396,7 +459,7 @@ class JsSource(
         Dispatchers.IO,
     ) {
         try {
-            val escapedQuery = query.replace("'", "\\'").replace("\"", "\\\"")
+            val escapedQuery = escapeJsString(query)
 
             // Determine if non-default filters are present
             val hasActiveFilters = filters.isNotEmpty() && filters.any { filter ->
@@ -414,7 +477,7 @@ class JsSource(
 
             if (query.isNotBlank()) {
                 // Use searchNovels for text search
-                val currentResult = executePluginMethod("plugin.searchNovels('$escapedQuery', $page)")
+                val currentResult = executeBrowseMethod("plugin.searchNovels('$escapedQuery', $page)")
                 val parsed = parseMangasPage(currentResult, page)
                 inferHasNextPage(
                     currentPage = page,
@@ -425,7 +488,7 @@ class JsSource(
                 // Use popularNovels with user-modified filters
                 val filtersJs = convertFiltersToJs(filters)
                 val currentResult =
-                    executePluginMethod("plugin.popularNovels($page, { showLatestNovels: false, filters: $filtersJs })")
+                    executeBrowseMethod("plugin.popularNovels($page, { showLatestNovels: false, filters: $filtersJs })")
                 val parsed = parseMangasPage(currentResult, page)
                 inferHasNextPage(
                     currentPage = page,
@@ -437,7 +500,7 @@ class JsSource(
             } else {
                 // Default to popular with plugin's original filters
                 val currentResult =
-                    executePluginMethod(
+                    executeBrowseMethod(
                         "plugin.popularNovels($page, { showLatestNovels: false, filters: plugin.filters })",
                     )
                 val parsed = parseMangasPage(currentResult, page)
@@ -536,20 +599,8 @@ class JsSource(
 
     override suspend fun getMangaDetails(manga: SManga): SManga = withContext(Dispatchers.IO) {
         try {
-            // Check cache first
-            val cached = detailsCache[manga.url]
-            val now = System.currentTimeMillis()
-            if (cached != null && (now - cached.second) < cacheTimeout) {
-                return@withContext cached.first
-            }
-
-            val path = normalizePluginPath(manga.url).replace("'", "\\'").replace("\"", "\\\"")
-            val result = executePluginMethod("plugin.parseNovel('$path')")
-            val details = parseNovelDetails(result, manga)
-
-            // Cache the result
-            detailsCache[manga.url] = details to now
-            details
+            // parseNovelCached dedupes the fetch with getChapterList; parsing the raw JSON is cheap.
+            parseNovelDetails(parseNovelCached(manga.url), manga)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Error in getMangaDetails for ${plugin.name}" }
             manga
@@ -565,8 +616,8 @@ class JsSource(
                 return@withContext cached.first
             }
 
-            val path = normalizePluginPath(manga.url).replace("'", "\\'").replace("\"", "\\\"")
-            val result = executePluginMethod("plugin.parseNovel('$path')")
+            val path = escapeJsString(normalizePluginPath(manga.url))
+            val result = parseNovelCached(manga.url)
             val chapters = parseChapterList(result).toMutableList()
 
             // Support paged chapter sources (like novelight, novelfire)
@@ -624,33 +675,27 @@ class JsSource(
         }
     }
 
-    override suspend fun getPageList(chapter: SChapter): List<Page> = withContext(Dispatchers.IO) {
-        try {
-            // Validate chapter URL is not empty/blank to avoid fetching base URL
-            if (chapter.url.isBlank()) {
-                logcat(LogPriority.ERROR) { "[$id] getPageList: chapter.url is blank, cannot parse chapter" }
-                return@withContext emptyList()
-            }
-            val path = normalizePluginPath(chapter.url).replace("'", "\\'").replace("\"", "\\\"")
-            val result = executePluginMethod("plugin.parseChapter('$path')")
-            listOf(Page(0, chapter.url, "").also { it.text = extractChapterText(result) })
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) {
-                "Error in getPageList for ${plugin.name}: chapter='${chapter.name}' url='${chapter.url}' " +
-                    "site='$baseUrl' cause='${e.message}'"
-            }
-            emptyList()
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        // Validate chapter URL is not empty/blank to avoid fetching base URL
+        if (chapter.url.isBlank()) {
+            logcat(LogPriority.ERROR) { "[$id] getPageList: chapter.url is blank, cannot parse chapter" }
+            return emptyList()
         }
+        // A novel chapter is always a single page; no network here. The one fetch happens in
+        // fetchPageText, which every consumer (reader, translator, downloader, EPUB export)
+        // goes through — parseChapterCached then dedupes them onto the same result.
+        return listOf(Page(0, chapter.url, ""))
     }
 
     override fun getFilterList(): FilterList {
         return try {
-            // getFilterList is synchronous in the interface, but we need to run suspend code.
-            // We use runBlocking here.
-            runBlocking {
-                val result = executePluginMethod("plugin.filters || {}")
-                parseFiltersFromJson(result)
-            }
+            // The interface is synchronous, so the first call must runBlocking into JS.
+            // Cache the raw JSON (static per plugin version) and re-parse per call —
+            // Filter instances are stateful and must stay fresh per invocation.
+            val result = filtersJsonCache
+                ?: runBlocking { executePluginMethod("plugin.filters || {}") }
+                    .also { filtersJsonCache = it }
+            parseFiltersFromJson(result)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Error getting filters for ${plugin.name}" }
             FilterList()
@@ -660,7 +705,9 @@ class JsSource(
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         // Read plugin's pluginSettings and create preferences backed by persistent storage
         try {
-            val result = runBlocking { executePluginMethod("JSON.stringify(plugin.pluginSettings || {})") }
+            val result = pluginSettingsJsonCache
+                ?: runBlocking { executePluginMethod("JSON.stringify(plugin.pluginSettings || {})") }
+                    .also { pluginSettingsJsonCache = it }
             val settingsJson = decodeJsonStringIfQuoted(result)
             if (settingsJson.isBlank() || settingsJson == "{}" || settingsJson == "null") return
 
@@ -766,6 +813,45 @@ class JsSource(
         }
     }
 
+    /** Escape a value for embedding in a single-quoted JS string literal. */
+    private fun escapeJsString(value: String): String =
+        value.replace("\\", "\\\\").replace("'", "\\'").replace("\"", "\\\"")
+
+    /** plugin.parseNovel with raw-result caching and in-flight dedup. */
+    private suspend fun parseNovelCached(mangaUrl: String): String {
+        val path = escapeJsString(normalizePluginPath(mangaUrl))
+        return parseNovelMutex.withLock {
+            val now = System.currentTimeMillis()
+            parseNovelCache[path]?.takeIf { (now - it.second) < cacheTimeout }?.let { return@withLock it.first }
+            val result = executePluginMethod("plugin.parseNovel('$path')")
+            parseNovelCache[path] = result to now
+            trimRawCache(parseNovelCache)
+            result
+        }
+    }
+
+    /** plugin.parseChapter with raw-result caching and in-flight dedup. */
+    private suspend fun parseChapterCached(chapterUrl: String): String {
+        val path = escapeJsString(normalizePluginPath(chapterUrl))
+        return chapterTextMutex.withLock {
+            val now = System.currentTimeMillis()
+            chapterTextCache[path]?.takeIf { (now - it.second) < cacheTimeout }?.let { return@withLock it.first }
+            val result = executePluginMethod("plugin.parseChapter('$path')")
+            chapterTextCache[path] = result to now
+            trimRawCache(chapterTextCache)
+            result
+        }
+    }
+
+    /** Keep raw caches small — chapter HTML payloads can be large. */
+    private fun trimRawCache(cache: java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>) {
+        val maxEntries = 8
+        if (cache.size <= maxEntries) return
+        cache.entries.sortedBy { it.value.second }
+            .take(cache.size - maxEntries)
+            .forEach { cache.remove(it.key) }
+    }
+
     // Parsing helpers
 
     private fun String.decodeEntities(): String {
@@ -839,7 +925,17 @@ class JsSource(
 
         val probePage = currentPage + 1
         return try {
-            val nextResult = executePluginMethod(methodCallForPage(probePage))
+            val probeCall = methodCallForPage(probePage)
+            val nextResult = executePluginMethod(probeCall)
+            // Save so paging to probePage serves this result instead of refetching it.
+            // Evict oldest under lock so a concurrent probe's fresh entry isn't wiped.
+            synchronized(browseProbeCache) {
+                while (browseProbeCache.size > 4) {
+                    val oldest = browseProbeCache.minByOrNull { it.value.second }?.key ?: break
+                    browseProbeCache.remove(oldest)
+                }
+                browseProbeCache[probeCall] = nextResult to System.currentTimeMillis()
+            }
             val nextParsed = parseMangasPage(nextResult, probePage)
             MangasPage(current.mangas, nextParsed.mangas.isNotEmpty())
         } catch (_: Exception) {
@@ -1265,13 +1361,12 @@ class JsSource(
             }
 
             // Validate URL before calling plugin - avoid fetching base URL with empty path
-            val chapterUrl = normalizePluginPath(page.url).replace("'", "\\'").replace("\"", "\\\"")
-            if (chapterUrl.isBlank()) {
+            if (normalizePluginPath(page.url).isBlank()) {
                 logcat(LogPriority.WARN) { "[$id] fetchPageText: page.url is blank, cannot parse chapter" }
                 return@withContext "Chapter content unavailable (empty URL)"
             }
 
-            val result = executePluginMethod("plugin.parseChapter('$chapterUrl')")
+            val result = parseChapterCached(page.url)
             extractChapterText(result)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Error fetching page text for ${plugin.name}" }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -73,9 +73,8 @@ internal class HttpPageLoader(
      */
     override suspend fun getPages(): List<ReaderPage> {
         val pages = if (source.isNovelSource()) {
-            // Novel getPageList is metadata-only (single page, no network); the text itself
-            // is fetched once in internalLoadPage via fetchNovelPageText. Skip the page-list
-            // cache — text is @Transient so cached entries carry nothing useful anyway.
+            // Novel getPageList is metadata-only; the text is fetched once in internalLoadPage.
+            // Skip the page-list cache, text is @Transient so cached entries are useless.
             source.getPageList(chapter.chapter)
         } else {
             try {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -73,9 +73,9 @@ internal class HttpPageLoader(
      */
     override suspend fun getPages(): List<ReaderPage> {
         val pages = if (source.isNovelSource()) {
-            // Novel page text is @Transient — not serializable — so the page-list
-            // cache always returns pages with text=null. Always fetch fresh so that
-            // internalLoadPage sees the text and can mark pages Ready immediately.
+            // Novel getPageList is metadata-only (single page, no network); the text itself
+            // is fetched once in internalLoadPage via fetchNovelPageText. Skip the page-list
+            // cache — text is @Transient so cached entries carry nothing useful anyway.
             source.getPageList(chapter.chapter)
         } else {
             try {

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -300,12 +300,9 @@ abstract class HttpSource : CatalogueSource {
      */
     @Suppress("DEPRECATION")
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        // Novel chapters are a single text page whose content is fetched once in
-        // fetchPageText. Every novel source's pageListParse just rebuilds
-        // Page(0, chapter.url) from the URL, so the page-list request would fetch
-        // the chapter page and throw the body away — skip the network entirely.
-        // Extensions load this class from the app at runtime, so this covers all
-        // installed novel extensions. Sources overriding getPageList are unaffected.
+        // Novel chapters are a single text page fetched once in fetchPageText; the page-list
+        // request would fetch the chapter page only for pageListParse to discard the body.
+        // Sources overriding getPageList are unaffected.
         if (isNovelSource()) {
             return listOf(Page(0, chapter.url))
         }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.newCachelessCallWithProgress
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -299,6 +300,15 @@ abstract class HttpSource : CatalogueSource {
      */
     @Suppress("DEPRECATION")
     override suspend fun getPageList(chapter: SChapter): List<Page> {
+        // Novel chapters are a single text page whose content is fetched once in
+        // fetchPageText. Every novel source's pageListParse just rebuilds
+        // Page(0, chapter.url) from the URL, so the page-list request would fetch
+        // the chapter page and throw the body away — skip the network entirely.
+        // Extensions load this class from the app at runtime, so this covers all
+        // installed novel extensions. Sources overriding getPageList are unaffected.
+        if (isNovelSource()) {
+            return listOf(Page(0, chapter.url))
+        }
         return fetchPageList(chapter).awaitSingle()
     }
 


### PR DESCRIPTION

- `setTimeout` / `setInterval` / `queueMicrotask` polyfills backed by a Kotlin `__delay` async function.
- Plugin install/update writes use delete-then-create instead of SAF `"w"`-mode, which does not truncate on all providers and corrupted updates that shrank the file.
- **Single chapter fetch** `getPageList` for novels is now metadata-only: a novel chapter is always exactly one page. saves network calls.
- `rebuildSources()` reuses `JsSource` instances whose plugin didn't change and releases only the replaced runtimes. previously every storage change recreated all sources and killed in-flight calls.