### PR TITLE
feat(track): improve NovelList session handling and fix API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)
 - Fix custom fonts not working with local files [@mrissaoussama](https://github.com/mrissaoussama) [#237](https://github.com/tsundoku-otaku/tsundoku/pull/237)
+- Imrpove NovelList session handling and fix API errors [@mrissaoussama](https://github.com/mrissaoussama) [#249](https://github.com/tsundoku-otaku/tsundoku/pull/249)
 - Correctly recognize .zip archives [@mrissaoussama](https://github.com/mrissaoussama) [#226](https://github.com/tsundoku-otaku/tsundoku/pull/226)
 - Improve translation reliability and interactions with images; Bug with short chapters [@mrissaoussama](https://github.com/mrissaoussama) [#232](https://github.com/tsundoku-otaku/tsundoku/pull/232)
 - Make Grid items better respect max lines limits in library [@mrissaoussama](https://github.com/mrissaoussama) [#216](https://github.com/tsundoku-otaku/tsundoku/pull/216)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/novellist/NovelList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/novellist/NovelList.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.data.track.novellist
 
-import android.graphics.Color
-import android.util.Base64
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
@@ -182,12 +180,11 @@ class NovelList(id: Long) : BaseTracker(id, "NovelList") {
         // Send OPTIONS preflight first
         sendOptionsRequest(url, "PUT")
 
-        // NovelList uses PUT to the same endpoint for both adding and updating
+        // NovelList uses PUT to the same endpoint for both adding and updating.
+        // rating must be omitted unless >= 1, the API rejects 0 with a 422.
         val requestBody = buildJsonObject {
             put("status", if (hasReadChapters) "IN_PROGRESS" else "PLANNED")
             put("chapter_count", track.last_chapter_read.toInt())
-            put("rating", 0)
-            put("note", "")
         }.toString().toRequestBody("application/json".toMediaType())
 
         val request = buildAuthenticatedRequest(url)
@@ -241,7 +238,7 @@ class NovelList(id: Long) : BaseTracker(id, "NovelList") {
                 val slug = obj["slug"]?.jsonPrimitive?.contentOrNull ?: idString
                 // Store UUID in tracking_url - use special format to preserve both slug and id
                 // Format: https://www.novellist.co/novel/slug#uuid
-                track.tracking_url = "https://www.novellist.co/novel/$slug#$idString"
+                track.tracking_url = "https://www.novellist.co/novels/$slug#$idString"
                 track.publishing_status = obj["status"]?.jsonPrimitive?.contentOrNull ?: ""
                 track
             }
@@ -272,27 +269,6 @@ class NovelList(id: Long) : BaseTracker(id, "NovelList") {
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "NovelList refresh failed" }
             track
-        }
-    }
-
-    /**
-     * Extract JWT token from novellist cookie.
-     * Cookie format: base64-{base64 encoded JSON containing access_token}
-     */
-    fun extractTokenFromCookie(cookieValue: String): String? {
-        return try {
-            if (cookieValue.startsWith("base64-")) {
-                val base64Part = cookieValue.removePrefix("base64-")
-                val decodedBytes = Base64.decode(base64Part, Base64.DEFAULT)
-                val decodedString = String(decodedBytes, Charsets.UTF_8)
-                val jsonObj = json.decodeFromString<JsonObject>(decodedString)
-                jsonObj["access_token"]?.jsonPrimitive?.contentOrNull
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) { "Failed to extract token from cookie" }
-            null
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/webview/TrackerWebViewLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/webview/TrackerWebViewLoginActivity.kt
@@ -374,37 +374,44 @@ private fun normalizeRanobeDbCookie(input: String): String? {
     return value.trim().ifBlank { null }?.let { "auth_session=$it" }
 }
 
+private val novelListAccessTokenRegex = Regex("\"access_token\"\\s*:\\s*\"([^\"]+)\"")
+private val jwtRegex = Regex("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
+
+/**
+ * Accepts any of: a raw JWT, `Bearer <jwt>`, the session JSON, a `novellist` cookie,
+ * a full cookie header, or a localStorage entry like `novellist.0:"base64-..."`.
+ * Returns the JWT access token, or null if none can be extracted.
+ */
 private fun normalizeNovelListToken(input: String): String? {
     val raw = input.trim()
     if (raw.isEmpty()) return null
 
-    val extracted = run {
-        val cookieRegex = Regex("(?:^|[;\\s])novellist=([^;]+)")
-        val match = cookieRegex.find(raw)
-        match?.groupValues?.getOrNull(1) ?: raw
+    // base64-encoded session blob anywhere in the input (cookie value or
+    // localStorage chunk; chunked entries may be truncated mid-blob).
+    Regex("base64-([A-Za-z0-9+/=_-]+)").find(raw)?.groupValues?.get(1)?.let { blob ->
+        decodeNovelListBase64(blob)?.let { decoded ->
+            novelListAccessTokenRegex.find(decoded)?.groupValues?.get(1)?.let { return it }
+        }
     }
 
-    val candidate = extracted.trim().removePrefix("novellist=")
+    // Plain session JSON.
+    novelListAccessTokenRegex.find(raw)?.groupValues?.get(1)?.let { return it }
 
-    // If a direct JWT/token was pasted, use it as-is.
-    if (!candidate.startsWith("base64-")) {
-        val tokenInJson = Regex("\"access_token\"\\s*:\\s*\"([^\"]+)\"")
-            .find(candidate)
-            ?.groupValues
-            ?.getOrNull(1)
-        return tokenInJson ?: candidate.ifBlank { null }
-    }
+    // Raw JWT, optionally prefixed with "Bearer ".
+    return jwtRegex.find(raw)?.value
+}
 
-    val decoded = runCatching {
-        val encoded = candidate.removePrefix("base64-")
-        val bytes = android.util.Base64.decode(encoded, android.util.Base64.DEFAULT)
-        String(bytes, Charsets.UTF_8)
-    }.getOrNull() ?: return null
-
-    return Regex("\"access_token\"\\s*:\\s*\"([^\"]+)\"")
-        .find(decoded)
-        ?.groupValues
-        ?.getOrNull(1)
+/**
+ * Decode a base64/base64url blob, tolerating truncation from localStorage chunking
+ * (`novellist.0`, `novellist.1`, ...). The access_token sits at the start of the
+ * session JSON, so a partial first chunk still decodes far enough to find it.
+ */
+private fun decodeNovelListBase64(encoded: String): String? {
+    var cleaned = encoded.replace('-', '+').replace('_', '/').replace("=", "")
+    cleaned = cleaned.dropLast(cleaned.length % 4)
+    return runCatching {
+        String(android.util.Base64.decode(cleaned, android.util.Base64.NO_PADDING), Charsets.UTF_8)
+    }.getOrNull()
 }
 
 private suspend fun extractTokenFromCookies(trackerId: Long, currentUrl: String): String? {
@@ -429,34 +436,16 @@ private suspend fun extractTokenFromCookies(trackerId: Long, currentUrl: String)
                 val cookies = cookieManager.getCookie("https://www.novellist.co")
                 logcat(LogPriority.DEBUG) { "NovelList cookies: $cookies" }
                 if (cookies != null) {
-                    // Try to find the novellist cookie which contains the JWT
-                    val regex = Regex("novellist=([^;]+)")
-                    val match = regex.find(cookies)
-                    val novellistCookie = match?.groupValues?.get(1)
-
-                    if (novellistCookie != null) {
-                        // Decode base64 if needed
-                        val decoded = try {
-                            if (novellistCookie.startsWith("base64-")) {
-                                val base64Part = novellistCookie.removePrefix("base64-")
-                                val decoded = android.util.Base64.decode(base64Part, android.util.Base64.DEFAULT)
-                                String(decoded)
-                            } else {
-                                novellistCookie
-                            }
-                        } catch (e: Exception) {
-                            logcat(LogPriority.ERROR, e) { "Failed to decode NovelList cookie" }
-                            novellistCookie
-                        }
-
-                        // Extract access_token from JSON if present
-                        try {
-                            val jsonRegex = Regex("\"access_token\"\\s*:\\s*\"([^\"]+)\"")
-                            val tokenMatch = jsonRegex.find(decoded)
-                            tokenMatch?.groupValues?.get(1) ?: decoded
-                        } catch (e: Exception) {
-                            decoded
-                        }
+                    // Session is either a single `novellist` cookie or chunked
+                    // across `novellist.0`, `novellist.1`, ...
+                    val single = Regex("novellist=([^;]+)").find(cookies)?.groupValues?.get(1)
+                    val chunked = Regex("novellist\\.(\\d+)=([^;]+)").findAll(cookies)
+                        .sortedBy { it.groupValues[1].toInt() }
+                        .joinToString("") { it.groupValues[2] }
+                        .ifEmpty { null }
+                    val cookieValue = single ?: chunked
+                    if (cookieValue != null) {
+                        normalizeNovelListToken(cookieValue)
                     } else {
                         logcat(LogPriority.WARN) { "NovelList cookie not found" }
                         null


### PR DESCRIPTION
Session Handling:
- Support chunked session cookies (`novellist.0`, `novellist.1`, etc.) by joining them in order before token extraction
- Rework `normalizeNovelListToken` to support raw JWTs, "Bearer" prefixes, session JSON, or `base64-` encoded blobs
- Add a tolerant base64 decoder to `TrackerWebViewLoginActivity` that handles padding and truncation, allowing extraction from partial `localStorage` chunks

API Fixes:
- Remove default `rating` and `note` fields from the update request body; the API rejects `rating: 0` with a 422 error
- Correct the `tracking_url` format to use `/novels/` instead of `/novel/`

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
