### PR TITLE
fix(massimport): improve accuracy of active import notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)
 - Fix service restrictions and background start crashes [@mrissaoussama](https://github.com/mrissaoussama) [#243](https://github.com/tsundoku-otaku/tsundoku/pull/243)
 - Encoding issues when parsing jssource chapters [@mrissaoussama](https://github.com/mrissaoussama) [#224](https://github.com/tsundoku-otaku/tsundoku/pull/224)
+- Fix accuracy of mass import notification [@mrissaoussama](https://github.com/mrissaoussama) [#254](https://github.com/tsundoku-otaku/tsundoku/pull/254)
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)
 - Fix custom fonts not working with local files [@mrissaoussama](https://github.com/mrissaoussama) [#237](https://github.com/tsundoku-otaku/tsundoku/pull/237)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -523,13 +523,6 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
                     waitForMemoryPressure()
 
-                    activeImports[url] = true
-                    updateNotification(
-                        completedCount.get(),
-                        totalCount,
-                        "Processing: ${activeImports.size} active",
-                    )
-
                     var erroredThisUrl = false
                     var cancelledWhileQueued = false
                     try {
@@ -553,6 +546,12 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                         BatchStatus.Paused -> false
                                         else -> {
                                             delay(delayMs)
+                                            activeImports[url] = true
+                                            updateNotification(
+                                                completedCount.get(),
+                                                totalCount,
+                                                "Processing: ${activeImports.size} active",
+                                            )
                                             result = processUrlWithSource(
                                                 url, source, addToLibrary, fetchDetails, categoryId,
                                                 fetchChapters, pendingAddIds, flushBatchSize,
@@ -567,6 +566,12 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                             if (!awaitResumed(batchId)) {
                                 null
                             } else {
+                                activeImports[url] = true
+                                updateNotification(
+                                    completedCount.get(),
+                                    totalCount,
+                                    "Processing: ${activeImports.size} active",
+                                )
                                 processUrlWithSource(
                                     url, source, addToLibrary, fetchDetails, categoryId,
                                     fetchChapters, pendingAddIds, flushBatchSize,


### PR DESCRIPTION
Move the tracking of active URL imports and notification updates inside the processing block to ensure the count reflects URLs actually fetching rather than those parked on per-source semaphore queues.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
