### PR TITLE
perf(reader): split novel chapter text into chunk TextViews+minor webview optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Novellist webview tracker login [@mrissaoussama](https://github.com/mrissaoussama) [#230](https://github.com/tsundoku-otaku/tsundoku/pull/230)
 - Novel Viewer Improvements - Refactors JS with infinite scroll, and more detailed metadata. [@mrissaoussama](https://github.com/mrissaoussama) [#198](https://github.com/tsundoku-otaku/tsundoku/pull/198)
 - Improve novel image loading and support SVGs [@mrissaoussama](https://github.com/mrissaoussama) [#253](https://github.com/tsundoku-otaku/tsundoku/pull/253)
+- Reader performance improvement by chunking text [@mrissaoussama](https://github.com/mrissaoussama) [#258](https://github.com/tsundoku-otaku/tsundoku/pull/258)
 - Persist translation queue across restarts, group by series [@mrissaoussama](https://github.com/mrissaoussama) [#244](https://github.com/tsundoku-otaku/tsundoku/pull/244)
 - Novel description screen now supports novel searches when tapping novel title [@mrissaoussama](https://github.com/mrissaoussama) [#207](https://github.com/tsundoku-otaku/tsundoku/pull/207)
 - Library search performance improved, removed redundant parsing [@mrissaoussama](https://github.com/mrissaoussama) [#247](https://github.com/tsundoku-otaku/tsundoku/pull/247)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
@@ -1,0 +1,87 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.text.textview
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.text.Spanned
+import android.text.style.ImageSpan
+import android.view.Gravity
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/**
+ * Holds a chapter's text as a column of chunk TextViews instead of one giant view.
+ * A single TextView makes StaticLayout size, span lookups and selection hit-testing
+ * O(chapter); large txt/md chapters caused constant GC and multi-second touch handling.
+ * Chunked views keep each layout small so all of that is O(chunk).
+ */
+internal class ChapterTextBlock(
+    context: Context,
+    private val createChunkView: () -> TextView,
+) {
+
+    val container = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+        layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        )
+    }
+
+    val chunkViews = mutableListOf<TextView>()
+
+    /** Start offset of each chunk view's text within [fullText]. */
+    var chunkStarts = IntArray(0)
+
+    /** Concatenation of all chunk texts; the text TTS and offset mapping operate on. */
+    var fullText: String? = null
+
+    private var placeholderView: TextView? = null
+
+    fun ensureChunkCount(count: Int) {
+        hidePlaceholder()
+        while (chunkViews.size < count) {
+            val view = createChunkView()
+            chunkViews.add(view)
+            container.addView(view)
+        }
+        while (chunkViews.size > count) {
+            val view = chunkViews.removeAt(chunkViews.size - 1)
+            container.removeView(view)
+        }
+    }
+
+    fun showPlaceholder(text: CharSequence) {
+        val view = placeholderView ?: createChunkView().apply {
+            gravity = Gravity.CENTER
+            placeholderView = this
+            container.addView(this, 0)
+        }
+        view.text = text
+    }
+
+    fun hidePlaceholder() {
+        placeholderView?.let { container.removeView(it) }
+        placeholderView = null
+    }
+
+    fun hasSelection(): Boolean = chunkViews.any { it.hasSelection() }
+
+    fun selectedText(): String? {
+        val view = chunkViews.firstOrNull { it.hasSelection() } ?: return null
+        val start = view.selectionStart
+        val end = view.selectionEnd
+        if (start < 0 || end < 0 || start >= end) return null
+        return view.text.subSequence(start, end).toString()
+    }
+
+    fun clearSelections() {
+        chunkViews.forEach { NovelTextRenderer.clearTextViewSelection(it) }
+    }
+
+    /** Chunk view whose text contains the ImageSpan backed by [drawable]. */
+    fun chunkViewFor(drawable: Drawable): TextView? = chunkViews.firstOrNull { view ->
+        (view.text as? Spanned)
+            ?.getSpans(0, view.text.length, ImageSpan::class.java)
+            ?.any { it.drawable === drawable } == true
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
@@ -35,6 +35,13 @@ internal class ChapterTextBlock(
     /** Concatenation of all chunk texts; the text TTS and offset mapping operate on. */
     var fullText: String? = null
 
+    /**
+     * Bumped each time a render of this block starts. A render coroutine captures the
+     * value and bails if it changes, so an overlapping re-render (translation finish,
+     * reload) never races view mutations against a stale one.
+     */
+    var renderToken: Int = 0
+
     private var placeholderView: TextView? = null
 
     fun ensureChunkCount(count: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelImageGetter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelImageGetter.kt
@@ -51,18 +51,20 @@ internal class DrawableWrapper : Drawable() {
     override fun getOpacity(): Int = PixelFormat.TRANSPARENT
 }
 
-// must be constructed on Main; getDrawable runs on worker thread — do not touch the view.
 internal class CoilImageGetter(
-    private val textView: TextView,
     private val activity: ReaderActivity,
     private val scope: CoroutineScope,
+    contentWidthPx: Int,
+    private val resolveView: (Drawable) -> TextView?,
 ) : Html.ImageGetter {
 
     private val capturedContentWidth: Int =
-        (textView.width - textView.paddingLeft - textView.paddingRight)
-            .takeIf { it > 0 } ?: activity.resources.displayMetrics.widthPixels
+        contentWidthPx.takeIf { it > 0 } ?: activity.resources.displayMetrics.widthPixels
 
-    private var recomputeJob: Job? = null
+    private val recomputeJobs = mutableMapOf<TextView, Job>()
+
+    // Chunk views that received an image; recomputed in one batch once all loads finish.
+    private val dirtyViews = java.util.concurrent.ConcurrentHashMap.newKeySet<TextView>()
 
     private data class PendingLoad(val source: String, val wrapper: DrawableWrapper)
     private val pendingLoads = mutableListOf<PendingLoad>()
@@ -182,7 +184,9 @@ internal class CoilImageGetter(
 
     private fun onLoadFinished() {
         if (outstandingLoads.decrementAndGet() <= 0) {
-            scheduleRecompute()
+            val views = dirtyViews.toList()
+            dirtyViews.clear()
+            views.forEach { scheduleRecompute(it) }
         }
     }
 
@@ -200,12 +204,15 @@ internal class CoilImageGetter(
 
     private fun fitToWidthAndInvalidate(drawable: Drawable, wrapper: DrawableWrapper) {
         fitToWidth(drawable, wrapper)
+        val textView = resolveView(wrapper) ?: return
         textView.invalidate()
+        // Recompute is batched in onLoadFinished once outstanding loads reach zero.
+        dirtyViews.add(textView)
     }
 
-    private fun scheduleRecompute() {
-        recomputeJob?.cancel()
-        recomputeJob = scope.launch(Dispatchers.Main) {
+    private fun scheduleRecompute(textView: TextView) {
+        recomputeJobs[textView]?.cancel()
+        recomputeJobs[textView] = scope.launch(Dispatchers.Main) {
             delay(RECOMPUTE_DEBOUNCE_MS)
             if (!textView.isAttachedToWindow) return@launch
             val snapshot = textView.text ?: return@launch

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelImageGetter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelImageGetter.kt
@@ -211,8 +211,8 @@ internal class CoilImageGetter(
     }
 
     private fun scheduleRecompute(textView: TextView) {
-        recomputeJobs[textView]?.cancel()
-        recomputeJobs[textView] = scope.launch(Dispatchers.Main) {
+        recomputeJobs.remove(textView)?.cancel()
+        val job = scope.launch(Dispatchers.Main) {
             delay(RECOMPUTE_DEBOUNCE_MS)
             if (!textView.isAttachedToWindow) return@launch
             val snapshot = textView.text ?: return@launch
@@ -223,6 +223,8 @@ internal class CoilImageGetter(
             if (!textView.isAttachedToWindow) return@launch
             TextViewCompat.setPrecomputedText(textView, precomputed)
         }
+        recomputeJobs[textView] = job
+        job.invokeOnCompletion { recomputeJobs.remove(textView, job) }
     }
 
     private fun sampleSizeForWidth(srcWidth: Int): Int {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
@@ -24,21 +24,16 @@ internal class NovelTextRenderer(
 ) {
 
     fun render(
-        textView: TextView,
+        block: ChapterTextBlock,
         processed: ProcessedContent,
-        clearSelection: (TextView) -> Unit,
-        onTextSet: (TextView) -> Unit,
+        onTextSet: () -> Unit,
     ) {
-        if (preferences.novelShowRawHtml.get()) {
-            if (!textView.isAttachedToWindow) return
-            clearSelection(textView)
-            textView.text = processed.text
-            return
-        }
+        val rawHtmlMode = preferences.novelShowRawHtml.get()
+        val plainTextMode = rawHtmlMode || processed.isPlainText
 
-        val plainTextMode = processed.isPlainText
-
-        var processedContent = if (plainTextMode && TranslationHtmlUtils.hasSourceHashTag(processed.text)) {
+        var processedContent = if (!rawHtmlMode && processed.isPlainText &&
+            TranslationHtmlUtils.hasSourceHashTag(processed.text)
+        ) {
             TranslationHtmlUtils.extractTextFromHtml(processed.text)
         } else {
             processed.text
@@ -48,15 +43,19 @@ internal class NovelTextRenderer(
             processedContent = wrapParagraphs(processedContent)
         }
 
-        val paragraphSpacing = preferences.novelParagraphSpacing.get()
-        val paragraphIndent = preferences.novelParagraphIndent.get()
+        val paragraphSpacing = if (rawHtmlMode) 0f else preferences.novelParagraphSpacing.get()
+        val paragraphIndent = if (rawHtmlMode) 0f else preferences.novelParagraphIndent.get()
         val fontSize = preferences.novelFontSize.get()
         val density = activity.resources.displayMetrics.density
         val blockMedia = preferences.novelBlockMedia.get()
 
         scope.launch {
-            val imageGetter = if (!blockMedia) {
-                CoilImageGetter(textView, activity, scope)
+            val imageGetter = if (!blockMedia && !plainTextMode) {
+                val widthPx = block.chunkViews.firstOrNull()
+                    ?.let { it.width - it.paddingLeft - it.paddingRight }
+                    ?.takeIf { it > 0 }
+                    ?: activity.resources.displayMetrics.widthPixels
+                CoilImageGetter(activity, scope, widthPx, block::chunkViewFor)
             } else {
                 null
             }
@@ -68,33 +67,80 @@ internal class NovelTextRenderer(
                     val cleanHtmlContent = normalizeHtmlForRendering(processedContent)
                     Html.fromHtml(cleanHtmlContent, Html.FROM_HTML_MODE_LEGACY, imageGetter, null)
                 }
-                val result = SpannableStringBuilder(spanned)
-                val spacingPx = (paragraphSpacing * fontSize * density).toInt()
-                val indentPx = (paragraphIndent * fontSize * density).toInt()
-                if (spacingPx > 0 || indentPx > 0) {
-                    applyParagraphSpans(result, spacingPx, indentPx)
+                SpannableStringBuilder(spanned)
+            }
+
+            val spacingPx = (paragraphSpacing * fontSize * density).toInt()
+            val indentPx = (paragraphIndent * fontSize * density).toInt()
+
+            val chunks = withContext(Dispatchers.Default) {
+                chunkRanges(spannable).map { (start, end) ->
+                    SpannableStringBuilder(spannable.subSequence(start, end)).also {
+                        if (spacingPx > 0 || indentPx > 0) {
+                            applyParagraphSpans(it, spacingPx, indentPx)
+                        }
+                    }
                 }
-                result
             }
 
-            if (!textView.isAttachedToWindow) return@launch
+            if (!block.container.isAttachedToWindow) return@launch
+            block.ensureChunkCount(chunks.size)
 
-            val params = TextViewCompat.getTextMetricsParams(textView)
+            if (chunks.isEmpty()) {
+                block.chunkStarts = IntArray(0)
+                block.fullText = ""
+                onTextSet()
+                return@launch
+            }
+
+            val params = TextViewCompat.getTextMetricsParams(block.chunkViews.first())
             val precomputed = withContext(Dispatchers.Default) {
-                PrecomputedTextCompat.create(spannable, params)
+                chunks.map { PrecomputedTextCompat.create(it, params) }
             }
 
-            if (!textView.isAttachedToWindow) return@launch
+            if (!block.container.isAttachedToWindow) return@launch
 
-            clearSelection(textView)
-            TextViewCompat.setPrecomputedText(textView, precomputed)
+            block.clearSelections()
+            val starts = IntArray(chunks.size)
+            var offset = 0
+            chunks.forEachIndexed { i, chunk ->
+                starts[i] = offset
+                offset += chunk.length
+            }
+            precomputed.forEachIndexed { i, text ->
+                TextViewCompat.setPrecomputedText(block.chunkViews[i], text)
+            }
+            block.chunkStarts = starts
+            block.fullText = spannable.toString()
             imageGetter?.startLoading()
-            onTextSet(textView)
+            onTextSet()
         }
     }
 
+    /**
+     * Splits at the first paragraph boundary past every CHUNK_TARGET_CHARS so chunk
+     * layouts stay small.
+     */
+    private fun chunkRanges(text: CharSequence): List<Pair<Int, Int>> {
+        val length = text.length
+        if (length == 0) return emptyList()
+        val ranges = ArrayList<Pair<Int, Int>>(length / CHUNK_TARGET_CHARS + 1)
+        var start = 0
+        while (start < length) {
+            var end = (start + CHUNK_TARGET_CHARS).coerceAtMost(length)
+            if (end < length) {
+                var newline = end
+                while (newline < length && text[newline] != '\n') newline++
+                end = if (newline < length) newline + 1 else length
+            }
+            ranges.add(start to end)
+            start = end
+        }
+        return ranges
+    }
+
     private fun wrapParagraphs(html: String): String {
-        var content = html.replace(Regex("<p>(?: |&#160;|&nbsp;)+"), "<p>")
+        var content = html.replace(Regex("<p>(?: |&#160;|&nbsp;)+"), "<p>")
         if (!content.contains("<p>", ignoreCase = true)) {
             content = content
                 .replace("\n\n", "</p><p>")
@@ -168,6 +214,8 @@ internal class NovelTextRenderer(
     }
 
     companion object {
+        private const val CHUNK_TARGET_CHARS = 6_000
+
         fun clearTextViewSelection(textView: TextView) {
             val text = textView.text
             if (text is Spannable && text.isNotEmpty() &&

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
@@ -49,6 +49,8 @@ internal class NovelTextRenderer(
         val density = activity.resources.displayMetrics.density
         val blockMedia = preferences.novelBlockMedia.get()
 
+        val token = ++block.renderToken
+
         scope.launch {
             val imageGetter = if (!blockMedia && !plainTextMode) {
                 val widthPx = block.chunkViews.firstOrNull()
@@ -83,7 +85,7 @@ internal class NovelTextRenderer(
                 }
             }
 
-            if (!block.container.isAttachedToWindow) return@launch
+            if (token != block.renderToken || !block.container.isAttachedToWindow) return@launch
             block.ensureChunkCount(chunks.size)
 
             if (chunks.isEmpty()) {
@@ -94,24 +96,25 @@ internal class NovelTextRenderer(
             }
 
             val params = TextViewCompat.getTextMetricsParams(block.chunkViews.first())
-            val precomputed = withContext(Dispatchers.Default) {
-                chunks.map { PrecomputedTextCompat.create(it, params) }
+            val (precomputed, fullText) = withContext(Dispatchers.Default) {
+                chunks.map { PrecomputedTextCompat.create(it, params) } to spannable.toString()
             }
 
-            if (!block.container.isAttachedToWindow) return@launch
+            if (token != block.renderToken || !block.container.isAttachedToWindow) return@launch
 
-            block.clearSelections()
             val starts = IntArray(chunks.size)
             var offset = 0
             chunks.forEachIndexed { i, chunk ->
                 starts[i] = offset
                 offset += chunk.length
             }
+
+            block.clearSelections()
             precomputed.forEachIndexed { i, text ->
                 TextViewCompat.setPrecomputedText(block.chunkViews[i], text)
             }
             block.chunkStarts = starts
-            block.fullText = spannable.toString()
+            block.fullText = fullText
             imageGetter?.startLoading()
             onTextSet()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -91,12 +91,12 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     private data class LoadedChapter(
         val chapter: ReaderChapter,
-        val textView: TextView,
+        val block: ChapterTextBlock,
         val headerView: TextView,
         var separatorView: View? = null,
         var isLoaded: Boolean = false,
-        // True once textView.setText has been called — guards against false short-chapter
-        // marks when the empty textView has a smaller height than scrollView.
+        // True once the chunk views received text — guards against false short-chapter
+        // marks when the empty block has a smaller height than scrollView.
         var isTextSet: Boolean = false,
         // Holds pre-processed content to be rendered once the view is attached.
         var pendingContent: ProcessedContent? = null,
@@ -164,7 +164,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 // also fires onSingleTapConfirmed and toggles the app bars.
                 if (e.eventTime - e.downTime >= android.view.ViewConfiguration.getLongPressTimeout()) return true
                 // Never toggle menu while text is selected
-                if (loadedChapters.any { it.textView.hasSelection() }) return false
+                if (loadedChapters.any { it.block.hasSelection() }) return false
 
                 val pos = android.graphics.PointF(
                     e.x / container.width.toFloat(),
@@ -316,8 +316,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     private fun calculateCurrentChapterProgress(scrollY: Int): Float {
         val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return 0f
-        val textTop = loaded.textView.top
-        val textBottom = loaded.textView.bottom
+        val textTop = loaded.block.container.top
+        val textBottom = loaded.block.container.bottom
         val textHeight = textBottom - textTop
 
         // Guard: if the textView hasn't been laid out yet, its height will be 0.
@@ -387,9 +387,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         if (page.status != Page.State.Ready || page.text.isNullOrBlank()) return
 
         val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return
-        // Don't mark while textView still shows empty layout (text set hasn't completed yet).
+        // Don't mark while the block still shows empty layout (text set hasn't completed yet).
         if (!loaded.isTextSet) return
-        val textHeight = loaded.textView.height
+        val textHeight = loaded.block.container.height
         if (textHeight <= 0 || textHeight > scrollView.height) return
 
         lastSavedProgress = 1f
@@ -407,11 +407,11 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         if (loadedChapters.size <= 1) return
 
         // Find the FIRST chapter whose text has not yet been completely scrolled past.
-        // By using textView.bottom (not headerView.top), the separator belongs to neither chapter:
+        // By using the block bottom (not headerView.top), the separator belongs to neither chapter:
         // while the separator is visible, scrollY is below prev chapter's text and above next
         // chapter's text → next chapter is detected (progress = 0% since scrollY < textTop).
         for ((index, loaded) in loadedChapters.withIndex()) {
-            if (loaded.textView.bottom > scrollY) {
+            if (loaded.block.container.bottom > scrollY) {
                 if (currentChapterIndex != index) {
                     onChapterChanged(oldIndex = currentChapterIndex, newIndex = index)
                 }
@@ -631,6 +631,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         }
     }
 
+    private fun createChapterBlock(): ChapterTextBlock =
+        ChapterTextBlock(activity) { createSelectableTextView().also(::applyTextViewStyles) }
+
     private fun applyTextSelectionPreference(textView: TextView) {
         val selectable = preferences.novelTextSelectable.get()
         textView.setTextIsSelectable(selectable)
@@ -646,7 +649,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     private fun refreshAllChapterStyles() {
         loadedChapters.forEach { loaded ->
             if (loaded.isLoaded) {
-                applyTextViewStyles(loaded.textView)
+                loaded.block.chunkViews.forEach(::applyTextViewStyles)
             }
         }
         applyBackgroundColor()
@@ -695,12 +698,14 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     private fun clearTtsSpansInLoadedChapters() {
         loadedChapters.forEach { loaded ->
             if (!loaded.isLoaded) return@forEach
-            val spanned = loaded.textView.text as? android.text.Spannable ?: return@forEach
-            val len = loaded.textView.text.length
-            spanned.getSpans(0, len, BackgroundColorSpan::class.java).forEach { spanned.removeSpan(it) }
-            spanned.getSpans(0, len, ForegroundColorSpan::class.java).forEach { spanned.removeSpan(it) }
-            spanned.getSpans(0, len, UnderlineSpan::class.java).forEach { spanned.removeSpan(it) }
-            spanned.getSpans(0, len, RoundedOutlineSpan::class.java).forEach { spanned.removeSpan(it) }
+            loaded.block.chunkViews.forEach { chunkView ->
+                val spanned = chunkView.text as? android.text.Spannable ?: return@forEach
+                val len = spanned.length
+                spanned.getSpans(0, len, BackgroundColorSpan::class.java).forEach { spanned.removeSpan(it) }
+                spanned.getSpans(0, len, ForegroundColorSpan::class.java).forEach { spanned.removeSpan(it) }
+                spanned.getSpans(0, len, UnderlineSpan::class.java).forEach { spanned.removeSpan(it) }
+                spanned.getSpans(0, len, RoundedOutlineSpan::class.java).forEach { spanned.removeSpan(it) }
+            }
         }
     }
 
@@ -721,35 +726,52 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 loadedChapters.firstOrNull { it.chapter.chapter.id == id }
             } ?: loadedChapters.getOrNull(ttsController.ttsPlaybackChapterIndex)) ?: return@runOnUiThread
             if (!targetLoaded.isLoaded || !targetLoaded.isTextSet) return@runOnUiThread
-            val textView = targetLoaded.textView
-            val text = textView.text.toString()
-            val spanned = textView.text as? android.text.Spannable ?: return@runOnUiThread
+            val block = targetLoaded.block
+            val text = block.fullText ?: return@runOnUiThread
 
             val startIndex = text.indexOf(chunk, startOffset.coerceAtLeast(0))
             if (startIndex < 0) return@runOnUiThread
             val endIndex = (startIndex + chunk.length).coerceAtMost(text.length)
 
-            when (highlightStyle) {
-                "underline" -> spanned.setSpan(UnderlineSpan(), startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                "outline" -> {
-                    spanned.setSpan(RoundedOutlineSpan(highlightColor), startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    spanned.setSpan(ForegroundColorSpan(highlightTextColor), startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            var firstChunkView: TextView? = null
+            var firstChunkLocalStart = 0
+            for ((i, chunkView) in block.chunkViews.withIndex()) {
+                val chunkStart = block.chunkStarts.getOrNull(i) ?: break
+                val chunkEnd = chunkStart + chunkView.text.length
+                if (chunkEnd <= startIndex) continue
+                if (chunkStart >= endIndex) break
+                val spanned = chunkView.text as? android.text.Spannable ?: continue
+                val localStart = (startIndex - chunkStart).coerceAtLeast(0)
+                val localEnd = (endIndex - chunkStart).coerceAtMost(spanned.length)
+                if (localEnd <= localStart) continue
+                if (firstChunkView == null) {
+                    firstChunkView = chunkView
+                    firstChunkLocalStart = localStart
                 }
-                else -> {
-                    spanned.setSpan(BackgroundColorSpan(highlightColor), startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    spanned.setSpan(ForegroundColorSpan(highlightTextColor), startIndex, endIndex, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                when (highlightStyle) {
+                    "underline" -> spanned.setSpan(UnderlineSpan(), localStart, localEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    "outline" -> {
+                        spanned.setSpan(RoundedOutlineSpan(highlightColor), localStart, localEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        spanned.setSpan(ForegroundColorSpan(highlightTextColor), localStart, localEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    }
+                    else -> {
+                        spanned.setSpan(BackgroundColorSpan(highlightColor), localStart, localEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        spanned.setSpan(ForegroundColorSpan(highlightTextColor), localStart, localEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    }
                 }
             }
 
             if (keepInView) {
+                val scrollTarget = firstChunkView ?: return@runOnUiThread
+                val localStart = firstChunkLocalStart
                 fun doScroll() {
-                    val layout = textView.layout ?: return
-                    val line = layout.getLineForOffset(startIndex.coerceAtMost(layout.text.length - 1).coerceAtLeast(0))
-                    val targetInTextView = layout.getLineTop(line)
-                    val targetInScroll = textView.top + targetInTextView - (scrollView.height / 3)
+                    val layout = scrollTarget.layout ?: return
+                    val line = layout.getLineForOffset(localStart.coerceAtMost(layout.text.length - 1).coerceAtLeast(0))
+                    val targetInChunk = layout.getLineTop(line)
+                    val targetInScroll = block.container.top + scrollTarget.top + targetInChunk - (scrollView.height / 3)
                     scrollView.smoothScrollTo(0, targetInScroll.coerceAtLeast(0))
                 }
-                if (textView.layout != null) doScroll() else textView.post { doScroll() }
+                if (scrollTarget.layout != null) doScroll() else scrollTarget.post { doScroll() }
             }
         }
     }
@@ -761,7 +783,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             if (moveToLoadedNextChapterForTts(anchorChapterIndex)) {
                 // For already-loaded chapters, text is ready — start immediately.
                 // For pre-fetched chapters, moveToLoadedNextChapterForTts sets pendingTtsAutoStart
-                // and fires setTextViewContent; startTts() will be called once the spannable is ready.
+                // and fires setChapterContent; startTts() will be called once the chunks are ready.
                 if (!pendingTtsAutoStart) {
                     startTts()
                 }
@@ -834,12 +856,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                         setPadding(16, 32, 16, 16)
                         isVisible = false
                     }
-                    val textView = createSelectableTextView()
-                    applyTextViewStyles(textView)
-
                     val cachedChapter = LoadedChapter(
                         chapter = preparedChapter,
-                        textView = textView,
+                        block = createChapterBlock(),
                         headerView = headerView,
                         isLoaded = true,
                         isTextSet = false,
@@ -888,7 +907,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             contentContainer.addView(separator)
             cached.separatorView = separator
             contentContainer.addView(cached.headerView)
-            contentContainer.addView(cached.textView)
+            contentContainer.addView(cached.block.container)
             chapterQueue.append(cached)
             scrollView.post { isRestoringScroll = false }
 
@@ -901,13 +920,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             }
             logcat(LogPriority.DEBUG) { "TTS: used pre-fetched chapter ${cached.chapter.chapter.name} ts=${System.currentTimeMillis()}" }
 
-            // View is now attached — render the stored content. setTextViewContent's coroutine
-            // will set pendingTtsAutoStart → startTts() once the spannable is ready.
+            // View is now attached — render the stored content. setChapterContent's coroutine
+            // will set pendingTtsAutoStart → startTts() once the chunks are ready.
             val content = cached.pendingContent
             if (content != null) {
                 cached.pendingContent = null
                 pendingTtsAutoStart = true
-                setTextViewContent(cached.textView, content)
+                setChapterContent(cached, content)
             }
             return true
         }
@@ -936,8 +955,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
         syncCurrentChapterIndexWithCurrentPage()
-        val text = loadedChapters.getOrNull(currentChapterIndex)?.textView?.text?.toString()
-            ?: loadedChapters.firstOrNull()?.textView?.text?.toString()
+        val text = loadedChapters.getOrNull(currentChapterIndex)?.block?.fullText
+            ?: loadedChapters.firstOrNull()?.block?.fullText
         if (text.isNullOrEmpty()) {
             logcat(LogPriority.WARN) { "TTS: No text to speak. loadedChapters=${loadedChapters.size}, currentIndex=$currentChapterIndex" }
             return
@@ -997,8 +1016,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
         syncCurrentChapterIndexWithCurrentPage()
-        val text = loadedChapters.getOrNull(currentChapterIndex)?.textView?.text?.toString()
-            ?: loadedChapters.firstOrNull()?.textView?.text?.toString()
+        val text = loadedChapters.getOrNull(currentChapterIndex)?.block?.fullText
+            ?: loadedChapters.firstOrNull()?.block?.fullText
         if (text.isNullOrEmpty()) {
             logcat(LogPriority.WARN) { "TTS: No text available for viewport start" }
             return
@@ -1042,18 +1061,21 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
         loadedChapters.forEach { loaded ->
             if (!loaded.isLoaded) return@forEach
-            val textView = loaded.textView
-            val textViewTop = textView.top
-            val textViewBottom = textViewTop + textView.height
+            val containerTop = loaded.block.container.top
+            for ((i, chunkView) in loaded.block.chunkViews.withIndex()) {
+                val chunkTop = containerTop + chunkView.top
+                val chunkBottom = chunkTop + chunkView.height
 
-            if (textViewBottom > viewportTop && textViewTop < viewportBottom) {
-                val layout = textView.layout ?: return 0
-                if (layout.lineCount > 0) {
-                    val textViewRelativeY = (viewportTop - textViewTop).coerceAtLeast(0)
-                    val lineAtViewportTop = layout.getLineForVertical(textViewRelativeY.coerceAtMost(layout.height))
-                    val charOffset = layout.getLineStart(lineAtViewportTop).coerceAtLeast(0)
-                    val pIdx = paragraphOffsets.indexOfLast { it <= charOffset }
-                    return if (pIdx >= 0) pIdx else 0
+                if (chunkBottom > viewportTop && chunkTop < viewportBottom) {
+                    val layout = chunkView.layout ?: return 0
+                    if (layout.lineCount > 0) {
+                        val chunkRelativeY = (viewportTop - chunkTop).coerceAtLeast(0)
+                        val lineAtViewportTop = layout.getLineForVertical(chunkRelativeY.coerceAtMost(layout.height))
+                        val chunkStart = loaded.block.chunkStarts.getOrNull(i) ?: 0
+                        val charOffset = (chunkStart + layout.getLineStart(lineAtViewportTop)).coerceAtLeast(0)
+                        val pIdx = paragraphOffsets.indexOfLast { it <= charOffset }
+                        return if (pIdx >= 0) pIdx else 0
+                    }
                 }
             }
         }
@@ -1080,7 +1102,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         loadedChapters.forEach { loadedChapter ->
             val page = loadedChapter.chapter.pages?.firstOrNull() ?: return@forEach
             val content = page.text ?: return@forEach
-            val textView = loadedChapter.textView
+            val block = loadedChapter.block
             val cfg = ContentConfig.from(
                 preferences,
                 RenderTarget.TEXT_VIEW,
@@ -1091,14 +1113,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             scope.launch {
                 val pre = withContext(Dispatchers.Default) { contentPipeline.preTranslate(content, cfg) }
                 val processed = if (activity.isTranslationEnabled()) {
-                    textView.gravity = Gravity.CENTER
                     val chapterId = loadedChapter.chapter.chapter.id
                     val labelRes = if (activity.hasCachedTranslation(chapterId)) {
                         TDMR.strings.novel_chapter_translating_from_cache
                     } else {
                         TDMR.strings.novel_chapter_translating_from_api
                     }
-                    textView.text = activity.stringResource(labelRes)
+                    block.showPlaceholder(activity.stringResource(labelRes))
                     withContext(Dispatchers.Default) {
                         contentPipeline.finalize(pre, cfg) { activity.translateContentIfEnabled(it, chapterId) }
                     }
@@ -1106,8 +1127,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     withContext(Dispatchers.Default) { contentPipeline.finalize(pre, cfg) }
                 }
                 if (generation != renderGeneration) return@launch
-                if (!textView.isAttachedToWindow) return@launch
-                setTextViewContent(textView, processed)
+                if (!block.container.isAttachedToWindow) return@launch
+                setChapterContent(loadedChapter, processed)
             }
         }
     }
@@ -1207,13 +1228,11 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             isVisible = false
         }
 
-        val textView = createSelectableTextView()
-
-        applyTextViewStyles(textView)
+        val block = createChapterBlock()
 
         val loadedChapter = LoadedChapter(
             chapter = chapter,
-            textView = textView,
+            block = block,
             headerView = headerView,
             isLoaded = true,
         )
@@ -1249,7 +1268,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         }
 
         contentContainer.addView(headerView)
-        contentContainer.addView(textView)
+        contentContainer.addView(block.container)
 
         val cfg = ContentConfig.from(
             preferences,
@@ -1260,23 +1279,20 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         scope.launch {
             val pre = withContext(Dispatchers.Default) { contentPipeline.preTranslate(rawContent, cfg) }
             if (activity.isTranslationEnabled() && !preferences.novelShowRawHtml.get()) {
-                val savedGravity = textView.gravity
-                textView.gravity = Gravity.CENTER
                 val chapterId = chapter.chapter.id
                 val labelRes = if (activity.hasCachedTranslation(chapterId)) {
                     TDMR.strings.novel_chapter_translating_from_cache
                 } else {
                     TDMR.strings.novel_chapter_translating_from_api
                 }
-                textView.text = activity.stringResource(labelRes)
+                block.showPlaceholder(activity.stringResource(labelRes))
                 val translated = withContext(Dispatchers.Default) {
                     contentPipeline.finalize(pre, cfg) { activity.translateContentIfEnabled(it, chapterId) }
                 }
-                textView.gravity = savedGravity
-                setTextViewContent(textView, translated)
+                setChapterContent(loadedChapter, translated)
             } else {
                 val processed = withContext(Dispatchers.Default) { contentPipeline.finalize(pre, cfg) }
-                setTextViewContent(textView, processed)
+                setChapterContent(loadedChapter, processed)
             }
         }
 
@@ -1349,7 +1365,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val maxChapters = 3
         while (loadedChapters.size > maxChapters && currentChapterIndex > 0) {
             val toRemove = loadedChapters.first()
-            var removedHeight = toRemove.headerView.height + toRemove.textView.height
+            var removedHeight = toRemove.headerView.height + toRemove.block.container.height
 
             toRemove.separatorView?.let { sep ->
                 removedHeight += sep.height
@@ -1357,7 +1373,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             }
 
             contentContainer.removeView(toRemove.headerView)
-            contentContainer.removeView(toRemove.textView)
+            contentContainer.removeView(toRemove.block.container)
             chapterQueue.removeFirst()
 
             if (loadedChapters.isNotEmpty()) {
@@ -1509,27 +1525,24 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     private fun getThemeColors(theme: String): Pair<Int, Int> =
         ThemeUtils.getThemeColors(activity, preferences, theme)
 
-    private fun setTextViewContent(textView: TextView, processed: ProcessedContent) {
+    private fun setChapterContent(loaded: LoadedChapter, processed: ProcessedContent) {
         textRenderer.render(
-            textView = textView,
+            block = loaded.block,
             processed = processed,
-            clearSelection = ::clearTextViewSelection,
-            onTextSet = ::onChapterTextSet,
+            onTextSet = { onChapterTextSet(loaded) },
         )
     }
 
-    private fun onChapterTextSet(textView: TextView) {
-        val loadedIdx = loadedChapters.indexOfFirst { it.textView === textView }
-        if (loadedIdx >= 0) {
-            loadedChapters[loadedIdx].isTextSet = true
-        }
+    private fun onChapterTextSet(loaded: LoadedChapter) {
+        loaded.isTextSet = true
         if (pendingTtsAutoStart) {
             pendingTtsAutoStart = false
+            val loadedIdx = loadedChapters.indexOf(loaded)
             if (loadedIdx >= 0) {
                 currentChapterIndex = loadedIdx
-                loadedChapters[loadedIdx].chapter.pages?.firstOrNull()?.let { page ->
+                loaded.chapter.pages?.firstOrNull()?.let { page ->
                     currentPage = page
-                    activity.viewModel.setNovelVisibleChapter(loadedChapters[loadedIdx].chapter.chapter)
+                    activity.viewModel.setNovelVisibleChapter(loaded.chapter.chapter)
                     activity.onPageSelected(page)
                     activity.onNovelProgressChanged(0f)
                 }
@@ -1537,9 +1550,6 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             startTts()
         }
     }
-
-    private fun clearTextViewSelection(textView: TextView) =
-        NovelTextRenderer.clearTextViewSelection(textView)
 
 
     private var initialLoadingView: TextView? = null
@@ -1702,14 +1712,14 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         for ((index, loadedChapter) in loadedChapters.withIndex()) {
             val separatorHeight = loadedChapter.separatorView?.height ?: 0
             if (index == currentChapterIndex) {
-                val chapterHeight = loadedChapter.headerView.height + loadedChapter.textView.height + separatorHeight
+                val chapterHeight = loadedChapter.headerView.height + loadedChapter.block.container.height + separatorHeight
                 val visibleHeight = scrollView.height
                 val effectiveChapterHeight = (chapterHeight - visibleHeight).coerceAtLeast(1)
                 val chapterScrollY = accumulatedHeight + (effectiveChapterHeight * progress).toInt()
                 scrollView.scrollTo(0, chapterScrollY)
                 return
             }
-            accumulatedHeight += loadedChapter.headerView.height + loadedChapter.textView.height + separatorHeight
+            accumulatedHeight += loadedChapter.headerView.height + loadedChapter.block.container.height + separatorHeight
         }
     }
 
@@ -1771,15 +1781,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     fun getSelectedText(): String? {
         val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return null
-        val textView = loaded.textView
-        if (!textView.hasSelection()) return null
-
-        val start = textView.selectionStart
-        val end = textView.selectionEnd
-        if (start < 0 || end < 0 || start >= end) return null
-
-        val text = textView.text.toString()
-        return text.substring(start, end)
+        return loaded.block.selectedText()
     }
 
     fun getCurrentChapterName(): String? {
@@ -1789,10 +1791,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     fun clearTextSelection() {
         val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return
-        val textView = loaded.textView
-        if (textView.hasSelection()) {
-            textView.clearFocus()
-        }
+        loaded.block.clearSelections()
     }
 
     private fun onRememberSelectedText() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
@@ -46,18 +46,24 @@ internal class NovelWebViewImageCache(
             return WebResourceResponse(
                 guessMimeType(imagePath),
                 "UTF-8",
-                cachedFile.readBytes().inputStream(),
+                cachedFile.inputStream(),
             )
         }
 
         if (loader == null) return null
         prefetchJobs.remove(cacheKey)?.cancel()
         return try {
-            val bytes = runBlocking { loader.getPageDataStream(imagePath)?.use { it.readBytes() } } ?: return null
             val cachedFile = makeCachedFile(cacheKey, imagePath)
-            cachedFile.writeBytes(bytes)
+            // Stream source → file (no full-image byte[] held in memory), then serve from the file.
+            val wrote = runBlocking {
+                loader.getPageDataStream(imagePath)?.use { input ->
+                    cachedFile.outputStream().use { output -> input.copyTo(output) }
+                    true
+                } ?: false
+            }
+            if (!wrote) return null
             cache[cacheKey] = cachedFile
-            WebResourceResponse(guessMimeType(imagePath), "UTF-8", bytes.inputStream())
+            WebResourceResponse(guessMimeType(imagePath), "UTF-8", cachedFile.inputStream())
         } catch (e: Exception) {
             logcat(LogPriority.DEBUG) { "NovelWebViewImageCache: sync load $imagePath failed: ${e.message}" }
             null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1067,15 +1067,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Appended chapter $chapterId (${loadedChapterIds.size} total)" }
     }
 
-    private fun loadHtmlContent(
+    private suspend fun loadHtmlContent(
         processed: ProcessedContent,
         chapter: ReaderChapter? = null,
     ) {
         val chapterModel = chapter?.chapter
         val chapterId = chapterModel?.id ?: -1L
         val chapterPath = chapterModel?.url.orEmpty()
-
-        imageCache.schedulePrefetch(processed.text, chapterId.takeIf { it != -1L }, currentPage?.chapter?.pageLoader)
 
         val stylePayload = styler.buildPayload()
         webView.setBackgroundColor(stylePayload.backgroundColor)
@@ -1084,17 +1082,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         chapterQueue.clear()
         currentChapterIndex = 0
 
-        val html = NovelWebViewDocumentBuilder.assemble(
-            NovelWebViewDocumentBuilder.DocumentInput(
-                processed = processed,
-                chapter = chapter,
-                style = stylePayload,
-                themeTokens = ThemeUtils.getThemeTokens(activity, preferences, preferences.novelTheme.get()),
-                tsundokuScript = buildTsundokuScript(),
-                infiniteScrollEnabled = preferences.novelInfiniteScroll.get(),
-                blockMedia = preferences.novelBlockMedia.get(),
-            ),
+        // Inputs are gathered on Main (touch viewer state), but the heavy work — the image-URL
+        // regex scan and the Jsoup parse + full-document string build — runs off the main thread.
+        // For large chapters this was a multi-MB alloc + DOM parse on the UI thread (frame skips).
+        val input = NovelWebViewDocumentBuilder.DocumentInput(
+            processed = processed,
+            chapter = chapter,
+            style = stylePayload,
+            themeTokens = ThemeUtils.getThemeTokens(activity, preferences, preferences.novelTheme.get()),
+            tsundokuScript = buildTsundokuScript(),
+            infiniteScrollEnabled = preferences.novelInfiniteScroll.get(),
+            blockMedia = preferences.novelBlockMedia.get(),
         )
+        val pageLoader = currentPage?.chapter?.pageLoader
+        val html = withContext(Dispatchers.Default) {
+            imageCache.schedulePrefetch(processed.text, chapterId.takeIf { it != -1L }, pageLoader)
+            NovelWebViewDocumentBuilder.assemble(input)
+        }
 
         // Signal to onPageFinished that the next callback is for real chapter content, not
         // the loading-indicator page (which also fires onPageFinished with url="about:blank").


### PR DESCRIPTION
large txt/md chapters caused constant GC.
 ChapterTextBlock holds a column of ~6k-char chunk TextViews split at paragraph boundaries, keeping layout and selection O(chunk).

NovelImageGetter resolves the target chunk view per drawable, and NovelViewer remaps TTS highlight, scroll and progress across chunk boundaries.
webview: stream images, offload some work to dispatchers
I nearly went insane listening to tts at 6x over and over to see if it works properly with chunks
