### PR TITLE
Fix/novel tts playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fix
 - Emergency fix for novelextension type to stop crash [@Rojikku](https://github.com/Rojikku) [#251](https://github.com/tsundoku-otaku/tsundoku/pull/251)
+- Fix TTS crashes, and issues with chapter change and rendering [@Rojikku](https://github.com/Rojikku) [#251](https://github.com/tsundoku-otaku/tsundoku/pull/251)
 - Make JS scripts regardless of inf scroll [@mrissaoussama](https://github.com/mrissaoussama) [#220](https://github.com/tsundoku-otaku/tsundoku/pull/220)
 - Always serve cached translations [@mrissaoussama](https://github.com/mrissaoussama) [#236](https://github.com/tsundoku-otaku/tsundoku/pull/236)
 - JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1104,7 +1104,10 @@ class ReaderActivity : BaseActivity() {
 
     private fun startBackgroundTtsIfEnabled() {
         if (readerPreferences.novelTtsBackgroundPlayback.get()) {
-            TtsPlaybackService.start(this)
+            // Don't push a placeholder "TTS playback" notification here: every caller
+            // follows with syncBackgroundTtsState(), which starts the foreground service
+            // with the real novel/chapter title. Starting it twice just flashes the
+            // generic title for a frame.
             startTtsNotificationSync()
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1139,13 +1139,14 @@ class ReaderActivity : BaseActivity() {
     private fun startTtsNotificationSync() {
         ttsNotificationSyncJob?.cancel()
         ttsNotificationSyncJob = lifecycleScope.launch {
-            // Delay the first poll: lifecycleScope is Dispatchers.Main.immediate, so an
-            // immediate first iteration runs before the caller sets the TTS state, sees
-            // active=false, and stopService()s before startForeground() runs, crashing with
-            // ForegroundServiceDidNotStartInTimeException. Start sites sync explicitly after.
-            delay(750)
+            // The first loop pass runs immediately (Main.immediate), before the caller has
+            // set the TTS state. Don't let it stop the service until TTS has actually been
+            // active once: stopping the just-started service before it calls startForeground()
+            // crashes with ForegroundServiceDidNotStartInTimeException.
+            var ttsWasActive = false
             while (isActive) {
-                syncBackgroundTtsState()
+                if (currentNovelTtsState()?.active == true) ttsWasActive = true
+                if (ttsWasActive) syncBackgroundTtsState()
                 delay(750)
             }
         }
@@ -1384,11 +1385,9 @@ class ReaderActivity : BaseActivity() {
     }
 
     /**
-     * Loads the next chapter for a TTS auto-advance handoff WITHOUT stopping the
-     * active TTS session. The viewer has already set its `pendingTtsAutoStart`
-     * flag and relies on it surviving the chapter swap so playback resumes once
-     * the new chapter text is rendered. Routing through [loadNextChapter] would
-     * call [stopNovelTtsForManualNav] and clear that flag.
+     * Loads the next chapter for a TTS auto-advance without stopping TTS. The viewer
+     * has set pendingTtsAutoStart and needs it to survive the chapter swap so playback
+     * resumes; [loadNextChapter] would clear it via [stopNovelTtsForManualNav].
      */
     internal fun loadNextChapterForTtsHandoff() {
         loadNextChapterInternal()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -668,9 +668,8 @@ class ReaderActivity : BaseActivity() {
             var isTtsActive by remember { mutableStateOf(false) }
             var isTtsPaused by remember { mutableStateOf(false) }
             var ttsControlsVisible by remember { mutableStateOf(readerPreferences.novelTtsControlsVisible.get()) }
-            // Re-sync the pause/play button from the viewer on menu open and on every
-            // chapter change. Chapter nav stops TTS without going through a button tap, so
-            // keying on the chapter id resets the button instead of leaving it stale.
+            // Re-sync the pause/play button on menu open and chapter change. Chapter nav
+            // stops TTS without a button tap, so key on chapter id to reset it.
             LaunchedEffect(state.menuVisible, state.novelVisibleChapter?.id) {
                 if (!state.menuVisible) return@LaunchedEffect
                 val viewer = state.viewer
@@ -1104,10 +1103,8 @@ class ReaderActivity : BaseActivity() {
 
     private fun startBackgroundTtsIfEnabled() {
         if (readerPreferences.novelTtsBackgroundPlayback.get()) {
-            // Don't push a placeholder "TTS playback" notification here: every caller
-            // follows with syncBackgroundTtsState(), which starts the foreground service
-            // with the real novel/chapter title. Starting it twice just flashes the
-            // generic title for a frame.
+            // No placeholder notification: the caller's syncBackgroundTtsState() starts
+            // the service with the real novel/chapter title.
             startTtsNotificationSync()
         }
     }
@@ -1144,10 +1141,9 @@ class ReaderActivity : BaseActivity() {
     private fun startTtsNotificationSync() {
         ttsNotificationSyncJob?.cancel()
         ttsNotificationSyncJob = lifecycleScope.launch {
-            // The first loop pass runs immediately (Main.immediate), before the caller has
-            // set the TTS state. Don't let it stop the service until TTS has actually been
-            // active once: stopping the just-started service before it calls startForeground()
-            // crashes with ForegroundServiceDidNotStartInTimeException.
+            // First pass runs before the caller sets TTS state. Don't stop the service
+            // until TTS has been active once: stopping it before startForeground() crashes
+            // with ForegroundServiceDidNotStartInTimeException.
             var ttsWasActive = false
             while (isActive) {
                 if (currentNovelTtsState()?.active == true) ttsWasActive = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1139,6 +1139,11 @@ class ReaderActivity : BaseActivity() {
     private fun startTtsNotificationSync() {
         ttsNotificationSyncJob?.cancel()
         ttsNotificationSyncJob = lifecycleScope.launch {
+            // Delay the first poll: lifecycleScope is Dispatchers.Main.immediate, so an
+            // immediate first iteration runs before the caller sets the TTS state, sees
+            // active=false, and stopService()s before startForeground() runs, crashing with
+            // ForegroundServiceDidNotStartInTimeException. Start sites sync explicitly after.
+            delay(750)
             while (isActive) {
                 syncBackgroundTtsState()
                 delay(750)
@@ -1375,6 +1380,21 @@ class ReaderActivity : BaseActivity() {
      */
     internal fun loadNextChapter() {
         stopNovelTtsForManualNav()
+        loadNextChapterInternal()
+    }
+
+    /**
+     * Loads the next chapter for a TTS auto-advance handoff WITHOUT stopping the
+     * active TTS session. The viewer has already set its `pendingTtsAutoStart`
+     * flag and relies on it surviving the chapter swap so playback resumes once
+     * the new chapter text is rendered. Routing through [loadNextChapter] would
+     * call [stopNovelTtsForManualNav] and clear that flag.
+     */
+    internal fun loadNextChapterForTtsHandoff() {
+        loadNextChapterInternal()
+    }
+
+    private fun loadNextChapterInternal() {
         lifecycleScope.launch {
             viewModel.loadNextChapter()
             // Only reset to page 0 if NOT using infinite scroll for novel viewers

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -668,19 +668,21 @@ class ReaderActivity : BaseActivity() {
             var isTtsActive by remember { mutableStateOf(false) }
             var isTtsPaused by remember { mutableStateOf(false) }
             var ttsControlsVisible by remember { mutableStateOf(readerPreferences.novelTtsControlsVisible.get()) }
-            LaunchedEffect(state.menuVisible) {
-                if (state.menuVisible) {
-                    val viewer = state.viewer
-                    isTtsActive = when (viewer) {
-                        is NovelViewer -> viewer.isTtsSpeaking() || viewer.isTtsPaused()
-                        is NovelWebViewViewer -> viewer.isTtsSpeaking() || viewer.isTtsPaused()
-                        else -> false
-                    }
-                    isTtsPaused = when (viewer) {
-                        is NovelViewer -> viewer.isTtsPaused()
-                        is NovelWebViewViewer -> viewer.isTtsPaused()
-                        else -> false
-                    }
+            // Re-sync the pause/play button from the viewer on menu open and on every
+            // chapter change. Chapter nav stops TTS without going through a button tap, so
+            // keying on the chapter id resets the button instead of leaving it stale.
+            LaunchedEffect(state.menuVisible, state.novelVisibleChapter?.id) {
+                if (!state.menuVisible) return@LaunchedEffect
+                val viewer = state.viewer
+                isTtsActive = when (viewer) {
+                    is NovelViewer -> viewer.isTtsActive()
+                    is NovelWebViewViewer -> viewer.isTtsActive()
+                    else -> false
+                }
+                isTtsPaused = when (viewer) {
+                    is NovelViewer -> viewer.isTtsPaused()
+                    is NovelWebViewViewer -> viewer.isTtsPaused()
+                    else -> false
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/service/TtsPlaybackService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/service/TtsPlaybackService.kt
@@ -240,18 +240,6 @@ class TtsPlaybackService : Service() {
         private const val EXTRA_MANGA_ID = "extra_manga_id"
         private const val EXTRA_CHAPTER_ID = "extra_chapter_id"
 
-        fun start(context: Context) {
-            syncState(
-                context = context,
-                isPaused = false,
-                progressPercent = 0,
-                novelTitle = "TTS playback",
-                chapterTitle = "",
-                mangaId = -1L,
-                chapterId = -1L,
-            )
-        }
-
         fun syncState(
             context: Context,
             isPaused: Boolean,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -802,7 +802,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         }
 
         val chapters = currentChapters ?: return
-        chapters.nextChapter ?: return
+        if (chapters.nextChapter == null) {
+            // End of novel: no next chapter to hand off to. End the session so the
+            // background notification/service tears down instead of lingering with
+            // isTtsAutoPlay stuck true.
+            stopTts()
+            return
+        }
 
         pendingTtsAutoStart = true
         scope.launch {
@@ -884,8 +890,14 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 }
             } finally {
                 if (handoffState.isPreFetching) handoffState = TtsHandoffState.Idle
-                // Prefetch ended without caching (e.g. fetch failed); drop the pending retry.
-                pendingTtsHandoffAfterPrefetch = false
+                // Reaching here with the retry flag still set means the prefetch ended
+                // without caching (fetch failed or no next chapter). The handoff can't
+                // proceed, so end the session instead of leaving isTtsAutoPlay stuck true
+                // (which keeps the background notification/service alive forever).
+                if (pendingTtsHandoffAfterPrefetch) {
+                    pendingTtsHandoffAfterPrefetch = false
+                    stopTts()
+                }
             }
         }
     }
@@ -994,6 +1006,18 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         pendingTtsAutoStart = false
         handoffState = TtsHandoffState.Idle
         ttsController.stop()
+    }
+
+    /**
+     * A deferred TTS start ([pendingTtsAutoStart]) waits for [onChapterTextSet], which
+     * never fires when the chapter fails to load. Clear the pending session so
+     * isTtsAutoPlay doesn't stay stuck true (which would keep the background
+     * notification/service alive with nothing playing).
+     */
+    private fun abortPendingTtsOnLoadFailure() {
+        if (pendingTtsAutoStart || ttsController.isTtsAutoPlay) {
+            stopTts()
+        }
     }
 
     fun pauseTts() {
@@ -1200,6 +1224,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 }
             } catch (e: TimeoutCancellationException) {
                 hideLoadingIndicator()
+                abortPendingTtsOnLoadFailure()
                 displayError(e)
                 return@launch
             }
@@ -1212,6 +1237,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 }
                 is Page.State.Error -> {
                     hideLoadingIndicator()
+                    abortPendingTtsOnLoadFailure()
                     displayError(state.error)
                 }
                 else -> {}
@@ -1223,6 +1249,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val rawContent = page.text
         if (rawContent.isNullOrBlank()) {
             logcat(LogPriority.ERROR) { "NovelViewer: Page text is null or blank for chapter ${chapter.chapter.name}" }
+            abortPendingTtsOnLoadFailure()
             displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
             return
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -657,6 +657,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     private var pendingTtsAutoStart = false
 
+    // Set when an inf-scroll TTS handoff found nothing prefetched and kicked a prefetch;
+    // the prefetch completion retries the handoff.
+    private var pendingTtsHandoffAfterPrefetch = false
+
     @Volatile private var handoffState: TtsHandoffState<LoadedChapter> = TtsHandoffState.Idle
 
     private val ttsController = TtsController(
@@ -788,7 +792,11 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     startTts()
                 }
             } else {
-                logcat(LogPriority.WARN) { "TTS: No next chapter in loadedChapters or cache for inf-scroll handoff" }
+                // Nothing prefetched: TTS reads in place, so the scroll-driven prefetch never
+                // fired. Fetch the next chapter now and retry the handoff once it's cached.
+                logcat(LogPriority.DEBUG) { "TTS: next chapter not ready, prefetching for handoff" }
+                pendingTtsHandoffAfterPrefetch = true
+                preFetchNextChapterForTts()
             }
             return
         }
@@ -868,9 +876,16 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     )
                     handoffState = TtsHandoffState.Cached(cachedChapter)
                     logcat(LogPriority.DEBUG) { "TTS: Cached next chapter ${preparedChapter.chapter.name}" }
+
+                    if (pendingTtsHandoffAfterPrefetch) {
+                        pendingTtsHandoffAfterPrefetch = false
+                        loadNextChapterForTts(currentChapterIndex)
+                    }
                 }
             } finally {
                 if (handoffState.isPreFetching) handoffState = TtsHandoffState.Idle
+                // Prefetch ended without caching (e.g. fetch failed); drop the pending retry.
+                pendingTtsHandoffAfterPrefetch = false
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -960,7 +960,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val text = loadedChapters.getOrNull(currentChapterIndex)?.block?.fullText
             ?: loadedChapters.firstOrNull()?.block?.fullText
         if (text.isNullOrEmpty()) {
-            logcat(LogPriority.WARN) { "TTS: No text to speak. loadedChapters=${loadedChapters.size}, currentIndex=$currentChapterIndex" }
+            // Chapter text hasn't rendered yet; defer so onChapterTextSet starts playback
+            // once it's ready instead of failing the start silently.
+            logcat(LogPriority.WARN) { "TTS: text not ready, deferring start. loadedChapters=${loadedChapters.size}, currentIndex=$currentChapterIndex" }
+            pendingTtsAutoStart = true
             return
         }
         logcat(LogPriority.DEBUG) { "TTS: Starting to speak ${text.length} characters" }
@@ -1021,7 +1024,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val text = loadedChapters.getOrNull(currentChapterIndex)?.block?.fullText
             ?: loadedChapters.firstOrNull()?.block?.fullText
         if (text.isNullOrEmpty()) {
-            logcat(LogPriority.WARN) { "TTS: No text available for viewport start" }
+            // Chapter text not rendered yet; defer to onChapterTextSet rather than no-op.
+            logcat(LogPriority.WARN) { "TTS: text not ready for viewport start, deferring" }
+            pendingTtsAutoStart = true
             return
         }
         val firstVisibleParagraphIndex = findFirstVisibleParagraphIndex(text)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -798,7 +798,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
         pendingTtsAutoStart = true
         scope.launch {
-            activity.loadNextChapter()
+            // Must NOT use activity.loadNextChapter(): it stops TTS (manual-nav)
+            // and clears pendingTtsAutoStart, so playback never resumes.
+            activity.loadNextChapterForTtsHandoff()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -803,9 +803,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
         val chapters = currentChapters ?: return
         if (chapters.nextChapter == null) {
-            // End of novel: no next chapter to hand off to. End the session so the
-            // background notification/service tears down instead of lingering with
-            // isTtsAutoPlay stuck true.
+            // End of novel: stop so the background service tears down instead of
+            // lingering with isTtsAutoPlay stuck true.
             stopTts()
             return
         }
@@ -890,10 +889,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 }
             } finally {
                 if (handoffState.isPreFetching) handoffState = TtsHandoffState.Idle
-                // Reaching here with the retry flag still set means the prefetch ended
-                // without caching (fetch failed or no next chapter). The handoff can't
-                // proceed, so end the session instead of leaving isTtsAutoPlay stuck true
-                // (which keeps the background notification/service alive forever).
+                // Flag still set: prefetch ended without caching (fetch failed or no next
+                // chapter). Stop instead of leaving isTtsAutoPlay stuck true.
                 if (pendingTtsHandoffAfterPrefetch) {
                     pendingTtsHandoffAfterPrefetch = false
                     stopTts()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -353,7 +353,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 setPendingTtsHandoffTimeout()
             } else {
                 val chapters = currentChapters ?: return@launch
-                chapters.nextChapter ?: return@launch
+                if (chapters.nextChapter == null) {
+                    // End of novel: end the session so the background notification/service
+                    // tears down instead of lingering with isTtsAutoPlay stuck true.
+                    stopTts()
+                    return@launch
+                }
                 // Use a viewer-owned flag so ttsController.stop() (called from setChapters)
                 // cannot clear it before onPageFinished fires.
                 pendingTtsAutoStartOnLoad = true
@@ -426,14 +431,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // Cancel any prior timeout regardless of state.
         handoffState.timeoutJob?.cancel()
 
+        val loadedCountAtSchedule = loadedChapters.size
         val timeoutJob = scope.launch {
             delay(5000L)
             if (handoffState.isAppending) {
-                logcat(LogPriority.WARN) {
-                    "TTS (WebView): Handoff timeout after 5000ms; clearing pending state and resuming playback"
-                }
                 clearPendingTtsHandoff()
-                if (ttsController.isTtsAutoPlay && !ttsController.isSpeaking()) {
+                if (loadedChapters.size <= loadedCountAtSchedule) {
+                    // No new chapter appended within the window (end of novel or fetch
+                    // failure). Restarting here would re-read the just-finished chapter on
+                    // a loop, so end the session and let the service tear down instead.
+                    logcat(LogPriority.WARN) {
+                        "TTS (WebView): Handoff timeout, no next chapter appended; stopping playback"
+                    }
+                    stopTts()
+                } else if (ttsController.isTtsAutoPlay && !ttsController.isSpeaking()) {
+                    logcat(LogPriority.WARN) {
+                        "TTS (WebView): Handoff timeout after 5000ms; resuming playback on new chapter"
+                    }
                     startTts()
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -354,7 +354,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 // Use a viewer-owned flag so ttsController.stop() (called from setChapters)
                 // cannot clear it before onPageFinished fires.
                 pendingTtsAutoStartOnLoad = true
-                activity.loadNextChapter()
+                // Must NOT use activity.loadNextChapter(): stopNovelTtsForManualNav() →
+                // stopTts() clears pendingTtsAutoStartOnLoad, so playback never resumes.
+                activity.loadNextChapterForTtsHandoff()
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -129,6 +129,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // True only while loadHtmlContent() has called loadDataWithBaseURL for real chapter content
     // (not the loading-indicator page). Lets onPageFinished distinguish real vs loading loads.
     private var isLoadingRealChapter = false
+    // False while the loading indicator is up or real content is still loading; true once real
+    // chapter content has finished rendering. Guards TTS from reading the loading placeholder.
+    private var webChapterContentReady = false
 
     private val ttsController: TtsController
 
@@ -567,6 +570,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     // when the chapter URL is relative, making the URL useless as a guard.
                     if (isLoadingRealChapter) {
                         isLoadingRealChapter = false
+                        // Real content is now rendered; let TTS start read the body.
+                        webChapterContentReady = true
                         if (pendingTtsAutoStartOnLoad) {
                             pendingTtsAutoStartOnLoad = false
                             startTts()
@@ -1105,6 +1110,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // Signal to onPageFinished that the next callback is for real chapter content, not
         // the loading-indicator page (which also fires onPageFinished with url="about:blank").
         isLoadingRealChapter = true
+        webChapterContentReady = false
         webView.loadDataWithBaseURL(resolveWebViewBaseUrl(chapterPath), html, "text/html", "UTF-8", null)
     }
 
@@ -1179,6 +1185,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         """.trimIndent()
 
         isLoadingRealChapter = false
+        webChapterContentReady = false
         webView.loadDataWithBaseURL(null, loadingHtml, "text/html", "UTF-8", null)
     }
 
@@ -1864,6 +1871,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
+        if (!webChapterContentReady) {
+            // Loading indicator still up; reading the body now would speak the placeholder
+            // and auto-advance. Defer; onPageFinished starts TTS once content is rendered.
+            pendingTtsAutoStartOnLoad = true
+            return
+        }
         val (chapterIdx, chapterId) = getTtsChapterContext()
         evaluateJavascriptSafe(
             """
@@ -1966,6 +1979,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
+        if (!webChapterContentReady) {
+            // Still loading; defer so onPageFinished re-runs the viewport start once content is in.
+            ttsController.pendingStartRequest = TtsController.StartRequest.VIEWPORT
+            return
+        }
         val (chapterIdx, chapterId) = getTtsChapterContext()
         evaluateJavascriptSafe(
             """

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -354,8 +354,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             } else {
                 val chapters = currentChapters ?: return@launch
                 if (chapters.nextChapter == null) {
-                    // End of novel: end the session so the background notification/service
-                    // tears down instead of lingering with isTtsAutoPlay stuck true.
+                    // End of novel: stop so the background service tears down instead of
+                    // lingering with isTtsAutoPlay stuck true.
                     stopTts()
                     return@launch
                 }
@@ -437,9 +437,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             if (handoffState.isAppending) {
                 clearPendingTtsHandoff()
                 if (loadedChapters.size <= loadedCountAtSchedule) {
-                    // No new chapter appended within the window (end of novel or fetch
-                    // failure). Restarting here would re-read the just-finished chapter on
-                    // a loop, so end the session and let the service tear down instead.
+                    // No new chapter appended (end of novel or fetch failure). Restarting
+                    // would re-read the finished chapter on a loop, so stop instead.
                     logcat(LogPriority.WARN) {
                         "TTS (WebView): Handoff timeout, no next chapter appended; stopping playback"
                     }
@@ -584,7 +583,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     // when the chapter URL is relative, making the URL useless as a guard.
                     if (isLoadingRealChapter) {
                         isLoadingRealChapter = false
-                        // Real content is now rendered; let TTS start read the body.
+                        // Real content rendered; TTS may now read the body.
                         webChapterContentReady = true
                         if (pendingTtsAutoStartOnLoad) {
                             pendingTtsAutoStartOnLoad = false


### PR DESCRIPTION

  - Stop the foreground-service crash (start/stop racing startForeground).
  - Wait for chapter text to render before starting, so it doesn't read the loading screen.
  - Reset the pause button on chapter change.
  - Stop at end of novel / on load failure instead of leaving the notification stuck.
