### PR TITLE
feat: Give refresh context for chapter lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Better detect novels via proeprty, drop reflection [@mrissaoussama](https://github.com/mrissaoussama) [#257](https://github.com/tsundoku-otaku/tsundoku/pull/257)
 - Expanded custom HTTP engine options [@mrissaoussama](https://github.com/mrissaoussama) [#250](https://github.com/tsundoku-otaku/tsundoku/pull/250)
 - Added tsundoku specific extensions, so apps can avoid appearing as manga sources in other apps [@mrissaoussama](https://github.com/mrissaoussama) [#238](https://github.com/tsundoku-otaku/tsundoku/pull/238)
+- Implement RefreshContext interface for getChapterList, enabling extensions to avoid redundant requests [@Rojikku](https://github.com/Rojikku) [#260](https://github.com/tsundoku-otaku/tsundoku/pull/260)
 
 
 ## [v0.1.4] - 2026-05-09

--- a/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
@@ -1,9 +1,16 @@
 package eu.kanade.domain.chapter.model
 
 import eu.kanade.tachiyomi.data.database.models.ChapterImpl
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import tachiyomi.domain.chapter.model.Chapter
 import eu.kanade.tachiyomi.data.database.models.Chapter as DbChapter
+
+/**
+ * Builds the chapter list for a [RefreshContext], sorted by sourceOrder.
+ */
+fun List<Chapter>.toRefreshContextChapters(): List<SChapter> =
+    sortedBy { it.sourceOrder }.map { it.toSChapter() }
 
 // TODO: Remove when all deps are migrated
 fun Chapter.toSChapter(): SChapter {

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -105,6 +105,7 @@ fun MangaScreen(
 
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
+    onForceRefresh: (() -> Unit)? = null,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
 
@@ -170,6 +171,7 @@ fun MangaScreen(
             onCopyTagToClipboard = onCopyTagToClipboard,
             onFilterClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
+            onForceRefresh = onForceRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
             onCoverClicked = onCoverClicked,
@@ -218,6 +220,7 @@ fun MangaScreen(
             onCopyTagToClipboard = onCopyTagToClipboard,
             onFilterButtonClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
+            onForceRefresh = onForceRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
             onCoverClicked = onCoverClicked,
@@ -272,6 +275,7 @@ private fun MangaScreenSmallImpl(
 
     onFilterClicked: () -> Unit,
     onRefresh: () -> Unit,
+    onForceRefresh: (() -> Unit)? = null,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
 
@@ -439,6 +443,7 @@ private fun MangaScreenSmallImpl(
         PullRefresh(
             refreshing = state.isRefreshingData,
             onRefresh = onRefresh,
+            onForceRefresh = onForceRefresh,
             enabled = !isAnySelected,
             indicatorPadding = PaddingValues(top = topPadding),
         ) {
@@ -571,6 +576,7 @@ fun MangaScreenLargeImpl(
 
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
+    onForceRefresh: (() -> Unit)? = null,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
 
@@ -736,6 +742,7 @@ fun MangaScreenLargeImpl(
         PullRefresh(
             refreshing = state.isRefreshingData,
             onRefresh = onRefresh,
+            onForceRefresh = onForceRefresh,
             enabled = !isAnySelected,
             indicatorPadding = PaddingValues(
                 start = insetPadding.calculateStartPadding(layoutDirection),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -20,8 +20,10 @@ import androidx.work.WorkQuery
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
+import eu.kanade.domain.chapter.model.toSChapter
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.notification.Notifications
@@ -49,6 +51,7 @@ import tachiyomi.core.common.preference.getAndSet
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.model.NoChaptersException
 import tachiyomi.domain.download.service.NovelDownloadPreferences
@@ -98,6 +101,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val getManga: GetManga = Injekt.get()
     private val updateManga: UpdateManga = Injekt.get()
     private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
+    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get()
     private val fetchInterval: FetchInterval = Injekt.get()
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get()
     private val novelDownloadPreferences: NovelDownloadPreferences = Injekt.get()
@@ -480,7 +484,13 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
         if (skipChapterFetch) return emptyList()
 
-        val chapters = source.getChapterList(manga.toSManga())
+        val existingChapters = getChaptersByMangaId.await(manga.id)
+        val refreshContext = RefreshContext(
+            mangaId = manga.id,
+            existingChapters = existingChapters.map { it.toSChapter() },
+            lastFetchTime = manga.lastUpdate,
+        )
+        val chapters = source.getChapterList(manga.toSManga(), refreshContext)
 
         // Get manga from database to account for if it was removed during the update and
         // to get latest data so it doesn't get overwritten later on

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -20,7 +20,7 @@ import androidx.work.WorkQuery
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
-import eu.kanade.domain.chapter.model.toSChapter
+import eu.kanade.domain.chapter.model.toRefreshContextChapters
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.source.model.RefreshContext
@@ -487,7 +487,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         val existingChapters = getChaptersByMangaId.await(manga.id)
         val refreshContext = RefreshContext(
             mangaId = manga.id,
-            existingChapters = existingChapters.map { it.toSChapter() },
+            existingChapters = existingChapters.toRefreshContextChapters(),
             lastFetchTime = manga.lastUpdate,
         )
         val chapters = source.getChapterList(manga.toSManga(), refreshContext)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -155,6 +155,7 @@ class MangaScreen(
             onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
             onFilterButtonClicked = screenModel::showSettingsDialog,
             onRefresh = screenModel::fetchAllFromSource,
+            onForceRefresh = { screenModel.fetchAllFromSource(forceRefresh = true) },
             onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },
             onSearch = { query, global ->
                 scope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -308,12 +308,12 @@ class MangaScreenModel(
         }
     }
 
-    fun fetchAllFromSource(manualFetch: Boolean = true) {
+    fun fetchAllFromSource(manualFetch: Boolean = true, forceRefresh: Boolean = false) {
         screenModelScope.launch {
             updateSuccessState { it.copy(isRefreshingData = true) }
             val fetchFromSourceTasks = listOf(
                 async { fetchMangaFromSource(manualFetch) },
-                async { fetchChaptersFromSource(manualFetch) },
+                async { fetchChaptersFromSource(manualFetch, forceRefresh) },
             )
             fetchFromSourceTasks.awaitAll()
             updateSuccessState { it.copy(isRefreshingData = false) }
@@ -721,15 +721,16 @@ class MangaScreenModel(
     /**
      * Requests an updated list of chapters from the source.
      */
-    private suspend fun fetchChaptersFromSource(manualFetch: Boolean = false) {
+    private suspend fun fetchChaptersFromSource(manualFetch: Boolean = false, forceRefresh: Boolean = false) {
         val state = successState ?: return
         try {
             withIOContext {
                 val existingChapters = getMangaAndChapters.awaitChapters(state.manga.id)
                 val refreshContext = RefreshContext(
                     mangaId = state.manga.id,
-                    existingChapters = existingChapters.map { it.toSChapter() },
+                    existingChapters = if (forceRefresh) emptyList() else existingChapters.map { it.toSChapter() },
                     lastFetchTime = state.manga.lastUpdate,
+                    forceRefresh = forceRefresh,
                 )
                 val chapters = state.source.getChapterList(state.manga.toSManga(), refreshContext)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -17,6 +17,7 @@ import eu.kanade.core.util.insertSeparators
 import eu.kanade.domain.chapter.interactor.GetAvailableScanlators
 import eu.kanade.domain.chapter.interactor.SetReadStatus
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
+import eu.kanade.domain.chapter.model.toSChapter
 import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.UpdateManga
@@ -43,6 +44,7 @@ import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isNovelSource
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
@@ -723,7 +725,13 @@ class MangaScreenModel(
         val state = successState ?: return
         try {
             withIOContext {
-                val chapters = state.source.getChapterList(state.manga.toSManga())
+                val existingChapters = getMangaAndChapters.awaitChapters(state.manga.id)
+                val refreshContext = RefreshContext(
+                    mangaId = state.manga.id,
+                    existingChapters = existingChapters.map { it.toSChapter() },
+                    lastFetchTime = state.manga.lastUpdate,
+                )
+                val chapters = state.source.getChapterList(state.manga.toSManga(), refreshContext)
 
                 val newChapters = syncChaptersWithSource.await(
                     chapters,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -17,7 +17,7 @@ import eu.kanade.core.util.insertSeparators
 import eu.kanade.domain.chapter.interactor.GetAvailableScanlators
 import eu.kanade.domain.chapter.interactor.SetReadStatus
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
-import eu.kanade.domain.chapter.model.toSChapter
+import eu.kanade.domain.chapter.model.toRefreshContextChapters
 import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.UpdateManga
@@ -728,7 +728,7 @@ class MangaScreenModel(
                 val existingChapters = getMangaAndChapters.awaitChapters(state.manga.id)
                 val refreshContext = RefreshContext(
                     mangaId = state.manga.id,
-                    existingChapters = if (forceRefresh) emptyList() else existingChapters.map { it.toSChapter() },
+                    existingChapters = if (forceRefresh) emptyList() else existingChapters.toRefreshContextChapters(),
                     lastFetchTime = state.manga.lastUpdate,
                     forceRefresh = forceRefresh,
                 )

--- a/app/src/test/java/eu/kanade/domain/chapter/model/RefreshContextChaptersTest.kt
+++ b/app/src/test/java/eu/kanade/domain/chapter/model/RefreshContextChaptersTest.kt
@@ -1,0 +1,80 @@
+package eu.kanade.domain.chapter.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.model.Chapter
+
+class RefreshContextChaptersTest {
+
+    private fun chapter(
+        url: String,
+        sourceOrder: Long,
+        read: Boolean = false,
+        lastPageRead: Long = 0,
+    ) = Chapter.create().copy(
+        url = url,
+        name = url.trimStart('/'),
+        sourceOrder = sourceOrder,
+        read = read,
+        lastPageRead = lastPageRead,
+    )
+
+    @Test
+    fun `result is ordered newest-first by sourceOrder regardless of input order`() {
+        val dbRowOrder = listOf(
+            chapter("/c3", sourceOrder = 1),
+            chapter("/c2", sourceOrder = 2),
+            chapter("/c1", sourceOrder = 3),
+            chapter("/c4", sourceOrder = 0),
+        )
+
+        val result = dbRowOrder.toRefreshContextChapters()
+
+        assertEquals(listOf("/c4", "/c3", "/c2", "/c1"), result.map { it.url })
+    }
+
+    @Test
+    fun `already sorted input stays newest-first`() {
+        val sorted = listOf(
+            chapter("/c4", sourceOrder = 0),
+            chapter("/c3", sourceOrder = 1),
+            chapter("/c2", sourceOrder = 2),
+            chapter("/c1", sourceOrder = 3),
+        )
+
+        val result = sorted.toRefreshContextChapters()
+
+        assertEquals(listOf("/c4", "/c3", "/c2", "/c1"), result.map { it.url })
+    }
+
+    @Test
+    fun `empty input yields empty output`() {
+        assertTrue(emptyList<Chapter>().toRefreshContextChapters().isEmpty())
+    }
+
+    @Test
+    fun `read state and progress are carried into the SChapter`() {
+        val input = listOf(
+            chapter("/c2", sourceOrder = 0, read = false, lastPageRead = 0),
+            chapter("/c1", sourceOrder = 1, read = true, lastPageRead = 42),
+        )
+
+        val result = input.toRefreshContextChapters().associateBy { it.url }
+
+        assertEquals(true, result.getValue("/c1").read)
+        assertEquals(42, result.getValue("/c1").last_page_read)
+        assertEquals(false, result.getValue("/c2").read)
+        assertEquals(0, result.getValue("/c2").last_page_read)
+    }
+
+    @Test
+    fun `no chapter is dropped`() {
+        val input = (0L until 250L).map { chapter("/c$it", sourceOrder = it) }
+
+        val result = input.toRefreshContextChapters()
+
+        assertEquals(input.size, result.size)
+        assertEquals(input.map { it.url }.toSet(), result.map { it.url }.toSet())
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/source/SourceRefreshContextTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/SourceRefreshContextTest.kt
@@ -1,0 +1,78 @@
+package eu.kanade.tachiyomi.source
+
+import eu.kanade.tachiyomi.source.model.RefreshContext
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class SourceRefreshContextTest {
+
+    private val manga = SManga.create().apply { url = "/novel"; title = "Novel" }
+
+    private fun chapter(url: String) = SChapter.create().apply { this.url = url; name = url }
+
+    private fun refreshContext(existing: List<SChapter> = emptyList(), force: Boolean = false) =
+        RefreshContext(mangaId = 1L, existingChapters = existing, lastFetchTime = 0L, forceRefresh = force)
+
+    /** Legacy source: only the old single-arg [getChapterList] is implemented. */
+    private class LegacySource(private val chapters: List<SChapter>) : Source {
+        override val id = 1L
+        override val name = "Legacy"
+        var legacyCallCount = 0
+        override suspend fun getChapterList(manga: SManga): List<SChapter> {
+            legacyCallCount++
+            return chapters
+        }
+    }
+
+    /** Context-aware source: overrides the new two-arg [getChapterList]. */
+    private class ContextSource : Source {
+        override val id = 2L
+        override val name = "Context"
+        var receivedContext: RefreshContext? = null
+        override suspend fun getChapterList(manga: SManga): List<SChapter> =
+            error("legacy path must not be used when override is present")
+        override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+            receivedContext = context
+            return context.existingChapters
+        }
+    }
+
+    @Test
+    fun `default context overload falls back to the legacy method`() = runBlocking {
+        val expected = listOf(chapter("/c1"), chapter("/c2"))
+        val source = LegacySource(expected)
+
+        val result = source.getChapterList(manga, refreshContext())
+
+        assertEquals(expected, result)
+        assertEquals(1, source.legacyCallCount)
+    }
+
+    @Test
+    fun `legacy fallback ignores context contents`() = runBlocking {
+        val source = LegacySource(listOf(chapter("/only")))
+
+        val result = source.getChapterList(
+            manga,
+            refreshContext(existing = listOf(chapter("/stale")), force = true),
+        )
+
+        assertEquals(listOf("/only"), result.map { it.url })
+    }
+
+    @Test
+    fun `overriding source receives the context`() = runBlocking {
+        val source = ContextSource()
+        val existing = listOf(chapter("/c1"))
+        val ctx = refreshContext(existing = existing)
+
+        val result = source.getChapterList(manga, ctx)
+
+        assertSame(ctx, source.receivedContext)
+        assertEquals(existing, result)
+    }
+}

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/PullRefresh.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/PullRefresh.kt
@@ -1,6 +1,7 @@
 package tachiyomi.presentation.core.components.material
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -23,11 +24,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
-// Pull must reach 1.8× the normal threshold to enter force-refresh zone.
-private const val FORCE_THRESHOLD = 1.8f
+// Pull must reach 1.5× the normal threshold to enter force-refresh zone.
+private const val FORCE_THRESHOLD = 1.5f
 
 // Milliseconds the user must hold in the force zone to trigger force refresh.
 private const val FORCE_HOLD_MS = 3_000L
@@ -35,13 +38,19 @@ private const val FORCE_HOLD_MS = 3_000L
 // Releasing within this window after entering the force zone counts as a normal refresh.
 private const val FORCE_GRACE_MS = 1_000L
 
+// Matches Material3's internal SpinnerContainerSize used in IndicatorBox.
+private val SpinnerContainerSize = 40.dp
+
+// Indicator ring drawn around the pull indicator when in the force zone.
+private val ForceRingSize = 48.dp
+
 /**
  * @param refreshing Whether the layout is currently refreshing
  * @param onRefresh Lambda which is invoked when a swipe to refresh gesture is completed.
  * @param enabled Whether the layout should react to swipe gestures or not.
  * @param indicatorPadding Content padding for the indicator, to inset the indicator in if required.
- * @param onForceRefresh Optional lambda invoked when the user holds the pull in the force zone
- *   for [FORCE_HOLD_MS] milliseconds. When null, the force-refresh path is disabled entirely.
+ * @param onForceRefresh Optional lambda invoked when the user holds the pull in the force zone for
+ *   3 seconds. When null, the force-refresh path is disabled entirely.
  * @param content The content containing a vertically scrollable composable.
  */
 @Composable
@@ -55,18 +64,21 @@ fun PullRefresh(
     content: @Composable () -> Unit,
 ) {
     val state = rememberPullToRefreshState()
+    val density = LocalDensity.current
 
-    // True only when force-refresh is wired up and the pull distance exceeds the force threshold.
+    // Pre-computed in composition; read lazily inside graphicsLayer to avoid recomposition.
+    val maxDistancePx = with(density) { PullToRefreshDefaults.PositionalThreshold.roundToPx().toFloat() }
+    val spinnerSizePx = with(density) { SpinnerContainerSize.roundToPx().toFloat() }
+
     val inForceZone by remember(onForceRefresh) {
         derivedStateOf { onForceRefresh != null && state.distanceFraction >= FORCE_THRESHOLD }
     }
 
     var forceProgress by remember { mutableFloatStateOf(0f) }
     var holdEnteredAt by remember { mutableLongStateOf(0L) }
-    // Safety flag: force was triggered by the timer so the upcoming release should be ignored.
+    // Safety flag: timer completed and force refresh was already called — ignore the upcoming release.
     var forceTriggered by remember { mutableStateOf(false) }
 
-    // Timer coroutine — restarts whenever inForceZone changes.
     LaunchedEffect(inForceZone) {
         if (inForceZone) {
             holdEnteredAt = System.currentTimeMillis()
@@ -89,17 +101,11 @@ fun PullRefresh(
 
     val wrappedOnRefresh = {
         when {
-            forceTriggered -> {
-                // Timer already fired force refresh — ignore this release.
-                forceTriggered = false
-            }
+            forceTriggered -> forceTriggered = false // timer already fired, ignore release
             inForceZone -> {
                 val heldMs = if (holdEnteredAt > 0L) System.currentTimeMillis() - holdEnteredAt else 0L
-                if (heldMs < FORCE_GRACE_MS) {
-                    // Accidental overpull — treat as normal refresh.
-                    onRefresh()
-                }
-                // else: deliberate hold that didn't reach 3 s — cancel silently.
+                if (heldMs < FORCE_GRACE_MS) onRefresh() // accidental overpull — treat as normal
+                // else: deliberate hold that didn't reach 3 s — cancel silently
             }
             else -> onRefresh()
         }
@@ -116,21 +122,30 @@ fun PullRefresh(
         label = "pullIndicatorContent",
     )
 
+    // State objects for deferred reads inside graphicsLayer (avoids full recomposition per frame).
+    val ringAlphaState = animateFloatAsState(
+        targetValue = if (inForceZone && !refreshing) 1f else 0f,
+        animationSpec = tween(200),
+        label = "forceRingAlpha",
+    )
+
     Box(
-        modifier = modifier
-            .pullToRefresh(
-                isRefreshing = refreshing,
-                state = state,
-                enabled = enabled,
-                onRefresh = wrappedOnRefresh,
-            ),
+        modifier = modifier.pullToRefresh(
+            isRefreshing = refreshing,
+            state = state,
+            enabled = enabled,
+            onRefresh = wrappedOnRefresh,
+        ),
     ) {
         content()
 
+        // Fixed-size container prevents layout jumps when the ring appears/disappears.
+        // Size matches ForceRingSize so the indicator stays centered at (4dp, 4dp) within it.
         Box(
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .padding(indicatorPadding),
+                .padding(indicatorPadding)
+                .size(ForceRingSize),
             contentAlignment = Alignment.Center,
         ) {
             PullToRefreshDefaults.Indicator(
@@ -139,15 +154,26 @@ fun PullRefresh(
                 containerColor = containerColor,
                 color = indicatorColor,
             )
-            if (inForceZone) {
-                CircularProgressIndicator(
-                    progress = { forceProgress },
-                    modifier = Modifier.size(48.dp),
-                    color = MaterialTheme.colorScheme.error,
-                    trackColor = Color.Transparent,
-                    strokeWidth = 3.dp,
-                )
-            }
+
+            // Progress ring drawn around the indicator.
+            // Applies the same graphicsLayer translation that Material3's IndicatorBox uses
+            // internally so the ring tracks the indicator as it slides in/out with the pull gesture.
+            // Formula from M3 1.4.0 PullToRefresh.kt IndicatorBox:
+            //   translationY = distanceFraction * maxDistance.roundToPx() - containerSize
+            // With our 48dp ring centered in the fixed box over the 40dp indicator, the centers
+            // stay aligned throughout the pull motion.
+            CircularProgressIndicator(
+                progress = { forceProgress },
+                modifier = Modifier
+                    .size(ForceRingSize)
+                    .graphicsLayer {
+                        alpha = ringAlphaState.value
+                        translationY = state.distanceFraction * maxDistancePx - spinnerSizePx
+                    },
+                color = MaterialTheme.colorScheme.error,
+                trackColor = Color.Transparent,
+                strokeWidth = 3.dp,
+            )
         }
     }
 }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/PullRefresh.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/PullRefresh.kt
@@ -1,22 +1,47 @@
 package tachiyomi.presentation.core.components.material
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+// Pull must reach 1.8× the normal threshold to enter force-refresh zone.
+private const val FORCE_THRESHOLD = 1.8f
+
+// Milliseconds the user must hold in the force zone to trigger force refresh.
+private const val FORCE_HOLD_MS = 3_000L
+
+// Releasing within this window after entering the force zone counts as a normal refresh.
+private const val FORCE_GRACE_MS = 1_000L
 
 /**
  * @param refreshing Whether the layout is currently refreshing
  * @param onRefresh Lambda which is invoked when a swipe to refresh gesture is completed.
- * @param enabled Whether the the layout should react to swipe gestures or not.
+ * @param enabled Whether the layout should react to swipe gestures or not.
  * @param indicatorPadding Content padding for the indicator, to inset the indicator in if required.
+ * @param onForceRefresh Optional lambda invoked when the user holds the pull in the force zone
+ *   for [FORCE_HOLD_MS] milliseconds. When null, the force-refresh path is disabled entirely.
  * @param content The content containing a vertically scrollable composable.
  */
 @Composable
@@ -26,28 +51,103 @@ fun PullRefresh(
     onRefresh: () -> Unit,
     modifier: Modifier = Modifier,
     indicatorPadding: PaddingValues = PaddingValues(0.dp),
+    onForceRefresh: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     val state = rememberPullToRefreshState()
+
+    // True only when force-refresh is wired up and the pull distance exceeds the force threshold.
+    val inForceZone by remember(onForceRefresh) {
+        derivedStateOf { onForceRefresh != null && state.distanceFraction >= FORCE_THRESHOLD }
+    }
+
+    var forceProgress by remember { mutableFloatStateOf(0f) }
+    var holdEnteredAt by remember { mutableLongStateOf(0L) }
+    // Safety flag: force was triggered by the timer so the upcoming release should be ignored.
+    var forceTriggered by remember { mutableStateOf(false) }
+
+    // Timer coroutine — restarts whenever inForceZone changes.
+    LaunchedEffect(inForceZone) {
+        if (inForceZone) {
+            holdEnteredAt = System.currentTimeMillis()
+            val start = holdEnteredAt
+            while (true) {
+                val elapsed = System.currentTimeMillis() - start
+                forceProgress = (elapsed.toFloat() / FORCE_HOLD_MS).coerceIn(0f, 1f)
+                if (elapsed >= FORCE_HOLD_MS) {
+                    forceTriggered = true
+                    onForceRefresh!!()
+                    break
+                }
+                delay(16)
+            }
+        } else {
+            forceProgress = 0f
+            holdEnteredAt = 0L
+        }
+    }
+
+    val wrappedOnRefresh = {
+        when {
+            forceTriggered -> {
+                // Timer already fired force refresh — ignore this release.
+                forceTriggered = false
+            }
+            inForceZone -> {
+                val heldMs = if (holdEnteredAt > 0L) System.currentTimeMillis() - holdEnteredAt else 0L
+                if (heldMs < FORCE_GRACE_MS) {
+                    // Accidental overpull — treat as normal refresh.
+                    onRefresh()
+                }
+                // else: deliberate hold that didn't reach 3 s — cancel silently.
+            }
+            else -> onRefresh()
+        }
+    }
+
+    val containerColor by animateColorAsState(
+        targetValue = if (inForceZone) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.surfaceVariant,
+        animationSpec = tween(200),
+        label = "pullIndicatorContainer",
+    )
+    val indicatorColor by animateColorAsState(
+        targetValue = if (inForceZone) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(200),
+        label = "pullIndicatorContent",
+    )
+
     Box(
         modifier = modifier
             .pullToRefresh(
                 isRefreshing = refreshing,
                 state = state,
                 enabled = enabled,
-                onRefresh = onRefresh,
+                onRefresh = wrappedOnRefresh,
             ),
     ) {
         content()
 
-        PullToRefreshDefaults.Indicator(
+        Box(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .padding(indicatorPadding),
-            isRefreshing = refreshing,
-            state = state,
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+            contentAlignment = Alignment.Center,
+        ) {
+            PullToRefreshDefaults.Indicator(
+                isRefreshing = refreshing,
+                state = state,
+                containerColor = containerColor,
+                color = indicatorColor,
+            )
+            if (inForceZone) {
+                CircularProgressIndicator(
+                    progress = { forceProgress },
+                    modifier = Modifier.size(48.dp),
+                    color = MaterialTheme.colorScheme.error,
+                    trackColor = Color.Transparent,
+                    strokeWidth = 3.dp,
+                )
+            }
+        }
     }
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.source
 
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.awaitSingle
@@ -55,6 +56,20 @@ interface Source {
     @Suppress("DEPRECATION")
     suspend fun getChapterList(manga: SManga): List<SChapter> {
         return fetchChapterList(manga).awaitSingle()
+    }
+
+    /**
+     * Get all the available chapters for a manga.
+     *
+     * @since extensions-lib 1.6
+     * @param manga the manga to update.
+     * @param context refresh context containing existing local state
+     * @return the chapters for the manga.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        // Default implementation falls back to original method for backwards compatibility
+        return getChapterList(manga)
     }
 
     /**

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
@@ -1,0 +1,26 @@
+package eu.kanade.tachiyomi.source.model
+
+/**
+ * Context provided to a source when fetching chapter list for an existing manga.
+ * Contains read-only information about the current state that sources can use
+ * to optimize requests and avoid unnecessary network calls.
+ *
+ * @since 1.6.0
+ */
+data class RefreshContext(
+    /**
+     * The internal ID of the manga being refreshed.
+     */
+    val mangaId: Long,
+
+    /**
+     * List of chapters that currently exist locally for this manga.
+     * These are the chapters that were last fetched from this source.
+     */
+    val existingChapters: List<SChapter>,
+
+    /**
+     * Unix timestamp (milliseconds) of when this manga was last successfully refreshed.
+     */
+    val lastFetchTime: Long,
+)

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
@@ -23,4 +23,10 @@ data class RefreshContext(
      * Unix timestamp (milliseconds) of when this manga was last successfully refreshed.
      */
     val lastFetchTime: Long,
+
+    /**
+     * When true, the caller requests a full re-fetch regardless of cached state.
+     * Extensions should skip any count-based short-circuit logic.
+     */
+    val forceRefresh: Boolean = false,
 )

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
@@ -14,8 +14,7 @@ data class RefreshContext(
     val mangaId: Long,
 
     /**
-     * List of chapters that currently exist locally for this manga.
-     * These are the chapters that were last fetched from this source.
+     * List of chapters that currently exist locally for this manga, ordered by sourceOrder.
      */
     val existingChapters: List<SChapter>,
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -263,8 +263,8 @@ abstract class HttpSource : CatalogueSource {
 
     /**
      * Get all the available chapters for a manga with refresh context.
-     * Default implementation does intelligent delta refresh to avoid redundant requests.
-     * Extensions can override this for custom optimization logic.
+     * Default implementation ignores the context and falls back to the plain [getChapterList].
+     * Extensions can override this to use [context] for delta refresh and skip redundant requests.
      *
      * @param manga the manga to update
      * @param context refresh context containing existing local state

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import okhttp3.Headers
@@ -258,6 +259,19 @@ abstract class HttpSource : CatalogueSource {
     @Suppress("DEPRECATION")
     override suspend fun getChapterList(manga: SManga): List<SChapter> {
         return fetchChapterList(manga).awaitSingle()
+    }
+
+    /**
+     * Get all the available chapters for a manga with refresh context.
+     * Default implementation does intelligent delta refresh to avoid redundant requests.
+     * Extensions can override this for custom optimization logic.
+     *
+     * @param manga the manga to update
+     * @param context refresh context containing existing local state
+     * @return the chapters for the manga
+     */
+    override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        return getChapterList(manga)
     }
 
     @Deprecated("Use the non-RxJava API instead", replaceWith = ReplaceWith("getChapterList"))


### PR DESCRIPTION
Said I would do it eventually.

That's right, it's the ability for extensions to get refresh context when reloading chapter lists, so they don't have to re-request every single page.

1. Creates our own stub lib [tsundoku-otaku/extensions-lib](https://github.com/tsundoku-otaku/extensions-lib)
2. Double backwards compatible (Both directions)
3. Requires extension implementation for gains
4. Added force refresh mechanic - pull further than normal, and hold (timer appears, about 3s)