### PR TITLE
fix(tts): refine service lifecycle and background sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Improve translation reliability and interactions with images; Bug with short chapters [@mrissaoussama](https://github.com/mrissaoussama) [#232](https://github.com/tsundoku-otaku/tsundoku/pull/232)
 - Make Grid items better respect max lines limits in library [@mrissaoussama](https://github.com/mrissaoussama) [#216](https://github.com/tsundoku-otaku/tsundoku/pull/216)
 - TextView Regex; Short chapter detection false positives [@mrissaoussama](https://github.com/mrissaoussama) [#225](https://github.com/tsundoku-otaku/tsundoku/pull/225)
+- Fix TTS service lifecycle and background sync [@mrissaoussama](https://github.com/mrissaoussama) [#255](https://github.com/tsundoku-otaku/tsundoku/pull/255)
 - Update library unread counts when marking chapters as read [@mrissaoussama](https://github.com/mrissaoussama) [#240](https://github.com/tsundoku-otaku/tsundoku/pull/240)
 - Fix HTML vs plain text detection [@mrissaoussama](https://github.com/mrissaoussama) [#223](https://github.com/tsundoku-otaku/tsundoku/pull/223)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -524,7 +524,9 @@ class ReaderActivity : BaseActivity() {
         super.onResume()
         viewModel.restartReadTimer()
         setMenuVisibility(viewModel.state.value.menuVisible)
-        if (readerPreferences.novelTtsBackgroundPlayback.get()) {
+        if (readerPreferences.novelTtsBackgroundPlayback.get() &&
+            currentNovelTtsState()?.active == true
+        ) {
             startTtsNotificationSync()
             syncBackgroundTtsState()
         }
@@ -819,7 +821,6 @@ class ReaderActivity : BaseActivity() {
                     readerPreferences.novelTtsControlsVisible.set(nowVisible)
                     val viewer = state.viewer
                     if (nowVisible) {
-                        // Show panel → optionally start TTS if pref enabled and not already running
                         if (!isTtsActive && readerPreferences.novelTtsAutoStartOnPanelOpen.get()) {
                             when (viewer) {
                                 is NovelViewer -> {
@@ -840,7 +841,6 @@ class ReaderActivity : BaseActivity() {
                             }
                         }
                     } else {
-                        // Hide panel → stop TTS
                         when (viewer) {
                             is NovelViewer -> {
                                 stopBackgroundTtsIfRunning()
@@ -861,7 +861,6 @@ class ReaderActivity : BaseActivity() {
                     }
                 },
                 onToggleTts = {
-                    // Pause/resume — used by the TTS controls overlay
                     val viewer = state.viewer
                     when (viewer) {
                         is NovelViewer -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/service/TtsPlaybackService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/service/TtsPlaybackService.kt
@@ -27,12 +27,6 @@ class TtsPlaybackService : Service() {
     private var mangaId: Long = -1L
     private var chapterId: Long = -1L
 
-    override fun onCreate() {
-        super.onCreate()
-
-        startForegroundWithNotification()
-    }
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Null intent means a sticky restart by the system; there is no playback
         // state to restore and the app may not be allowed to start a foreground
@@ -43,12 +37,6 @@ class TtsPlaybackService : Service() {
         }
 
         when (intent.action) {
-            ACTION_STOP_SERVICE -> {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf()
-                return START_NOT_STICKY
-            }
-
             ACTION_TOGGLE_PAUSE -> {
                 sendControlBroadcast(COMMAND_TOGGLE_PAUSE)
             }
@@ -223,9 +211,6 @@ class TtsPlaybackService : Service() {
         private const val ACTION_SYNC =
             "eu.kanade.tachiyomi.ui.reader.service.TtsPlaybackService.SYNC"
 
-        private const val ACTION_STOP_SERVICE =
-            "eu.kanade.tachiyomi.ui.reader.service.TtsPlaybackService.STOP_SERVICE"
-
         private const val ACTION_TOGGLE_PAUSE =
             "eu.kanade.tachiyomi.ui.reader.service.TtsPlaybackService.TOGGLE_PAUSE"
 
@@ -300,15 +285,7 @@ class TtsPlaybackService : Service() {
         }
 
         fun stop(context: Context) {
-            try {
-                context.startService(
-                    Intent(context, TtsPlaybackService::class.java)
-                        .setAction(ACTION_STOP_SERVICE),
-                )
-            } catch (e: IllegalStateException) {
-                // App is in the background and the service is not running; nothing to stop.
-                logcat(LogPriority.WARN, e) { "Cannot stop TTS service" }
-            }
+            context.stopService(Intent(context, TtsPlaybackService::class.java))
         }
     }
 }


### PR DESCRIPTION
Improve the stability and lifecycle management of the TTS playback service.

- Update `ReaderActivity` to only initiate TTS notification and state sync on resume if a TTS session is currently active.
- Simplify `TtsPlaybackService` shutdown by using standard `stopService` instead of a custom stop action.
- Remove automatic foreground promotion in `TtsPlaybackService.onCreate` to prevent potential background start exceptions.
- Prevent sticky restarts of `TtsPlaybackService` by explicitly stopping the service if it is recreated with a null intent.


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
