### PR TITLE
feat(jsplugin): enhance DOM element properties and paged fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Webview constants refactor, also fixes (non-infinite) scroll having dividers - Changes that affect custom CSS/JS [@mrissaoussama](https://github.com/mrissaoussama) [#209](https://github.com/tsundoku-otaku/tsundoku/pull/209)
 - JS Plugin runtime, writes improved [@mrissaoussama](https://github.com/mrissaoussama) [#245](https://github.com/tsundoku-otaku/tsundoku/pull/245)
 - Added support for missing wrap function for JS plugins, and native cheerio support [@mrissaoussama](https://github.com/mrissaoussama) [#239](https://github.com/tsundoku-otaku/tsundoku/pull/239)
+- Enhanced DOM compatibility and multi-page fetching [@mrissaoussama](https://github.com/mrissaoussama) [#252](https://github.com/tsundoku-otaku/tsundoku/pull/252)
 - Mass import chunks to avoid memory errors, has better caching and redundancy checking, improve UI [@mrissaoussama](https://github.com/mrissaoussama) [#214](https://github.com/tsundoku-otaku/tsundoku/pull/214)
 - Browse should properly filter manga and novel sources [@mrissaoussama](https://github.com/mrissaoussama) [#246](https://github.com/tsundoku-otaku/tsundoku/pull/246)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/library/JSLibraryProvider.kt
@@ -797,8 +797,10 @@ class JSLibraryProvider(
         if (handle != null) {
             sb.append("\"_h\":").append(handle).append(',')
         }
+        val tag = escapeJsonString(element.tagName().lowercase())
         sb.append("\"name\":")
-        sb.append('"').append(escapeJsonString(element.tagName().lowercase())).append('"')
+        sb.append('"').append(tag).append('"')
+        sb.append(",\"tagName\":\"").append(tag).append('"')
         sb.append(",\"attribs\":{")
         element.attributes().forEachIndexed { i, attr ->
             if (i > 0) sb.append(',')
@@ -1499,6 +1501,10 @@ class JSLibraryProvider(
             if (eh < 0) return undefined;
             var node = { _h: eh, type: 'tag' };
             Object.defineProperty(node, 'name', {
+                get: function() { return __cheerioTagName(eh); },
+                enumerable: false, configurable: true
+            });
+            Object.defineProperty(node, 'tagName', {
                 get: function() { return __cheerioTagName(eh); },
                 enumerable: false, configurable: true
             });

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -625,12 +625,14 @@ class JsSource(
             }
 
             if (totalPages > 1 || chapters.isEmpty()) {
+                val hasParsePage =
+                    executePluginMethod("typeof plugin.parsePage === 'function'") == "true"
                 val maxPages = if (totalPages > 0) totalPages else 1
                 val startPage = if (chapters.isEmpty()) 1 else 2
                 logcat(LogPriority.DEBUG) {
-                    "JsSource[$pluginId]: Paged source detected, totalPages=$totalPages, startPage=$startPage, existingChapters=${chapters.size}"
+                    "JsSource[$pluginId]: Paged source detected, totalPages=$totalPages, startPage=$startPage, existingChapters=${chapters.size}, hasParsePage=$hasParsePage"
                 }
-                if (startPage <= maxPages) {
+                if (hasParsePage && startPage <= maxPages) {
                     for (page in startPage..maxPages) {
                         try {
                             val pageResult = executePluginMethod("plugin.parsePage('$path', $page)")


### PR DESCRIPTION
- Add `tagName` property to JS DOM elements to improve compatibility with standard web APIs, mirroring the existing `name` property.
- Implement a safety check to ensure `plugin.parsePage` is defined before attempting multi-page chapter fetching.
- Update logging for paged source detection to include the availability of the `parsePage` function.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
