### PR TITLE
Feat/massimport throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - TextView Regex; Short chapter detection false positives [@mrissaoussama](https://github.com/mrissaoussama) [#225](https://github.com/tsundoku-otaku/tsundoku/pull/225)
 - Fix TTS service lifecycle and background sync [@mrissaoussama](https://github.com/mrissaoussama) [#255](https://github.com/tsundoku-otaku/tsundoku/pull/255)
 - Update library unread counts when marking chapters as read [@mrissaoussama](https://github.com/mrissaoussama) [#240](https://github.com/tsundoku-otaku/tsundoku/pull/240)
+- Massimport throughput/threading [@mrissaoussama](https://github.com/mrissaoussama) [#263](https://github.com/tsundoku-otaku/tsundoku/pull/263)
 - Fix HTML vs plain text detection [@mrissaoussama](https://github.com/mrissaoussama) [#223](https://github.com/tsundoku-otaku/tsundoku/pull/223)
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
@@ -68,6 +69,10 @@ private const val MIN_FREE_MEMORY_BYTES = 50 * 1024 * 1024L
 private const val MAX_MEMORY_WAIT_ITERATIONS = 20
 // Upper bound on parallel fetches; matches the settings slider max.
 private const val MAX_CONCURRENCY = 30
+// Look-ahead window for host-interleaving the URL stream. Bounds the reorder buffer
+// (so a huge file stays O(window) memory) while breaking up contiguous same-source
+// clumps that would otherwise collapse the concurrency window onto one source semaphore.
+private const val MAX_LOOKAHEAD = 512
 // Bound the retained per-URL error detail so a mostly-failing huge import can't OOM.
 private const val MAX_TRACKED_ERRORS = 2000
 // Hard ceiling on a single source fetch so one hanging/oversized request can't freeze
@@ -117,6 +122,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         val missingSourceHosts = ConcurrentHashMap.newKeySet<String>()
 
         val jobBatchId = inputData.getString(KEY_BATCH_ID) ?: ""
+        val resumeOffset = inputData.getInt(KEY_RESUME_OFFSET, 0).coerceAtLeast(0)
         // Exit instead of parking in the pause loop: a parked foreground worker burns the
         // Android 15 dataSync time budget. Resume flips the status before re-enqueueing.
         hydrateBatchFromStore(jobBatchId)
@@ -185,6 +191,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                         urlFlow, totalCount,
                         categoryId, addToLibrary, fetchDetails, fetchChapters, batchId,
                         excludedHostsSet, hostSourceCache, missingSourceHosts, preferredSourceId,
+                        resumeOffset = resumeOffset,
                     )
 
                     Result.success()
@@ -227,6 +234,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     hostSourceCache,
                     missingSourceHosts,
                     preferredSourceId,
+                    resumeOffset = resumeOffset,
                 )
                 Result.success()
             } catch (e: Exception) {
@@ -298,6 +306,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         hostSourceCache: ConcurrentHashMap<String, CatalogueSource> = ConcurrentHashMap(),
         missingSourceHosts: MutableSet<String> = ConcurrentHashMap.newKeySet(),
         preferredSourceId: Long? = null,
+        resumeOffset: Int = 0,
     ): ImportResult {
         hydrateBatchFromStore(batchId)
         startRunningUnlessPaused(batchId)
@@ -351,10 +360,13 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             novelDownloadPreferences.parallelMassImport().get().coerceIn(1, MAX_CONCURRENCY)
         }
 
-        val completedCount = AtomicInteger(0)
-        val addedCount = AtomicInteger(0)
-        val skippedCount = AtomicInteger(0)
-        val erroredCount = AtomicInteger(0)
+        // Resume: seed counters from the persisted batch so progress/tallies continue
+        // instead of restarting at 0. The dropped prefix counts as already-completed.
+        val seed = if (resumeOffset > 0) _sharedQueue.value.find { it.id == batchId } else null
+        val completedCount = AtomicInteger(resumeOffset)
+        val addedCount = AtomicInteger(seed?.added ?: 0)
+        val skippedCount = AtomicInteger(seed?.skipped ?: 0)
+        val erroredCount = AtomicInteger(seed?.errored ?: 0)
         val pendingAddIds = java.util.Collections.synchronizedList(mutableListOf<Long>())
         val flushBatchSize = 50
         val activeImports = ConcurrentHashMap<String, Boolean>()
@@ -398,7 +410,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             if (batchId.isNotEmpty()) MassImportStore.appendErrors(context, batchId, toFlush)
         }
 
-        // Skipped URLs get the same disk log treatment as errors (`mi_<id>_skipped.csv`);
+        // Skipped URLs are streamed to a single-column `.txt` (`mi_<id>_skipped.txt`);
         // only the URL is persisted, the reason is dropped (there is a single skip reason).
         val skipLogBuffer = mutableListOf<Pair<String, String>>()
         fun recordSkip(url: String, reason: String) {
@@ -451,6 +463,11 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
         try {
         urlFlow
+            // Resume: skip the already-processed prefix.
+            .let { if (resumeOffset > 0) it.drop(resumeOffset) else it }
+            // Spread contiguous same-source URLs across the concurrency window so one
+            // source's per-source semaphore can't starve all the merge slots.
+            .interleaveByHost(MAX_LOOKAHEAD)
             .flatMapMerge(concurrency) { url ->
                 if (url.isBlank() || !(url.startsWith("http://") || url.startsWith("https://"))) {
                     return@flatMapMerge flow {
@@ -552,10 +569,17 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                                 totalCount,
                                                 "Processing: ${activeImports.size} active",
                                             )
-                                            result = processUrlWithSource(
-                                                url, source, addToLibrary, fetchDetails, categoryId,
-                                                fetchChapters, pendingAddIds, flushBatchSize,
-                                            )
+                                            // Remove when the fetch returns; keeping it until the
+                                            // outer finally (post-processing/flush) counts finished
+                                            // URLs as active, inflating the notif toward concurrency.
+                                            result = try {
+                                                processUrlWithSource(
+                                                    url, source, addToLibrary, fetchDetails, categoryId,
+                                                    fetchChapters, pendingAddIds, flushBatchSize,
+                                                )
+                                            } finally {
+                                                activeImports.remove(url)
+                                            }
                                             true
                                         }
                                     }
@@ -572,10 +596,14 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                     totalCount,
                                     "Processing: ${activeImports.size} active",
                                 )
-                                processUrlWithSource(
-                                    url, source, addToLibrary, fetchDetails, categoryId,
-                                    fetchChapters, pendingAddIds, flushBatchSize,
-                                )
+                                try {
+                                    processUrlWithSource(
+                                        url, source, addToLibrary, fetchDetails, categoryId,
+                                        fetchChapters, pendingAddIds, flushBatchSize,
+                                    )
+                                } finally {
+                                    activeImports.remove(url)
+                                }
                             }
                         }
                         when (success) {
@@ -734,6 +762,48 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
     private fun batchStatus(batchId: String): BatchStatus? =
         _sharedQueue.value.find { it.id == batchId }?.status
+
+    private fun hostKey(url: String): String =
+        try {
+            URI(url).host?.lowercase()?.removePrefix("www.") ?: url
+        } catch (e: Exception) {
+            url
+        }
+
+    /**
+     * Reorders the stream so consecutive same-host URLs are spread out: buffers up to
+     * [maxBuffer] URLs bucketed by host and, when full, emits one URL per bucket
+     * (round-robin) before refilling. Memory stays O([maxBuffer]).
+     *
+     * Without it, a long run of one source's URLs fills the whole `flatMapMerge` window;
+     * they all block on that source's single permit while the other slots sit idle.
+     */
+    private fun Flow<String>.interleaveByHost(maxBuffer: Int): Flow<String> {
+        val upstream = this
+        return flow {
+            val buckets = LinkedHashMap<String, ArrayDeque<String>>()
+
+            suspend fun emitRound() {
+                val iter = buckets.entries.iterator()
+                while (iter.hasNext()) {
+                    val deque = iter.next().value
+                    emit(deque.removeFirst())
+                    if (deque.isEmpty()) iter.remove()
+                }
+            }
+
+            var buffered = 0
+            upstream.collect { url ->
+                buckets.getOrPut(hostKey(url)) { ArrayDeque() }.addLast(url)
+                buffered++
+                if (buffered >= maxBuffer) {
+                    emitRound()
+                    buffered = buckets.values.sumOf { it.size }
+                }
+            }
+            while (buckets.isNotEmpty()) emitRound()
+        }
+    }
 
     // Parks while the batch is Paused; returns false when it was cancelled instead of resumed.
     private suspend fun awaitResumed(batchId: String): Boolean {
@@ -1127,6 +1197,10 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         const val KEY_BATCH_ID = "batchId"
         const val KEY_EXCLUDED_HOSTS = "excludedHosts"
         const val KEY_PREFERRED_SOURCE_ID = "preferredSourceId"
+        // Resume cursor: number of leading URLs to skip (the prefix already processed
+        // before a pause). Kept a safety margin behind the persisted progress so
+        // out-of-order completions never skip an unprocessed URL.
+        const val KEY_RESUME_OFFSET = "resumeOffset"
 
         // Number of URLs retained in the live queue for display; full list stays on disk.
         private const val URL_PREVIEW_LIMIT = 100
@@ -1670,6 +1744,11 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     return@launch abortResume("no persisted urls")
                 }
 
+                // Resume a margin behind persisted progress: out-of-order flatMapMerge
+                // completions plus interleaveByHost's look-ahead buffer mean a low-index URL
+                // can lag the completed count by up to MAX_LOOKAHEAD + MAX_CONCURRENCY. The
+                // re-done overlap DB-skips instantly; dropping less could skip a URL.
+                val resumeOffset = (batch.progress - (MAX_LOOKAHEAD + MAX_CONCURRENCY)).coerceAtLeast(0)
                 val payload = mutableListOf<Pair<String, Any?>>(
                     KEY_CATEGORY_ID to batch.categoryId,
                     KEY_ADD_TO_LIBRARY to batch.addToLibrary,
@@ -1677,6 +1756,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     KEY_FETCH_CHAPTERS to batch.fetchChapters,
                     KEY_BATCH_ID to batchId,
                     KEY_URLS_FILE to cacheFile.absolutePath,
+                    KEY_RESUME_OFFSET to resumeOffset,
                 )
                 if (batch.excludedHosts.isNotEmpty()) {
                     payload += KEY_EXCLUDED_HOSTS to batch.excludedHosts.joinToString(",")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -69,9 +69,8 @@ private const val MIN_FREE_MEMORY_BYTES = 50 * 1024 * 1024L
 private const val MAX_MEMORY_WAIT_ITERATIONS = 20
 // Upper bound on parallel fetches; matches the settings slider max.
 private const val MAX_CONCURRENCY = 30
-// Look-ahead window for host-interleaving the URL stream. Bounds the reorder buffer
-// (so a huge file stays O(window) memory) while breaking up contiguous same-source
-// clumps that would otherwise collapse the concurrency window onto one source semaphore.
+// How many URLs to look ahead when spreading same-host URLs apart (see interleaveByHost).
+// Caps the reorder buffer so a huge file stays small in memory.
 private const val MAX_LOOKAHEAD = 512
 // Bound the retained per-URL error detail so a mostly-failing huge import can't OOM.
 private const val MAX_TRACKED_ERRORS = 2000
@@ -465,8 +464,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         urlFlow
             // Resume: skip the already-processed prefix.
             .let { if (resumeOffset > 0) it.drop(resumeOffset) else it }
-            // Spread contiguous same-source URLs across the concurrency window so one
-            // source's per-source semaphore can't starve all the merge slots.
+            // Spread same-host URLs apart so one slow source doesn't fill every slot below.
             .interleaveByHost(MAX_LOOKAHEAD)
             .flatMapMerge(concurrency) { url ->
                 if (url.isBlank() || !(url.startsWith("http://") || url.startsWith("https://"))) {
@@ -569,9 +567,8 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                                 totalCount,
                                                 "Processing: ${activeImports.size} active",
                                             )
-                                            // Remove when the fetch returns; keeping it until the
-                                            // outer finally (post-processing/flush) counts finished
-                                            // URLs as active, inflating the notif toward concurrency.
+                                            // Remove when the fetch returns so the "active" count
+                                            // in the notification reflects only in-progress URLs.
                                             result = try {
                                                 processUrlWithSource(
                                                     url, source, addToLibrary, fetchDetails, categoryId,
@@ -771,12 +768,12 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
 
     /**
-     * Reorders the stream so consecutive same-host URLs are spread out: buffers up to
-     * [maxBuffer] URLs bucketed by host and, when full, emits one URL per bucket
-     * (round-robin) before refilling. Memory stays O([maxBuffer]).
+     * Reorders the stream so URLs from the same host aren't bunched together. Holds up to
+     * [maxBuffer] URLs grouped by host; when full, emits one from each host in turn, then
+     * refills. Memory is capped at [maxBuffer] so big files stay safe.
      *
-     * Without it, a long run of one source's URLs fills the whole `flatMapMerge` window;
-     * they all block on that source's single permit while the other slots sit idle.
+     * Without it, a long run of one host's URLs fills every parallel slot and they all wait
+     * on that one source while the other slots do nothing.
      */
     private fun Flow<String>.interleaveByHost(maxBuffer: Int): Flow<String> {
         val upstream = this
@@ -1197,9 +1194,8 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         const val KEY_BATCH_ID = "batchId"
         const val KEY_EXCLUDED_HOSTS = "excludedHosts"
         const val KEY_PREFERRED_SOURCE_ID = "preferredSourceId"
-        // Resume cursor: number of leading URLs to skip (the prefix already processed
-        // before a pause). Kept a safety margin behind the persisted progress so
-        // out-of-order completions never skip an unprocessed URL.
+        // Resume cursor: how many leading URLs to skip because they were already done
+        // before the pause.
         const val KEY_RESUME_OFFSET = "resumeOffset"
 
         // Number of URLs retained in the live queue for display; full list stays on disk.
@@ -1744,10 +1740,10 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     return@launch abortResume("no persisted urls")
                 }
 
-                // Resume a margin behind persisted progress: out-of-order flatMapMerge
-                // completions plus interleaveByHost's look-ahead buffer mean a low-index URL
-                // can lag the completed count by up to MAX_LOOKAHEAD + MAX_CONCURRENCY. The
-                // re-done overlap DB-skips instantly; dropping less could skip a URL.
+                // Restart a bit before the saved progress, not exactly at it: URLs finish out
+                // of order and the interleave buffer holds some back, so a few just past the
+                // saved count may still be unfinished. Re-doing that overlap is cheap (already
+                // imported ones skip instantly); skipping it could drop a URL.
                 val resumeOffset = (batch.progress - (MAX_LOOKAHEAD + MAX_CONCURRENCY)).coerceAtLeast(0)
                 val payload = mutableListOf<Pair<String, Any?>>(
                     KEY_CATEGORY_ID to batch.categoryId,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportStore.kt
@@ -12,7 +12,7 @@ import uy.kohesive.injekt.api.get
 
 /**
  * Per batch: `mi_<batchId>.txt` (URL list) + `mi_<batchId>.json` (metadata)
- * + `mi_<batchId>_errors.csv` (`url,message` per line) / `mi_<batchId>_skipped.csv` (url per line).
+ * + `mi_<batchId>_errors.csv` (`url,message` per line) / `mi_<batchId>_skipped.txt` (one raw url per line).
  */
 object MassImportStore {
 
@@ -53,11 +53,13 @@ object MassImportStore {
     private fun urlsName(batchId: String) = "$URLS_PREFIX$batchId$URLS_SUFFIX"
     private fun metaName(batchId: String) = "$URLS_PREFIX$batchId$META_SUFFIX"
     private fun errorsName(batchId: String) = "$URLS_PREFIX$batchId$ERRORS_INFIX$LOG_SUFFIX"
-    private fun skippedName(batchId: String) = "$URLS_PREFIX$batchId$SKIPPED_INFIX$LOG_SUFFIX"
+    // Skipped is single-column (url only), so it's a plain `.txt` url list, not CSV.
+    private fun skippedName(batchId: String) = "$URLS_PREFIX$batchId$SKIPPED_INFIX$URLS_SUFFIX"
 
-    // Pre-CSV logs used `.txt` with `url<TAB>message` lines; still read/cleaned for old batches.
+    // Pre-CSV error logs used `.txt` with `url<TAB>message` lines; still read/cleaned for old batches.
     private fun legacyErrorsName(batchId: String) = "$URLS_PREFIX$batchId$ERRORS_INFIX$URLS_SUFFIX"
-    private fun legacySkippedName(batchId: String) = "$URLS_PREFIX$batchId$SKIPPED_INFIX$URLS_SUFFIX"
+    // Older builds wrote skipped urls to a `.csv`; still read/cleaned for old batches.
+    private fun legacySkippedName(batchId: String) = "$URLS_PREFIX$batchId$SKIPPED_INFIX$LOG_SUFFIX"
 
     private fun overwrite(dir: UniFile, name: String, content: String) {
         dir.findFile(name)?.delete()
@@ -238,10 +240,14 @@ object MassImportStore {
                 val file = dir.findFile(name) ?: dir.createFile(name) ?: return@runCatching
                 file.openOutputStream(true).bufferedWriter().use { writer ->
                     for ((url, message) in entries) {
-                        writer.write(csvField(url.trim()))
                         if (withMessage) {
+                            // CSV: `url,message`
+                            writer.write(csvField(url.trim()))
                             writer.write(",")
                             writer.write(csvField(message.replace('\t', ' ').replace('\n', ' ').take(200)))
+                        } else {
+                            // Single-column `.txt`: raw url, directly re-importable.
+                            writer.write(url.trim())
                         }
                         writer.write("\n")
                     }


### PR DESCRIPTION

- fix threads sitting idle in some cases where file has sorted urls.
- fix notification showing inaccurate active threads.
- fix pause resetting import progress.
- switch skipped file format to txt.