### PR TITLE
fix(library): per-type extensions cache in settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Always serve cached translations [@mrissaoussama](https://github.com/mrissaoussama) [#236](https://github.com/tsundoku-otaku/tsundoku/pull/236)
 - JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)
 - Fix service restrictions and background start crashes [@mrissaoussama](https://github.com/mrissaoussama) [#243](https://github.com/tsundoku-otaku/tsundoku/pull/243)
+- Library settings now has per-type extension cache [@mrissaoussama](https://github.com/mrissaoussama) [#259](https://github.com/tsundoku-otaku/tsundoku/pull/259)
 - Encoding issues when parsing jssource chapters [@mrissaoussama](https://github.com/mrissaoussama) [#224](https://github.com/tsundoku-otaku/tsundoku/pull/224)
 - Fix accuracy of mass import notification [@mrissaoussama](https://github.com/mrissaoussama) [#254](https://github.com/tsundoku-otaku/tsundoku/pull/254)
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/LibrarySettingsCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/LibrarySettingsCache.kt
@@ -19,26 +19,32 @@ class LibrarySettingsCache(private val context: Context) {
         File(context.filesDir, "library_cache").apply { mkdirs() }
     }
 
-    private val extensionsFile by lazy { File(cacheDir, "extensions.json") }
     private val tagsFile by lazy { File(cacheDir, "tags.json") }
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun saveExtensions(extensions: List<ExtensionInfo>) {
+    // The list is saved already filtered by library type (manga/novel/all), so each type needs
+    // its own file: a shared one served the manga tab's list to the novel tab until a manual
+    // refresh, and vice versa. The pre-split "extensions.json" is removed on first save.
+    private fun extensionsFile(typeKey: String) = File(cacheDir, "extensions_$typeKey.json")
+
+    fun saveExtensions(typeKey: String, extensions: List<ExtensionInfo>) {
         try {
-            val data = extensions.map { ExtensionData(it.sourceId, it.sourceName, it.isStub) }
-            extensionsFile.writeText(json.encodeToString(data))
+            val data = extensions.map { ExtensionData(it.sourceId, it.sourceName, it.isStub, it.isNovel, it.isCustom) }
+            File(cacheDir, "extensions.json").delete()
+            extensionsFile(typeKey).writeText(json.encodeToString(data))
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Failed to save extensions cache" }
         }
     }
 
-    fun loadExtensions(): List<ExtensionInfo>? {
+    fun loadExtensions(typeKey: String): List<ExtensionInfo>? {
         return try {
-            if (!extensionsFile.exists()) return null
-            val text = extensionsFile.readText()
+            val file = extensionsFile(typeKey)
+            if (!file.exists()) return null
+            val text = file.readText()
             val data = json.decodeFromString<List<ExtensionData>>(text)
-            data.map { ExtensionInfo(it.id, it.name, it.isStub) }
+            data.map { ExtensionInfo(it.id, it.name, it.isStub, it.isNovel, it.isCustom) }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Failed to load extensions cache" }
             null
@@ -74,6 +80,8 @@ class LibrarySettingsCache(private val context: Context) {
         val id: Long,
         val name: String,
         val isStub: Boolean = false,
+        val isNovel: Boolean = false,
+        val isCustom: Boolean = false,
     )
 
     @Serializable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -215,7 +215,7 @@ class LibrarySettingsScreenModel(
             try {
                 // Try loading from disk cache first if not forced and not loaded yet
                 if (!forceRefresh && !_extensionsLoaded.get()) {
-                    val cached = librarySettingsCache.loadExtensions()
+                    val cached = librarySettingsCache.loadExtensions(type.name)
                     if (cached != null && cached.isNotEmpty()) {
                         _extensionsFlow.value = cached
                         _extensionsLoaded.set(true)
@@ -253,7 +253,7 @@ class LibrarySettingsScreenModel(
                 )
 
                 _extensionsFlow.value = extensions
-                librarySettingsCache.saveExtensions(extensions)
+                librarySettingsCache.saveExtensions(type.name, extensions)
                 _extensionsLoaded.set(true)
             } catch (e: Exception) {
                 // Ignore error, keep empty list


### PR DESCRIPTION
The settings dialog cached one filtered extensions list shared by all library types and dropped isNovel/isCustom on load, so the novel tab served the manga tab's cached list (and vice versa) until a manual refresh

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
