### PR TITLE
Add an "Update entries metadata" advanced preference+ fix alt titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Add advanced preference to prevent entries metadata from being overwritten [@mrissaoussama](https://github.com/mrissaoussama) [#271](https://github.com/tsundoku-otaku/tsundoku/pull/271)
+
 ### Fixed
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
@@ -107,17 +107,21 @@ class UpdateManga(
 
         val thumbnailUrl = remoteManga.thumbnail_url?.takeIf { it.isNotEmpty() }
 
+        // Don't overwrite manually edited metadata unless the preference is enabled
+        val updateMetadata = libraryPreferences.updateMangaMetadata.get()
+        val status = remoteManga.status.toLong()
+
         val success = mangaRepository.update(
             MangaUpdate(
                 id = localManga.id,
                 title = title,
                 coverLastModified = coverLastModified,
-                author = remoteManga.author,
-                artist = remoteManga.artist,
-                description = remoteManga.description,
-                genre = remoteManga.getGenres(),
+                author = remoteManga.author.takeIf { updateMetadata },
+                artist = remoteManga.artist.takeIf { updateMetadata },
+                description = remoteManga.description.takeIf { updateMetadata },
+                genre = remoteManga.getGenres().takeIf { updateMetadata },
                 thumbnailUrl = thumbnailUrl,
-                status = remoteManga.status.toLong(),
+                status = status.takeIf { updateMetadata },
                 updateStrategy = remoteManga.update_strategy,
                 initialized = true,
             ),
@@ -131,7 +135,7 @@ class UpdateManga(
                     title = title ?: manga.title,
                     thumbnailUrl = thumbnailUrl ?: manga.thumbnailUrl,
                     coverLastModified = coverLastModified ?: manga.coverLastModified,
-                    status = remoteManga.status.toLong(),
+                    status = if (updateMetadata) status else manga.status,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
@@ -111,6 +111,24 @@ class UpdateManga(
         val updateMetadata = libraryPreferences.updateMangaMetadata.get()
         val status = remoteManga.status.toLong()
 
+        // Alternative titles are always merged additively (never removed), so they don't clash with
+        // manual edits and aren't gated by updateMetadata.
+        val remoteAltTitles = try {
+            remoteManga.altTitles
+        } catch (_: Exception) {
+            emptyList()
+        }
+        val effectiveTitle = title ?: localManga.title
+        val mergedAltTitles = if (remoteAltTitles.isNotEmpty()) {
+            (localManga.alternativeTitles + remoteAltTitles)
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it != effectiveTitle }
+                .distinct()
+                .takeIf { it != localManga.alternativeTitles }
+        } else {
+            null
+        }
+
         val success = mangaRepository.update(
             MangaUpdate(
                 id = localManga.id,
@@ -120,6 +138,7 @@ class UpdateManga(
                 artist = remoteManga.artist.takeIf { updateMetadata },
                 description = remoteManga.description.takeIf { updateMetadata },
                 genre = remoteManga.getGenres().takeIf { updateMetadata },
+                alternativeTitles = mergedAltTitles,
                 thumbnailUrl = thumbnailUrl,
                 status = status.takeIf { updateMetadata },
                 updateStrategy = remoteManga.update_strategy,
@@ -136,6 +155,7 @@ class UpdateManga(
                     thumbnailUrl = thumbnailUrl ?: manga.thumbnailUrl,
                     coverLastModified = coverLastModified ?: manga.coverLastModified,
                     status = if (updateMetadata) status else manga.status,
+                    alternativeTitles = mergedAltTitles ?: manga.alternativeTitles,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -1384,6 +1384,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitle = stringResource(MR.strings.pref_update_library_manga_titles_summary),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.updateMangaMetadata,
+                    title = stringResource(TDMR.strings.pref_update_library_manga_metadata),
+                    subtitle = stringResource(TDMR.strings.pref_update_library_manga_metadata_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.disallowNonAsciiFilenames,
                     title = stringResource(MR.strings.pref_disallow_non_ascii_filenames),
                     subtitle = stringResource(MR.strings.pref_disallow_non_ascii_filenames_details),

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -298,7 +298,7 @@ class LibraryPreferences(
 
     val updateMangaTitles: Preference<Boolean> = preferenceStore.getBoolean("pref_update_library_manga_titles", false)
 
-    val updateMangaMetadata: Preference<Boolean> = preferenceStore.getBoolean("pref_update_library_manga_metadata", false)
+    val updateMangaMetadata: Preference<Boolean> = preferenceStore.getBoolean("pref_update_library_manga_metadata", true)
 
     val disallowNonAsciiFilenames: Preference<Boolean> = preferenceStore.getBoolean(
         "disallow_non_ascii_filenames",

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -298,6 +298,8 @@ class LibraryPreferences(
 
     val updateMangaTitles: Preference<Boolean> = preferenceStore.getBoolean("pref_update_library_manga_titles", false)
 
+    val updateMangaMetadata: Preference<Boolean> = preferenceStore.getBoolean("pref_update_library_manga_metadata", false)
+
     val disallowNonAsciiFilenames: Preference<Boolean> = preferenceStore.getBoolean(
         "disallow_non_ascii_filenames",
         false,

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -7,6 +7,8 @@
     nav_zone_next: Next
     nav_zone_prev: Prev
      -->
+    <string name="pref_update_library_manga_metadata">Update entries metadata to match source</string>
+    <string name="pref_update_library_manga_metadata_summary">When refreshing, overwrite author, description, status and tags with source data. Disable to keep your manual edits.</string>
     <!-- Screen Titles -->
     <string name="label_novel_download_queue">Novel downloads</string>
     <string name="label_manga_sources">Manga Sources</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -8,7 +8,7 @@
     nav_zone_prev: Prev
      -->
     <string name="pref_update_library_manga_metadata">Update entries metadata to match source</string>
-    <string name="pref_update_library_manga_metadata_summary">When refreshing, overwrite author, description, status and tags with source data. Disable to keep your manual edits.</string>
+    <string name="pref_update_library_manga_metadata_summary">When refreshing, overwrite author, description, status and tags with source data. Disable so further updates from the source never override the entry metadata, keeping your manual edits.</string>
     <!-- Screen Titles -->
     <string name="label_novel_download_queue">Novel downloads</string>
     <string name="label_manga_sources">Manga Sources</string>


### PR DESCRIPTION

When off, a library update no longer overwrites author/artist/description/genre/status with the remote values.
this happens even if there were no edits from the user (if source updated desc after last fetch, the old version will be kept)
this is why I've kept it off by default.


- Fix merging for alternative titles. there was an issue preventing them from being saved. alt titles are never overwritten. it only adds to it.
