### PR TITLE
feat(translation): expand custom HTTP engine configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Internationalize mass-import strings, add confirmation dialogues [@mrissaoussama](https://github.com/mrissaoussama) [#206](https://github.com/tsundoku-otaku/tsundoku/pull/206)
+- Expanded custom HTTP engine options [@mrissaoussama](https://github.com/mrissaoussama) [#250](https://github.com/tsundoku-otaku/tsundoku/pull/250)
 - Added tsundoku specific extensions, so apps can avoid appearing as manga sources in other apps [@mrissaoussama](https://github.com/mrissaoussama) [#238](https://github.com/tsundoku-otaku/tsundoku/pull/238)
 
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
@@ -13,6 +13,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.launch
 import tachiyomi.domain.translation.model.TranslationResult
@@ -486,6 +487,19 @@ object SettingsTranslationScreen : SearchableSettings {
                         preference = prefs.customHttpApiKey(),
                         title = stringResource(MR.strings.pref_translation_api_key),
                         subtitle = if (customHttpApiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.ListPreference(
+                        preference = prefs.customHttpMethod(),
+                        title = stringResource(MR.strings.pref_translation_request_method),
+                        entries = persistentMapOf(
+                            "POST" to "POST",
+                            "GET" to "GET",
+                        ),
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = prefs.customHttpHeaders(),
+                        title = stringResource(MR.strings.pref_translation_custom_headers),
+                        subtitle = stringResource(MR.strings.pref_translation_custom_headers_desc),
                     ),
                     Preference.PreferenceItem.EditTextPreference(
                         preference = prefs.customHttpRequestTemplate(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/CustomHttpTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/CustomHttpTranslateEngine.kt
@@ -21,6 +21,9 @@ import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.zip.GZIPInputStream
+import java.util.zip.Inflater
+import java.util.zip.InflaterInputStream
 
 /**
  * Custom HTTP translation engine.
@@ -124,27 +127,46 @@ class CustomHttpTranslateEngine(
         val apiKey = preferences.customHttpApiKey().get().takeIf { it.isNotBlank() }
         val requestTemplate = preferences.customHttpRequestTemplate().get()
         val responsePath = preferences.customHttpResponsePath().get()
+        val method = preferences.customHttpMethod().get()
 
-        // Build request body from template
-        val requestBody = buildRequestBody(requestTemplate, texts, sourceLanguage, targetLanguage)
+        // Placeholders in the URL are substituted URL-encoded (mainly for GET query params)
+        val finalUrl = substituteUrl(apiUrl, texts, sourceLanguage, targetLanguage)
 
-        val requestBuilder = Request.Builder()
-            .url(apiUrl)
-            .post(requestBody.toRequestBody("application/json".toMediaType()))
-            .header("Content-Type", "application/json")
+        val requestBuilder = Request.Builder().url(finalUrl)
+        if (method.equals("GET", ignoreCase = true)) {
+            requestBuilder.get()
+        } else {
+            // Build request body from template
+            val requestBody = buildRequestBody(requestTemplate, texts, sourceLanguage, targetLanguage)
+            requestBuilder
+                .post(requestBody.toRequestBody("application/json".toMediaType()))
+                .header("Content-Type", "application/json")
+        }
 
         // Add API key if configured
         if (!apiKey.isNullOrBlank()) {
             requestBuilder.header("Authorization", "Bearer $apiKey")
         }
 
+        // Custom headers as ;- or newline-separated "Name: Value" pairs, override defaults on name match
+        preferences.customHttpHeaders().get().split(';', '\n')
+            .mapNotNull { entry ->
+                val idx = entry.indexOf(':')
+                if (idx <= 0) return@mapNotNull null
+                entry.substring(0, idx).trim() to entry.substring(idx + 1).trim()
+            }
+            .filter { (name, _) -> name.isNotEmpty() }
+            .forEach { (name, value) ->
+                requestBuilder.header(name, value.replace("{apiKey}", apiKey.orEmpty()))
+            }
+
         return client.newCall(requestBuilder.build()).execute().use { response ->
             if (!response.isSuccessful) {
-                val errorBody = response.body?.string() ?: "Unknown error"
+                val errorBody = readBody(response) ?: "Unknown error"
                 throw Exception("HTTP ${response.code}: $errorBody")
             }
 
-            val responseBody = response.body?.string() ?: throw Exception("Empty response")
+            val responseBody = readBody(response) ?: throw Exception("Empty response")
             parseResponse(responseBody, responsePath, texts.size)
         }
     }
@@ -152,10 +174,13 @@ class CustomHttpTranslateEngine(
     /**
      * Build the request body from the user's template.
      * Replaces placeholders:
-     * - {text} - single text (first one if multiple)
+     * - {text} - single text as a JSON string literal, quotes included (first one if multiple)
+     * - {text_esc} - single text JSON-escaped without surrounding quotes, for embedding inside a larger string
      * - {texts} - JSON array of texts
      * - {source} - source language code
      * - {target} - target language code
+     * - {source_name} - source language English name (falls back to the code)
+     * - {target_name} - target language English name (falls back to the code)
      */
     private fun buildRequestBody(
         template: String,
@@ -169,9 +194,57 @@ class CustomHttpTranslateEngine(
 
         return template
             .replace("{texts}", textsJson)
+            .replace("{text_esc}", singleText.removeSurrounding("\""))
             .replace("{text}", singleText)
+            .replace("{source_name}", languageName(sourceLanguage))
+            .replace("{target_name}", languageName(targetLanguage))
             .replace("{source}", sourceLanguage)
             .replace("{target}", targetLanguage)
+    }
+
+    private fun languageName(code: String): String =
+        supportedLanguages.firstOrNull { it.first == code }?.second ?: code
+
+    /**
+     * Read the response body, decompressing manually if needed.
+     * OkHttp only auto-decompresses gzip when it added Accept-Encoding itself;
+     * a user-supplied Accept-Encoding header delivers the body raw.
+     */
+    private fun readBody(response: okhttp3.Response): String? {
+        val bytes = response.body?.bytes()?.takeIf { it.isNotEmpty() } ?: return null
+        return when (response.header("Content-Encoding")?.lowercase()) {
+            "gzip" -> GZIPInputStream(bytes.inputStream()).use { it.readBytes() }.toString(Charsets.UTF_8)
+            "deflate" -> inflate(bytes).toString(Charsets.UTF_8)
+            else -> String(bytes, Charsets.UTF_8)
+        }
+    }
+
+    private fun inflate(bytes: ByteArray): ByteArray =
+        try {
+            // zlib-wrapped deflate
+            InflaterInputStream(bytes.inputStream()).use { it.readBytes() }
+        } catch (e: Exception) {
+            // raw deflate, some servers omit the zlib header
+            InflaterInputStream(bytes.inputStream(), Inflater(true)).use { it.readBytes() }
+        }
+
+    /**
+     * Substitute placeholders into the URL, URL-encoded.
+     * {text} here is the raw first text (no JSON quoting); {texts}/{text_esc} are not applicable.
+     */
+    private fun substituteUrl(
+        url: String,
+        texts: List<String>,
+        sourceLanguage: String,
+        targetLanguage: String,
+    ): String {
+        fun enc(value: String) = java.net.URLEncoder.encode(value, "UTF-8")
+        return url
+            .replace("{text}", enc(texts.firstOrNull().orEmpty()))
+            .replace("{source_name}", enc(languageName(sourceLanguage)))
+            .replace("{target_name}", enc(languageName(targetLanguage)))
+            .replace("{source}", enc(sourceLanguage))
+            .replace("{target}", enc(targetLanguage))
     }
 
     /**
@@ -181,7 +254,12 @@ class CustomHttpTranslateEngine(
      */
     private fun parseResponse(responseBody: String, path: String, expectedCount: Int): List<String> {
         val jsonElement = json.parseToJsonElement(responseBody)
-        val result = navigateJsonPath(jsonElement, path)
+        val result = try {
+            navigateJsonPath(jsonElement, path)
+        } catch (e: Exception) {
+            // Include the body so 200-with-error responses are diagnosable
+            throw Exception("${e.message}. Response body: ${responseBody.take(300)}")
+        }
 
         return when (result) {
             is JsonArray -> result.map {
@@ -213,7 +291,7 @@ class CustomHttpTranslateEngine(
     private fun navigateJsonPath(element: JsonElement, path: String): JsonElement {
         if (path.isBlank()) return element
 
-        val parts = path.split(".")
+        val parts = path.trim().split(".").map { it.trim() }
         var current = element
 
         for (part in parts) {

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -303,6 +303,26 @@ class TranslationPreferences(
     )
 
     /**
+     * Custom HTTP request method: POST or GET.
+     * GET sends no body; placeholders are substituted URL-encoded into the URL.
+     */
+    fun customHttpMethod() = preferenceStore.getString(
+        "translation_custom_http_method",
+        "POST",
+    )
+
+    /**
+     * Custom HTTP extra headers as ;- or newline-separated "Name: Value" pairs.
+     * Override the default Content-Type/Authorization headers on name match.
+     * {apiKey} in a value is replaced with the configured API key.
+     * Example: x-api-key: {apiKey}; Accept: application/json
+     */
+    fun customHttpHeaders() = preferenceStore.getString(
+        "translation_custom_http_headers",
+        "",
+    )
+
+    /**
      * Custom HTTP request template.
      * Use placeholders: {text}, {texts}, {source}, {target}
      * Example: {"q": "{text}", "source": "{source}", "target": "{target}"}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1178,8 +1178,11 @@
     <string name="pref_translation_api_key">API Key</string>
     <string name="pref_translation_api_url">API URL</string>
     <string name="pref_translation_custom_prompt">Custom Prompt</string>
+    <string name="pref_translation_request_method">Request Method</string>
+    <string name="pref_translation_custom_headers">Custom Headers</string>
+    <string name="pref_translation_custom_headers_desc">"Name: Value" pairs separated by ; or line breaks, override defaults. {apiKey} is replaced with the API key</string>
     <string name="pref_translation_request_template">Request Template</string>
-    <string name="pref_translation_request_template_desc">Use {texts}, {text}, {source}, {target}</string>
+    <string name="pref_translation_request_template_desc">Use {texts}, {text}, {text_esc}, {source}, {target}, {source_name}, {target_name}</string>
     <string name="pref_translation_response_path">Response Path</string>
 
     <!-- EPUB compression settings -->


### PR DESCRIPTION
- Allow selecting between POST and GET request methods
- Support URL-encoded placeholder substitution in the API URL for GET query parameters
- Add custom header support with optional `{apiKey}` placeholder substitution
- Expand request template placeholders to include `{text_esc}` (JSON-escaped), `{source_name}`, and `{target_name}` (English language names)
- Implement manual decompression for gzip and deflate to handle responses when custom headers override default OkHttp behavior
- Include a preview of the response body in error messages when JSON path parsing fails
- Trim whitespace from JSON path segments during response navigation
- Update settings UI and strings to expose new configuration options

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
