### PR TITLE
fix(jsplugin): change default setting type to Text in JsSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - JS Source URL normalization [@mrissaoussama](https://github.com/mrissaoussama) [#231](https://github.com/tsundoku-otaku/tsundoku/pull/231)
 - Fix service restrictions and background start crashes [@mrissaoussama](https://github.com/mrissaoussama) [#243](https://github.com/tsundoku-otaku/tsundoku/pull/243)
 - Library filter OOM fix [@mrissaoussama](https://github.com/mrissaoussama) [#261](https://github.com/tsundoku-otaku/tsundoku/pull/261)
+- Change default setting type to text in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#267](https://github.com/tsundoku-otaku/tsundoku/pull/267)
 - Library settings now has per-type extension cache [@mrissaoussama](https://github.com/mrissaoussama) [#259](https://github.com/tsundoku-otaku/tsundoku/pull/259)
 - Encoding issues when parsing jssource chapters [@mrissaoussama](https://github.com/mrissaoussama) [#224](https://github.com/tsundoku-otaku/tsundoku/pull/224)
 - Fix accuracy of mass import notification [@mrissaoussama](https://github.com/mrissaoussama) [#254](https://github.com/tsundoku-otaku/tsundoku/pull/254)

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -713,7 +713,7 @@ class JsSource(
             settings.forEach { (key, value) ->
                 val settingObj = value as? JsonObject ?: return@forEach
                 val label = settingObj["label"]?.jsonPrimitive?.content ?: key
-                val type = settingObj["type"]?.jsonPrimitive?.content ?: "Switch"
+                val type = settingObj["type"]?.jsonPrimitive?.content ?: "Text"
 
                 when (type) {
                     "Switch" -> {


### PR DESCRIPTION
When parsing settings from a JS source, fall back to "Text" instead of "Switch" if the "type" property is missing in the configuration object.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
