### PR TITLE
feat(library): parse search once, resolve metadata fields perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Novellist webview tracker login [@mrissaoussama](https://github.com/mrissaoussama) [#230](https://github.com/tsundoku-otaku/tsundoku/pull/230)
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)
 - Novel description screen now supports novel searches when tapping novel title [@mrissaoussama](https://github.com/mrissaoussama) [#207](https://github.com/tsundoku-otaku/tsundoku/pull/207)
+- Library search performance improved, removed redundant parsing [@mrissaoussama](https://github.com/mrissaoussama) [#247](https://github.com/tsundoku-otaku/tsundoku/pull/247)
 - Webview constants refactor, also fixes (non-infinite) scroll having dividers - Changes that affect custom CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#209](https://github.com/tsundoku-otaku/tsundoku/pull/209)
 - Added support for missing wrap function for JS plugins, and native cheerio support [@mrissaoussama](https://github.com/mrissaoussama) [#239](https://github.com/tsundoku-otaku/tsundoku/pull/239)
 - Mass import chunks to avoid memory errors, has better caching and redundancy checking, improve UI [@mrissaoussama](https://github.com/mrissaoussama) [#214](https://github.com/tsundoku-otaku/tsundoku/pull/214)

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -90,6 +90,7 @@ import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
 import tachiyomi.domain.manga.interactor.GetMangaWithChapters
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
+import tachiyomi.domain.manga.interactor.SearchMangaMetadata
 import tachiyomi.domain.manga.interactor.SetMangaChapterFlags
 import tachiyomi.domain.manga.interactor.UpdateMangaNotes
 import tachiyomi.domain.manga.repository.MangaRepository
@@ -131,6 +132,7 @@ class DomainModule : InjektModule {
         addSingletonFactory<MangaRepository> { MangaRepositoryImpl(get()) }
         addFactory { GetDuplicateLibraryManga(get()) }
         addFactory { FindDuplicateNovels(get()) }
+        addFactory { SearchMangaMetadata(get()) }
         addFactory { GetFavorites(get()) }
         addFactory { GetFavoritesEntry(get()) }
         // Singleton so all screens share the same cached SharedFlow for library queries

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -38,142 +38,70 @@ data class LibraryItem(
     }
 
     /**
-     * Checks if a query matches the manga
+     * Checks if a parsed query matches this manga.
      *
-     * @param constraint the query to check.
-     * @param chapterMatchIds optional set of manga IDs that have chapters matching the query.
-     *                        When provided, manga with matching chapters are included in results.
-     * @param searchByUrl whether to include URL in search.
-     * @param useRegex whether to use regex matching.
-     * @return true if the manga matches the query, false otherwise.
+     * Author/artist/description matches are resolved via [metadataMatchIds] and chapter-name
+     * matches via [chapterMatchIds] because those fields are not loaded into the in-memory
+     * library list (they'd add strings per favorite on a large library).
      */
     fun matches(
-        constraint: String,
+        spec: LibrarySearchSpec,
         chapterMatchIds: Set<Long> = emptySet(),
-        searchByUrl: Boolean = false,
-        useRegex: Boolean = false,
+        metadataMatchIds: LibraryScreenModel.MetadataMatchIds = LibraryScreenModel.MetadataMatchIds(),
     ): Boolean {
-        val regexCache = if (useRegex) HashMap<String, Regex?>(4) else null
-        val sourceName by lazy { sourceManager.getOrStub(libraryManga.manga.source).getNameForMangaInfo() }
-
-        // Special prefixes for searching specific fields
-        if (constraint.startsWith("id:", true)) {
-            val q = constraint.substring("id:".length).trim()
-            return id == q.toLongOrNull()
+        val manga = libraryManga.manga
+        return when (spec.field) {
+            LibrarySearchSpec.Field.ID -> id == spec.term.toLongOrNull()
+            LibrarySearchSpec.Field.TITLE -> matchField(manga.title, spec.term, spec.termRegex, spec.useRegex)
+            LibrarySearchSpec.Field.AUTHOR -> metadataMatchIds.author.contains(id)
+            LibrarySearchSpec.Field.ARTIST -> metadataMatchIds.artist.contains(id)
+            LibrarySearchSpec.Field.DESCRIPTION -> metadataMatchIds.description.contains(id)
+            LibrarySearchSpec.Field.TAG ->
+                manga.genre?.any { matchField(it, spec.term, spec.termRegex, spec.useRegex) } ?: false
+            LibrarySearchSpec.Field.SOURCE -> matchField(sourceName, spec.term, spec.termRegex, spec.useRegex)
+            LibrarySearchSpec.Field.URL -> matchField(manga.url, spec.term, spec.termRegex, spec.useRegex)
+            LibrarySearchSpec.Field.CHAPTER -> chapterMatchIds.contains(id)
+            LibrarySearchSpec.Field.DEFAULT -> matchesDefault(spec, chapterMatchIds, metadataMatchIds)
         }
-        if (constraint.startsWith("title:", true)) {
-            val query = constraint.substring("title:".length).trim()
-            return matchString(libraryManga.manga.title, query, useRegex, regexCache)
-        }
-        if (constraint.startsWith("author:", true)) {
-            val query = constraint.substring("author:".length).trim()
-            return libraryManga.manga.author?.let { matchString(it, query, useRegex, regexCache) } ?: false
-        }
-        if (constraint.startsWith("artist:", true)) {
-            val query = constraint.substring("artist:".length).trim()
-            return libraryManga.manga.artist?.let { matchString(it, query, useRegex, regexCache) } ?: false
-        }
-        if (constraint.startsWith("desc:", true) || constraint.startsWith("description:", true)) {
-            val query = if (constraint.startsWith("desc:", true)) {
-                constraint.substring("desc:".length).trim()
-            } else {
-                constraint.substring("description:".length).trim()
-            }
-            return libraryManga.manga.description?.let { matchString(it, query, useRegex, regexCache) } ?: false
-        }
-        if (constraint.startsWith("tag:", true) || constraint.startsWith("genre:", true)) {
-            val query = if (constraint.startsWith("tag:", true)) {
-                constraint.substring("tag:".length).trim()
-            } else {
-                constraint.substring("genre:".length).trim()
-            }
-            return libraryManga.manga.genre?.any { matchString(it, query, useRegex, regexCache) } ?: false
-        }
-        if (constraint.startsWith("source:", true)) {
-            val query = constraint.substring("source:".length).trim()
-            return matchString(sourceName, query, useRegex, regexCache)
-        }
-        if (constraint.startsWith("url:", true)) {
-            val query = constraint.substring("url:".length).trim()
-            return matchString(libraryManga.manga.url, query, useRegex, regexCache)
-        }
-        // Search for chapter names explicitly
-        if (constraint.startsWith("chapter:", true)) {
-            return chapterMatchIds.contains(id)
-        }
-
-        // Default: search title, author, artist, description, source, tags, URL (if enabled), and optionally chapters
-        val basicMatch = matchString(libraryManga.manga.title, constraint, useRegex, regexCache) ||
-            (libraryManga.manga.author?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
-            (libraryManga.manga.artist?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
-            (libraryManga.manga.description?.let { matchString(it, constraint, useRegex, regexCache) } ?: false) ||
-            (searchByUrl && matchString(libraryManga.manga.url, constraint, useRegex, regexCache)) ||
-            constraint.split(",").map { it.trim() }.all { subconstraint ->
-                checkNegatableConstraint(subconstraint) {
-                    matchString(sourceName, it, useRegex, regexCache) ||
-                        (
-                            libraryManga.manga.genre?.any { genre -> matchString(genre, it, useRegex, regexCache) }
-                                ?: false
-                            )
-                }
-            }
-
-        // Include chapter name matches if available
-        return basicMatch || chapterMatchIds.contains(id)
     }
 
-    /**
-     * Match a string against a query, optionally using regex.
-     */
-    private fun matchString(text: String, query: String, useRegex: Boolean): Boolean {
+    // Memoized: source resolution + name build is otherwise repeated per sub-term per item,
+    // which is wasteful when filtering a 200k library.
+    private val sourceName: String by lazy {
+        sourceManager.getOrStub(libraryManga.manga.source).getNameForMangaInfo()
+    }
+
+    private fun matchesDefault(
+        spec: LibrarySearchSpec,
+        chapterMatchIds: Set<Long>,
+        metadataMatchIds: LibraryScreenModel.MetadataMatchIds,
+    ): Boolean {
+        if (spec.subTerms.isEmpty()) return true
+        val manga = libraryManga.manga
+
+        // Every comma sub-term must match some in-memory field (negatable per sub-term). Author,
+        // artist and description aren't resident, so they're handled via the DB id-sets below.
+        val inMemoryMatch = spec.subTerms.all { sub ->
+            val hit = matchField(manga.title, sub.text, sub.regex, spec.useRegex) ||
+                (spec.searchByUrl && matchField(manga.url, sub.text, sub.regex, spec.useRegex)) ||
+                matchField(sourceName, sub.text, sub.regex, spec.useRegex) ||
+                (manga.genre?.any { matchField(it, sub.text, sub.regex, spec.useRegex) } ?: false)
+            if (sub.negate) !hit else hit
+        }
+        if (inMemoryMatch) return true
+
+        // Author/artist/description/chapter live in the DB; their id-sets cover the whole query.
+        return metadataMatchIds.author.contains(id) ||
+            metadataMatchIds.artist.contains(id) ||
+            metadataMatchIds.description.contains(id) ||
+            chapterMatchIds.contains(id)
+    }
+
+    private fun matchField(text: String, term: String, regex: Regex?, useRegex: Boolean): Boolean {
         return if (useRegex) {
-            try {
-                Regex(query, RegexOption.IGNORE_CASE).containsMatchIn(text)
-            } catch (e: Exception) {
-                // Invalid regex, fall back to simple contains
-                text.contains(query, ignoreCase = true)
-            }
+            regex?.containsMatchIn(text) ?: text.contains(term, ignoreCase = true)
         } else {
-            text.contains(query, ignoreCase = true)
-        }
-    }
-
-    private fun matchString(
-        text: String,
-        query: String,
-        useRegex: Boolean,
-        regexCache: MutableMap<String, Regex?>?,
-    ): Boolean {
-        return if (useRegex) {
-            val cachedRegex = regexCache?.getOrPut(query) {
-                try {
-                    Regex(query, RegexOption.IGNORE_CASE)
-                } catch (_: Exception) {
-                    null
-                }
-            }
-            cachedRegex?.containsMatchIn(text) ?: text.contains(query, ignoreCase = true)
-        } else {
-            text.contains(query, ignoreCase = true)
-        }
-    }
-
-    /**
-     * Checks a predicate on a negatable constraint. If the constraint starts with a minus character,
-     * the minus is stripped and the result of the predicate is inverted.
-     *
-     * @param constraint the argument to the predicate. Inverts the predicate if it starts with '-'.
-     * @param predicate the check to be run against the constraint.
-     * @return !predicate(x) if constraint = "-x", otherwise predicate(constraint)
-     */
-    private fun checkNegatableConstraint(
-        constraint: String,
-        predicate: (String) -> Boolean,
-    ): Boolean {
-        return if (constraint.startsWith("-")) {
-            !predicate(constraint.substringAfter("-").trimStart())
-        } else {
-            predicate(constraint)
+            text.contains(term, ignoreCase = true)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -77,6 +77,8 @@ import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.sort
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.SearchMangaMetadata
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.model.applyFilter
@@ -104,6 +106,8 @@ class LibraryScreenModel(
     private val updateManga: UpdateManga = Injekt.get(),
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val searchChapterNames: SearchChapterNames = Injekt.get(),
+    private val searchMangaMetadata: SearchMangaMetadata = Injekt.get(),
+    private val getManga: GetManga = Injekt.get(),
     private val preferences: BasePreferences = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val coverCache: CoverCache = Injekt.get(),
@@ -171,14 +175,62 @@ class LibraryScreenModel(
                 }
             }
 
-            // Combine search query with chapter match IDs
+            // Author/artist/description aren't loaded into the in-memory library list (they'd add
+            // strings per favorite on a 200k library), so resolve those matches by streaming the
+            // DB cursor. Author and artist are always searchable; description stays gated behind
+            // the content pref in default search.
+            val metadataMatchIdsFlow = combine(
+                searchQueryFlow,
+                libraryPreferences.searchChapterContent.changes(),
+                libraryPreferences.useRegexSearch.changes(),
+            ) { query, searchContent, useRegex ->
+                if (query.isNullOrEmpty()) {
+                    MetadataMatchIds()
+                } else {
+                    val parsed = LibrarySearchSpec.parse(query, useRegex, searchByUrl = false)
+                    suspend fun ids(
+                        author: Boolean = false,
+                        artist: Boolean = false,
+                        description: Boolean = false,
+                    ): MetadataMatchIds {
+                        val matches = withIOContext {
+                            searchMangaMetadata.await(
+                                term = parsed.term,
+                                regex = parsed.termRegex,
+                                searchAuthor = author,
+                                searchArtist = artist,
+                                searchDescription = description,
+                            )
+                        }
+                        return MetadataMatchIds(
+                            author = matches.author,
+                            artist = matches.artist,
+                            description = matches.description,
+                        )
+                    }
+                    when (parsed.field) {
+                        LibrarySearchSpec.Field.AUTHOR -> ids(author = true)
+                        LibrarySearchSpec.Field.ARTIST -> ids(artist = true)
+                        // Explicit desc:/description: prefix is an unambiguous request, so it runs
+                        // regardless of the content checkbox. The checkbox only gates description in
+                        // default (non-prefixed) search, where it adds an expensive full-text scan.
+                        LibrarySearchSpec.Field.DESCRIPTION -> ids(description = true)
+                        LibrarySearchSpec.Field.DEFAULT ->
+                            ids(author = true, artist = true, description = searchContent)
+                        else -> MetadataMatchIds()
+                    }
+                }
+            }
+
             val searchWithChapterMatchesFlow = combine(
                 searchQueryFlow,
                 chapterMatchIdsFlow,
+                metadataMatchIdsFlow,
                 libraryPreferences.searchByUrl.changes(),
                 libraryPreferences.useRegexSearch.changes(),
-            ) { query, chapterMatchIds, searchByUrl, useRegex ->
-                SearchConfig(query, chapterMatchIds, searchByUrl, useRegex)
+            ) { query, chapterMatchIds, metadataMatchIds, searchByUrl, useRegex ->
+                val spec = query?.let { LibrarySearchSpec.parse(it, useRegex, searchByUrl) }
+                SearchConfig(spec, chapterMatchIds, metadataMatchIds)
             }
 
             val filteredLibraryDataFlow = combine(
@@ -206,11 +258,12 @@ class LibraryScreenModel(
             }
 
             combine(filteredLibraryDataFlow, searchWithChapterMatchesFlow) { filteredData, searchConfig ->
-                val searchedFavorites = if (searchConfig.query == null) {
+                val spec = searchConfig.spec
+                val searchedFavorites = if (spec == null) {
                     filteredData.favorites
                 } else {
                     filteredData.favorites.fastFilter { manga ->
-                        manga.matches(searchConfig.query, searchConfig.chapterMatchIds, searchConfig.searchByUrl, searchConfig.useRegex)
+                        manga.matches(spec, searchConfig.chapterMatchIds, searchConfig.metadataMatchIds)
                     }
                 }
 
@@ -277,6 +330,8 @@ class LibraryScreenModel(
                 prefs.filterCompleted,
                 prefs.filterIntervalCustom,
                 prefs.filterNoTags,
+                prefs.filterNovel,
+                prefs.filterChapterCount,
                 *trackFilters.values.toTypedArray(),
             )
                 .any { it != TriState.DISABLED } ||
@@ -319,13 +374,19 @@ class LibraryScreenModel(
         val tagIncludeModeAnd = preferences.tagIncludeModeAnd
         val tagExcludeModeAnd = preferences.tagExcludeModeAnd
 
+        val downloadCounts = if (filterDownloaded != TriState.DISABLED) {
+            downloadManager.getDownloadCounts(map { it.libraryManga.manga })
+        } else {
+            emptyMap()
+        }
+
         val result = fastFilter {
             // Quick exit for some checks that are fast
             val downloadPasses = applyFilter(filterDownloaded) {
                 it.libraryManga.manga.isLocal() ||
                     it.libraryManga.manga.isLocalNovel() ||
                     it.downloadCount > 0 ||
-                    downloadManager.getDownloadCount(it.libraryManga.manga) > 0
+                    (downloadCounts[it.id] ?: 0) > 0
             }
             if (!downloadPasses) return@fastFilter false
 
@@ -638,6 +699,12 @@ class LibraryScreenModel(
                 itemCachePrefs = preferences
             }
 
+            val downloadCounts = if (preferences.downloadBadge) {
+                downloadManager.getDownloadCounts(libraryManga.map { it.manga })
+            } else {
+                emptyMap()
+            }
+
             val result = ArrayList<LibraryItem>(libraryManga.size)
             for (manga in libraryManga) {
                 // Filter by library type
@@ -651,7 +718,7 @@ class LibraryScreenModel(
                 val cachedRef = itemCacheMangaRef[manga.id]
 
                 val dlCount = if (preferences.downloadBadge) {
-                    downloadManager.getDownloadCount(manga.manga).toLong()
+                    (downloadCounts[manga.id] ?: 0).toLong()
                 } else {
                     0L
                 }
@@ -1267,6 +1334,10 @@ class LibraryScreenModel(
                             continue
                         }
 
+                        // The selected library Manga omits author/description (not kept resident);
+                        // fetch the full record so the EPUB metadata is complete.
+                        val exportManga = getManga.await(manga.id) ?: manga
+
                         val chapters = getChaptersByMangaId.await(manga.id)
                             .sortedBy { it.chapterNumber }
 
@@ -1408,7 +1479,7 @@ class LibraryScreenModel(
 
                         // Get cover image
                         val coverImage = try {
-                            manga.thumbnailUrl?.let { url ->
+                            exportManga.thumbnailUrl?.let { url ->
                                 val request = okhttp3.Request.Builder().url(url).build()
                                 networkHelper.client.newCall(request).execute().use { it.body.bytes() }
                             }
@@ -1418,11 +1489,11 @@ class LibraryScreenModel(
 
                         // Create EPUB metadata
                         val metadata = mihon.core.archive.EpubWriter.Metadata(
-                            title = manga.title,
-                            author = manga.author,
-                            description = manga.description,
+                            title = exportManga.title,
+                            author = exportManga.author,
+                            description = exportManga.description,
                             language = "en",
-                            genres = manga.genre ?: emptyList(),
+                            genres = exportManga.genre ?: emptyList(),
                             publisher = source.name,
                         )
 
@@ -1677,10 +1748,16 @@ class LibraryScreenModel(
      * Configuration for library search.
      */
     private data class SearchConfig(
-        val query: String?,
+        val spec: LibrarySearchSpec?,
         val chapterMatchIds: Set<Long>,
-        val searchByUrl: Boolean,
-        val useRegex: Boolean,
+        val metadataMatchIds: MetadataMatchIds,
+    )
+
+    /** DB-resolved match id-sets for fields not held in the in-memory library list. */
+    data class MetadataMatchIds(
+        val author: Set<Long> = emptySet(),
+        val artist: Set<Long> = emptySet(),
+        val description: Set<Long> = emptySet(),
     )
 
     @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySearchSpec.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySearchSpec.kt
@@ -1,0 +1,64 @@
+package eu.kanade.tachiyomi.ui.library
+
+/**
+ * A library search query parsed once per search rather than once per item. Holds the
+ * resolved field, the comma-split negatable sub-terms, and any compiled regex so that
+ * matching 200k items does not recompile the pattern or re-parse the query each time.
+ */
+class LibrarySearchSpec private constructor(
+    val field: Field,
+    val term: String,
+    val termRegex: Regex?,
+    val subTerms: List<SubTerm>,
+    val useRegex: Boolean,
+    val searchByUrl: Boolean,
+) {
+    enum class Field { ID, TITLE, AUTHOR, ARTIST, DESCRIPTION, TAG, SOURCE, URL, CHAPTER, DEFAULT }
+
+    class SubTerm(val text: String, val negate: Boolean, val regex: Regex?)
+
+    companion object {
+        private val PREFIXES: List<Pair<String, Field>> = listOf(
+            "id:" to Field.ID,
+            "title:" to Field.TITLE,
+            "author:" to Field.AUTHOR,
+            "artist:" to Field.ARTIST,
+            "description:" to Field.DESCRIPTION,
+            "desc:" to Field.DESCRIPTION,
+            "tag:" to Field.TAG,
+            "genre:" to Field.TAG,
+            "source:" to Field.SOURCE,
+            "url:" to Field.URL,
+            "chapter:" to Field.CHAPTER,
+        )
+
+        private fun compile(query: String, useRegex: Boolean): Regex? =
+            if (useRegex && query.isNotEmpty()) {
+                try {
+                    Regex(query, RegexOption.IGNORE_CASE)
+                } catch (_: Exception) {
+                    null
+                }
+            } else {
+                null
+            }
+
+        fun parse(query: String, useRegex: Boolean, searchByUrl: Boolean): LibrarySearchSpec {
+            for ((prefix, field) in PREFIXES) {
+                if (query.startsWith(prefix, ignoreCase = true)) {
+                    val term = query.substring(prefix.length).trim()
+                    return LibrarySearchSpec(field, term, compile(term, useRegex), emptyList(), useRegex, searchByUrl)
+                }
+            }
+            val subTerms = query.split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .map { raw ->
+                    val negate = raw.startsWith("-")
+                    val text = if (negate) raw.substring(1).trimStart() else raw
+                    SubTerm(text, negate, compile(text, useRegex))
+                }
+            return LibrarySearchSpec(Field.DEFAULT, query, compile(query, useRegex), subTerms, useRegex, searchByUrl)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -289,55 +289,30 @@ class LibrarySettingsScreenModel(
                     }
                 }
 
-                // Load from DB with source IDs for filtering by content type
-                logcat(LogPriority.INFO) { "LibrarySettingsScreenModel: Loading tags from database (lightweight query with source filtering)..." }
-                val genresList = getLibraryManga.awaitGenresWithSource()
-                logcat(LogPriority.DEBUG) { "LibrarySettingsScreenModel: Got ${genresList.size} manga from library" }
+                // Aggregate tag counts in the DB layer (folds the cursor) instead of loading every
+                // favorite's genres into memory at once — the old full-list load could OOM a large
+                // library, especially while a mass import already had the heap under pressure.
+                logcat(LogPriority.INFO) { "LibrarySettingsScreenModel: Loading tags from database (streaming aggregation)..." }
+                // Classify via getOrStub so favorites from uninstalled extensions keep their DB
+                // is_novel flag; getCatalogueSources() only sees loaded sources.
+                val novelSourceIds = getLibraryManga.awaitSourceIds()
+                    .filter { sourceManager.getOrStub(it).isNovelSource() }
+                    .toSet()
+                val wantNovel = when (type) {
+                    LibraryScreenModel.LibraryType.All -> null
+                    LibraryScreenModel.LibraryType.Manga -> false
+                    LibraryScreenModel.LibraryType.Novel -> true
+                }
+                val (rawCounts, noTagsCount) = getLibraryManga.awaitGenreTagCounts(novelSourceIds, wantNovel)
 
-                // Calculate tag counts, filtering by type
+                // Merge raw tags into their normalized (title-cased) form. Operates on the small
+                // distinct-tag map, not the full library.
                 val tagCounts = mutableMapOf<String, Int>()
-                var noTagsCount = 0
                 val tagCache = mutableMapOf<String, String>()
-
-                genresList.forEach { (_, sourceId, genres) ->
-                    // Filter by content type
-                    val source = sourceManager.getOrStub(sourceId)
-                    val isNovel = source.isNovelSource()
-                    val shouldInclude = when (type) {
-                        LibraryScreenModel.LibraryType.All -> true
-                        LibraryScreenModel.LibraryType.Manga -> !isNovel
-                        LibraryScreenModel.LibraryType.Novel -> isNovel
-                    }
-
-                    if (shouldInclude) {
-                        if (genres.isNullOrEmpty()) {
-                            noTagsCount++
-                        } else {
-                            genres.forEach { rawTag ->
-                                val tag = rawTag.trim()
-                                val normalizedTag = tagCache.getOrPut(tag) {
-                                    val lowered = tag.lowercase()
-                                    val result = java.lang.StringBuilder(lowered.length)
-                                    var capitalizeNext = true
-                                    for (i in lowered.indices) {
-                                        val c = lowered[i]
-                                        if (c.isWhitespace()) {
-                                            capitalizeNext = true
-                                            result.append(c)
-                                        } else if (capitalizeNext) {
-                                            result.append(c.titlecaseChar())
-                                            capitalizeNext = false
-                                        } else {
-                                            result.append(c)
-                                        }
-                                    }
-                                    result.toString()
-                                }
-                                if (normalizedTag.isNotBlank()) {
-                                    tagCounts[normalizedTag] = (tagCounts[normalizedTag] ?: 0) + 1
-                                }
-                            }
-                        }
+                for ((rawTag, count) in rawCounts) {
+                    val normalizedTag = tagCache.getOrPut(rawTag) { normalizeTag(rawTag) }
+                    if (normalizedTag.isNotBlank()) {
+                        tagCounts[normalizedTag] = (tagCounts[normalizedTag] ?: 0) + count
                     }
                 }
 
@@ -362,5 +337,24 @@ class LibrarySettingsScreenModel(
                 _isLoading.value = false
             }
         }
+    }
+
+    /** Title-case a raw genre tag for display ("dark fantasy" -> "Dark Fantasy"). */
+    private fun normalizeTag(tag: String): String {
+        val lowered = tag.lowercase()
+        val result = StringBuilder(lowered.length)
+        var capitalizeNext = true
+        for (c in lowered) {
+            if (c.isWhitespace()) {
+                capitalizeNext = true
+                result.append(c)
+            } else if (capitalizeNext) {
+                result.append(c.titlecaseChar())
+                capitalizeNext = false
+            } else {
+                result.append(c)
+            }
+        }
+        return result.toString()
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/LibraryItemMatchesTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/LibraryItemMatchesTest.kt
@@ -1,0 +1,109 @@
+package eu.kanade.tachiyomi.ui.library
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.library.model.LibraryManga
+import tachiyomi.domain.manga.model.Manga
+
+/**
+ * Covers field-prefixed matching only. The DEFAULT and SOURCE paths resolve the source name via
+ * an Injekt-backed SourceManager and are exercised in instrumented/integration tests instead.
+ */
+class LibraryItemMatchesTest {
+
+    private fun item(
+        id: Long = 1L,
+        title: String = "Naruto",
+        author: String? = null,
+        artist: String? = null,
+        genre: List<String>? = null,
+        url: String = "",
+    ): LibraryItem {
+        val manga = Manga.create().copy(
+            id = id,
+            title = title,
+            author = author,
+            artist = artist,
+            genre = genre,
+            url = url,
+        )
+        return LibraryItem(
+            libraryManga = LibraryManga(
+                manga = manga,
+                categories = emptyList(),
+                totalChapters = 0,
+                readCount = 0,
+                bookmarkCount = 0,
+                latestUpload = 0,
+                chapterFetchedAt = 0,
+                lastRead = 0,
+            ),
+        )
+    }
+
+    private fun spec(query: String, useRegex: Boolean = false, searchByUrl: Boolean = false) =
+        LibrarySearchSpec.parse(query, useRegex, searchByUrl)
+
+    private fun metaIds(
+        author: Set<Long> = emptySet(),
+        artist: Set<Long> = emptySet(),
+        description: Set<Long> = emptySet(),
+    ) = LibraryScreenModel.MetadataMatchIds(author = author, artist = artist, description = description)
+
+    @Test
+    fun `title prefix matches substring case-insensitively`() {
+        assertTrue(item(title = "One Piece").matches(spec("title:piece")))
+        assertFalse(item(title = "One Piece").matches(spec("title:bleach")))
+    }
+
+    @Test
+    fun `title prefix supports regex`() {
+        assertTrue(item(title = "Naruto").matches(spec("title:nar.*to", useRegex = true)))
+    }
+
+    @Test
+    fun `author prefix is matched via metadataMatchIds not the in-memory field`() {
+        val it = item(id = 3L)
+        assertTrue(it.matches(spec("author:oda"), metadataMatchIds = metaIds(author = setOf(3L))))
+        assertFalse(it.matches(spec("author:oda"), metadataMatchIds = metaIds(author = setOf(4L))))
+    }
+
+    @Test
+    fun `artist prefix is matched via metadataMatchIds`() {
+        val it = item(id = 9L)
+        assertTrue(it.matches(spec("artist:x"), metadataMatchIds = metaIds(artist = setOf(9L))))
+        assertFalse(it.matches(spec("artist:x"), metadataMatchIds = metaIds(artist = emptySet())))
+    }
+
+    @Test
+    fun `description is matched via metadataMatchIds not the in-memory field`() {
+        val it = item(id = 7L)
+        assertTrue(it.matches(spec("desc:pirate"), metadataMatchIds = metaIds(description = setOf(7L))))
+        assertFalse(it.matches(spec("desc:pirate"), metadataMatchIds = metaIds(description = setOf(8L))))
+    }
+
+    @Test
+    fun `chapter prefix is matched via chapterMatchIds`() {
+        val it = item(id = 5L)
+        assertTrue(it.matches(spec("chapter:vol"), chapterMatchIds = setOf(5L)))
+        assertFalse(it.matches(spec("chapter:vol"), chapterMatchIds = emptySet()))
+    }
+
+    @Test
+    fun `tag prefix matches any genre`() {
+        assertTrue(item(genre = listOf("Action", "Comedy")).matches(spec("tag:comedy")))
+        assertFalse(item(genre = listOf("Action")).matches(spec("genre:horror")))
+    }
+
+    @Test
+    fun `url prefix matches url`() {
+        assertTrue(item(url = "/manga/123").matches(spec("url:/manga/")))
+    }
+
+    @Test
+    fun `id prefix matches numeric id`() {
+        assertTrue(item(id = 99L).matches(spec("id:99")))
+        assertFalse(item(id = 99L).matches(spec("id:100")))
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/LibrarySearchSpecTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/LibrarySearchSpecTest.kt
@@ -1,0 +1,76 @@
+package eu.kanade.tachiyomi.ui.library
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LibrarySearchSpecTest {
+
+    private fun parse(query: String, useRegex: Boolean = false, searchByUrl: Boolean = false) =
+        LibrarySearchSpec.parse(query, useRegex, searchByUrl)
+
+    @Test
+    fun `detects field prefixes case-insensitively and strips them`() {
+        assertEquals(LibrarySearchSpec.Field.TITLE, parse("title:naruto").field)
+        assertEquals("naruto", parse("Title:  naruto ").term)
+        assertEquals(LibrarySearchSpec.Field.AUTHOR, parse("author:oda").field)
+        assertEquals(LibrarySearchSpec.Field.ARTIST, parse("artist:x").field)
+        assertEquals(LibrarySearchSpec.Field.DESCRIPTION, parse("desc:pirate").field)
+        assertEquals(LibrarySearchSpec.Field.DESCRIPTION, parse("description:pirate").field)
+        assertEquals(LibrarySearchSpec.Field.TAG, parse("tag:action").field)
+        assertEquals(LibrarySearchSpec.Field.TAG, parse("genre:action").field)
+        assertEquals(LibrarySearchSpec.Field.SOURCE, parse("source:mangadex").field)
+        assertEquals(LibrarySearchSpec.Field.URL, parse("url:/manga/1").field)
+        assertEquals(LibrarySearchSpec.Field.CHAPTER, parse("chapter:vol").field)
+        assertEquals(LibrarySearchSpec.Field.ID, parse("id:42").field)
+    }
+
+    @Test
+    fun `plain query is DEFAULT field`() {
+        val spec = parse("one piece")
+        assertEquals(LibrarySearchSpec.Field.DEFAULT, spec.field)
+        assertEquals("one piece", spec.term)
+    }
+
+    @Test
+    fun `does not compile regex when useRegex is false`() {
+        assertNull(parse("naruto", useRegex = false).termRegex)
+    }
+
+    @Test
+    fun `compiles regex once when useRegex is true`() {
+        val spec = parse("nar.*to", useRegex = true)
+        assertNotNull(spec.termRegex)
+        assertTrue(spec.termRegex!!.containsMatchIn("naruto"))
+    }
+
+    @Test
+    fun `invalid regex compiles to null`() {
+        assertNull(parse("[unclosed", useRegex = true).termRegex)
+    }
+
+    @Test
+    fun `default query splits comma into sub-terms and parses negation`() {
+        val spec = parse("naruto, -filler")
+        assertEquals(2, spec.subTerms.size)
+        assertEquals("naruto", spec.subTerms[0].text)
+        assertFalse(spec.subTerms[0].negate)
+        assertEquals("filler", spec.subTerms[1].text)
+        assertTrue(spec.subTerms[1].negate)
+    }
+
+    @Test
+    fun `blank sub-terms are dropped`() {
+        val spec = parse("a, , b")
+        assertEquals(listOf("a", "b"), spec.subTerms.map { it.text })
+    }
+
+    @Test
+    fun `searchByUrl flag is carried on the spec`() {
+        assertTrue(parse("x", searchByUrl = true).searchByUrl)
+        assertFalse(parse("x", searchByUrl = false).searchByUrl)
+    }
+}

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1056,6 +1056,28 @@ class MangaRepositoryImpl(
         }
     }
 
+    override suspend fun findFavoriteIdsMatchingMetadata(
+        matchAuthor: ((String) -> Boolean)?,
+        matchArtist: ((String) -> Boolean)?,
+        matchDescription: ((String) -> Boolean)?,
+    ): Triple<Set<Long>, Set<Long>, Set<Long>> {
+        return handler.await {
+            val authorIds = HashSet<Long>()
+            val artistIds = HashSet<Long>()
+            val descriptionIds = HashSet<Long>()
+            // Side-effecting mapper: each row's strings are matched and discarded as the cursor
+            // streams, so the full favorite metadata is never held in memory at once.
+            mangasQueries.getFavoriteMetadataForSearch { id, author, artist, description ->
+                if (matchAuthor != null && author != null && matchAuthor(author)) authorIds.add(id)
+                if (matchArtist != null && artist != null && matchArtist(artist)) artistIds.add(id)
+                if (matchDescription != null && description != null && matchDescription(description)) {
+                    descriptionIds.add(id)
+                }
+            }.executeAsList()
+            Triple(authorIds, artistIds, descriptionIds)
+        }
+    }
+
     override suspend fun getFavoriteIdAndTitle(): List<Pair<Long, String>> {
         return handler.awaitList {
             mangasQueries.getFavoriteIdAndTitle { id, title ->
@@ -1107,6 +1129,33 @@ class MangaRepositoryImpl(
             "MangaRepositoryImpl.getFavoriteGenresWithSource: Query completed in ${queryDuration}ms, returned ${result.size} items"
         }
         return result
+    }
+
+    override suspend fun getFavoriteGenreTagCounts(
+        novelSourceIds: Set<Long>,
+        wantNovel: Boolean?,
+    ): Pair<Map<String, Int>, Int> {
+        return handler.await {
+            val counts = HashMap<String, Int>()
+            var noTagsCount = 0
+            // Side-effecting mapper: fold each row as the cursor streams it. executeAsList still
+            // builds a List<Unit> (one cheap singleton ref per row), but the genre sublists are
+            // decoded and discarded per row instead of all being held simultaneously.
+            mangasQueries.getFavoriteGenresWithSource { _, source, genre ->
+                val isNovel = source in novelSourceIds
+                if (wantNovel == null || wantNovel == isNovel) {
+                    if (genre.isNullOrEmpty()) {
+                        noTagsCount++
+                    } else {
+                        for (raw in genre) {
+                            val tag = raw.trim()
+                            if (tag.isNotEmpty()) counts[tag] = (counts[tag] ?: 0) + 1
+                        }
+                    }
+                }
+            }.executeAsList()
+            counts to noTagsCount
+        }
     }
 
     override suspend fun getFavoriteSourceUrlPairs(): List<Pair<Long, String>> {

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -242,6 +242,15 @@ GROUP BY lower(trim(title))
 HAVING count(*) > 1
 ORDER BY duplicate_count DESC;
 
+-- Author/artist/description are not loaded into the in-memory library list (they'd add
+-- two-to-three strings per favorite for a 200k library). Search over those fields streams
+-- this cursor and matches in Kotlin (one scan covers all three fields, supports regex, and
+-- avoids LIKE wildcard/escaping pitfalls).
+getFavoriteMetadataForSearch:
+SELECT _id, author, artist, description
+FROM mangas
+WHERE favorite = 1;
+
 -- Find all duplicate groups with contains match (one title contains another)
 -- Optimized: use substr index and smaller comparisons to avoid full table scans
 findDuplicatesContains:

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -408,6 +408,17 @@ class GetLibraryManga(
     }
 
     /**
+     * Memory-safe tag counting: aggregates in the DB layer instead of loading every favorite's
+     * genres into memory at once. Returns (rawTag -> count) and the no-tags count.
+     */
+    suspend fun awaitGenreTagCounts(
+        novelSourceIds: Set<Long>,
+        wantNovel: Boolean?,
+    ): Pair<Map<String, Int>, Int> {
+        return mangaRepository.getFavoriteGenreTagCounts(novelSourceIds, wantNovel)
+    }
+
+    /**
      * Get just the distinct source IDs from favorites - ultra-lightweight for extension listing.
      * This avoids the expensive libraryView JOIN and only fetches source IDs.
      */

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/SearchMangaMetadata.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/SearchMangaMetadata.kt
@@ -1,0 +1,50 @@
+package tachiyomi.domain.manga.interactor
+
+import tachiyomi.domain.manga.repository.MangaRepository
+
+/**
+ * Resolves favorite-manga matches for fields that are NOT kept in the in-memory library list
+ * (author, artist, description). Keeping these out of memory saves two-to-three strings per
+ * favorite on large libraries; matching streams the DB cursor on demand instead.
+ *
+ * Matching happens in Kotlin so it is Unicode case-insensitive and supports regex, with no
+ * SQL LIKE wildcard/escaping concerns.
+ */
+class SearchMangaMetadata(
+    private val mangaRepository: MangaRepository,
+) {
+
+    data class MatchIds(
+        val author: Set<Long> = emptySet(),
+        val artist: Set<Long> = emptySet(),
+        val description: Set<Long> = emptySet(),
+    )
+
+    /**
+     * @param term plain substring to match (ignored when [regex] is non-null).
+     * @param regex optional compiled pattern; takes precedence over [term].
+     */
+    suspend fun await(
+        term: String,
+        regex: Regex?,
+        searchAuthor: Boolean,
+        searchArtist: Boolean,
+        searchDescription: Boolean,
+    ): MatchIds {
+        if (regex == null && term.isBlank()) return MatchIds()
+        if (!searchAuthor && !searchArtist && !searchDescription) return MatchIds()
+
+        val predicate: (String) -> Boolean = if (regex != null) {
+            { regex.containsMatchIn(it) }
+        } else {
+            { it.contains(term, ignoreCase = true) }
+        }
+
+        val (author, artist, description) = mangaRepository.findFavoriteIdsMatchingMetadata(
+            matchAuthor = predicate.takeIf { searchAuthor },
+            matchArtist = predicate.takeIf { searchArtist },
+            matchDescription = predicate.takeIf { searchDescription },
+        )
+        return MatchIds(author = author, artist = artist, description = description)
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -84,6 +84,19 @@ interface MangaRepository {
     suspend fun findDuplicatesContains(): List<DuplicatePair>
 
     /**
+     * Stream favorites' (author, artist, description) through the given predicates and collect
+     * the matching IDs per field. Single cursor scan; rows are decoded and discarded one at a
+     * time, so nothing per-favorite is retained. A null predicate skips that field.
+     *
+     * @return matching favorite IDs as (author, artist, description) sets.
+     */
+    suspend fun findFavoriteIdsMatchingMetadata(
+        matchAuthor: ((String) -> Boolean)?,
+        matchArtist: ((String) -> Boolean)?,
+        matchDescription: ((String) -> Boolean)?,
+    ): Triple<Set<Long>, Set<Long>, Set<Long>>
+
+    /**
      * Get ID + title pairs for all favorites.
      */
     suspend fun getFavoriteIdAndTitle(): List<Pair<Long, String>>
@@ -105,6 +118,20 @@ interface MangaRepository {
      * Returns list of (mangaId, sourceId, genreList) triples.
      */
     suspend fun getFavoriteGenresWithSource(): List<Triple<Long, Long, List<String>?>>
+
+    /**
+     * Aggregate favorite genre tag counts without materializing the full per-manga genre list.
+     * Folds the DB cursor row-by-row into a small (rawTag -> count) map, so a 200k library can't
+     * OOM the way loading every genre row at once does.
+     *
+     * @param novelSourceIds source IDs considered novel sources (for content-type filtering).
+     * @param wantNovel null = all, true = novel-source favorites only, false = manga-source only.
+     * @return (rawTag -> count) and the number of included favorites with no tags.
+     */
+    suspend fun getFavoriteGenreTagCounts(
+        novelSourceIds: Set<Long>,
+        wantNovel: Boolean?,
+    ): Pair<Map<String, Int>, Int>
 
     /**
      * Get ultra-lightweight source + url pairs for duplicate checking.


### PR DESCRIPTION

Library search previously re-parsed the query and recompiled regexes per item, and matched author/artist/description against fields that are no longer resident in the in-memory library list.

- New LibrarySearchSpec parses the query once per search (field prefix, comma sub-terms with negation, compiled regex) instead of once per item; LibraryItem.matches() consumes the parsed spec.
- Author/artist/description matches resolve through the new SearchMangaMetadata interactor, which streams a single favorites cursor and matches in Kotlin: one scan covers all three fields, matching is Unicode case-insensitive.
- Explicit desc:/description: search always runs; in default search, description stays gated behind the search-content preference.
- Default comma-separated sub-terms now match title/url/source/tags uniformly, with per-sub-term negation.
- Tag counting in the library settings sheet aggregates in the DB layer instead of loading every favorite genre list into memory at once.
- Download badge/filter counts batch through getDownloadCounts() instead of one lookup per manga.
- EPUB export fetches the full manga record so author/description metadata is complete.


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
