### PR TITLE
fix(reader): exclude StubSource from LocalNovelPageLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix TTS crashes, and issues with chapter change and rendering [@Rojikku](https://github.com/Rojikku) [#251](https://github.com/tsundoku-otaku/tsundoku/pull/251)
 - Make JS scripts regardless of inf scroll [@mrissaoussama](https://github.com/mrissaoussama) [#220](https://github.com/tsundoku-otaku/tsundoku/pull/220)
 - Always serve cached translations [@mrissaoussama](https://github.com/mrissaoussama) [#236](https://github.com/tsundoku-otaku/tsundoku/pull/236)
+- Exclude stubsource from localnovelpageloader [@mrissaoussama](https://github.com/mrissaoussama) [#236](https://github.com/tsundoku-otaku/tsundoku/pull/236)
 - JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)
 - Fix service restrictions and background start crashes [@mrissaoussama](https://github.com/mrissaoussama) [#243](https://github.com/tsundoku-otaku/tsundoku/pull/243)
 - Library filter OOM fix [@mrissaoussama](https://github.com/mrissaoussama) [#261](https://github.com/tsundoku-otaku/tsundoku/pull/261)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -115,8 +115,10 @@ class ChapterLoader(
             // HttpSource novels (extensions + CustomNovelSource) return a no-fetch page list whose
             // URL their own fetchPageText consumes, so HttpPageLoader loads them (manga too).
             source is HttpSource -> HttpPageLoader(chapter, source)
-            // Non-HttpSource novels (JS plugins, etc.)
-            source.isNovelSource -> LocalNovelPageLoader(chapter, source)
+            // Non-HttpSource novels (JS plugins, etc.). Exclude StubSource: a stub carries the
+            // persisted isNovelSource flag but no fetchPageText impl, so it must fall through to
+            // the resolution branch below (e.g. after process death before sourceManager inits).
+            source.isNovelSource && source !is StubSource -> LocalNovelPageLoader(chapter, source)
             source is StubSource -> {
                 // Wait for sourceManager to finish combining all sources (KT ext + JS plugins)
                 if (!sourceManager.isInitialized.value) {


### PR DESCRIPTION
StubSources retain the persisted `isNovelSource` flag but lack a `fetchPageText` implementation. Excluding them from the `LocalNovelPageLoader` branch ensures they fall through to the resolution logic that waits for `sourceManager` to initialize (e.g., after process death), preventing potential crashes or load failures.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
