### PR TITLE
fix(jsplugin): surface chapter fetch errors instead of rendering them as content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix accuracy of mass import notification [@mrissaoussama](https://github.com/mrissaoussama) [#254](https://github.com/tsundoku-otaku/tsundoku/pull/254)
 - Properly remove TTS notification when stopped, more TTS states [@mrissaoussama](https://github.com/mrissaoussama) [#217](https://github.com/tsundoku-otaku/tsundoku/pull/217)
 - Manga mass import URL with JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#197](https://github.com/tsundoku-otaku/tsundoku/pull/197)
+- Throw errors properly instead of showing them as content in JS plugins [@mrissaoussama](https://github.com/mrissaoussama) [#262](https://github.com/tsundoku-otaku/tsundoku/pull/262)
 - Fix custom fonts not working with local files [@mrissaoussama](https://github.com/mrissaoussama) [#237](https://github.com/tsundoku-otaku/tsundoku/pull/237)
 - Imrpove NovelList session handling and fix API errors [@mrissaoussama](https://github.com/mrissaoussama) [#249](https://github.com/tsundoku-otaku/tsundoku/pull/249)
 - Correctly recognize .zip archives [@mrissaoussama](https://github.com/mrissaoussama) [#226](https://github.com/tsundoku-otaku/tsundoku/pull/226)

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -1346,23 +1346,23 @@ class JsSource(
     }
 
     override suspend fun fetchPageText(page: Page): String = withContext(Dispatchers.IO) {
+        // If the page already has text content (set by getPageList), return it directly
+        if (!page.text.isNullOrBlank()) {
+            return@withContext page.text!!
+        }
+
+        // Validate URL before calling plugin - avoid fetching base URL with empty path
+        if (normalizePluginPath(page.url).isBlank()) {
+            logcat(LogPriority.WARN) { "[$id] fetchPageText: page.url is blank, cannot parse chapter" }
+            throw IllegalStateException("Chapter content unavailable (empty URL)")
+        }
+
         try {
-            // If the page already has text content (set by getPageList), return it directly
-            if (!page.text.isNullOrBlank()) {
-                return@withContext page.text!!
-            }
-
-            // Validate URL before calling plugin - avoid fetching base URL with empty path
-            if (normalizePluginPath(page.url).isBlank()) {
-                logcat(LogPriority.WARN) { "[$id] fetchPageText: page.url is blank, cannot parse chapter" }
-                return@withContext "Chapter content unavailable (empty URL)"
-            }
-
             val result = parseChapterCached(page.url)
             extractChapterText(result)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Error fetching page text for ${plugin.name}" }
-            "Error loading chapter content: ${e.message}"
+            throw e
         }
     }
 


### PR DESCRIPTION

fetchPageText caught plugin failures and returned the error string as the page text, so the reader marked the page Ready and rendered the message as chapter content (and downloads/translations persisted it as the chapter). changed it to throw instead as the loaders already convert a thrown error into Page.State.Error.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
