### PR TITLE
feat(browse): filter sources list by content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Webview constants refactor, also fixes (non-infinite) scroll having dividers - Changes that affect custom CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#209](https://github.com/tsundoku-otaku/tsundoku/pull/209)
 - Added support for missing wrap function for JS plugins, and native cheerio support [@mrissaoussama](https://github.com/mrissaoussama) [#239](https://github.com/tsundoku-otaku/tsundoku/pull/239)
 - Mass import chunks to avoid memory errors, has better caching and redundancy checking, improve UI [@mrissaoussama](https://github.com/mrissaoussama) [#214](https://github.com/tsundoku-otaku/tsundoku/pull/214)
+- Browse should properly filter manga and novel sources [@mrissaoussama](https://github.com/mrissaoussama) [#246](https://github.com/tsundoku-otaku/tsundoku/pull/246)
 
 
 ### Fix

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesTab.kt
@@ -43,7 +43,7 @@ fun Screen.novelSourcesTab(): TabContent {
             AppBar.Action(
                 title = stringResource(MR.strings.action_filter),
                 icon = Icons.Outlined.FilterList,
-                onClick = { navigator.push(SourcesFilterScreen()) },
+                onClick = { navigator.push(SourcesFilterScreen(isNovel = true)) },
             ),
             AppBar.Action(
                 title = "Custom Sources", // TODO: Add string resource

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesFilterScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesFilterScreen.kt
@@ -14,12 +14,14 @@ import eu.kanade.tachiyomi.util.system.toast
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.screens.LoadingScreen
 
-class SourcesFilterScreen : Screen() {
+class SourcesFilterScreen(
+    private val isNovel: Boolean = false,
+) : Screen() {
 
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
-        val screenModel = rememberScreenModel { SourcesFilterScreenModel() }
+        val screenModel = rememberScreenModel { SourcesFilterScreenModel(isNovel) }
         val state by screenModel.state.collectAsState()
 
         if (state is SourcesFilterScreenModel.State.Loading) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesFilterScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesFilterScreenModel.kt
@@ -18,6 +18,9 @@ import uy.kohesive.injekt.api.get
 import java.util.SortedMap
 
 class SourcesFilterScreenModel(
+    // The filter is opened from either the novel or the manga sources tab; show only that tab's
+    // sources instead of every online source regardless of which tab launched it.
+    private val isNovel: Boolean,
     private val preferences: SourcePreferences = Injekt.get(),
     private val getLanguagesWithSources: GetLanguagesWithSources = Injekt.get(),
     private val toggleSource: ToggleSource = Injekt.get(),
@@ -39,9 +42,15 @@ class SourcesFilterScreenModel(
                     }
                 }
                 .collectLatest { (languagesWithSources, enabledLanguages, disabledSources) ->
+                    // Keep the language ordering from the source map; drop the other content type.
+                    val filtered = java.util.TreeMap<String, List<Source>>(languagesWithSources.comparator())
+                    for ((language, sources) in languagesWithSources) {
+                        val matching = sources.filter { it.isNovelSource == isNovel }
+                        if (matching.isNotEmpty()) filtered[language] = matching
+                    }
                     mutableState.update {
                         State.Success(
-                            items = languagesWithSources,
+                            items = filtered,
                             enabledLanguages = enabledLanguages,
                             disabledSources = disabledSources,
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -41,7 +41,7 @@ fun Screen.sourcesTab(): TabContent {
             AppBar.Action(
                 title = stringResource(MR.strings.action_filter),
                 icon = Icons.Outlined.FilterList,
-                onClick = { navigator.push(SourcesFilterScreen()) },
+                onClick = { navigator.push(SourcesFilterScreen(isNovel = false)) },
             ),
         ),
         content = { contentPadding, snackbarHostState ->


### PR DESCRIPTION
SourcesFilterScreen opened from the novel tab previously listed every online source, including manga sources irrelevant to that tab (and vice versa). this pr fixes it