### PR TITLE
feat: improve URL path resolution in JsSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
+- URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)
 
 ### Fixed
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/source/JsSource.kt
@@ -95,6 +95,9 @@ class JsSource(
         private const val INSTANCE_TIMEOUT_MS = 60_000L // 1 minute timeout
         private const val BROWSE_PROBE_TTL_MS = 60_000L
 
+        // Sentinel handed to plugin.resolveUrl to discover its base/prefix join shape.
+        private const val PATH_PROBE_TOKEN = "__tsundoku_path_probe__"
+
         private val HTML_TAG_REGEX = Regex(
             "<(?:p|div|br|span|h[1-6]|ul|ol|li|a|img|table|blockquote|strong|em|b|i|code)\\b",
             RegexOption.IGNORE_CASE,
@@ -610,7 +613,7 @@ class JsSource(
                 return@withContext cached.first
             }
 
-            val path = escapeJsString(normalizePluginPath(manga.url))
+            val path = escapeJsString(resolvePluginPath(manga.url))
             val result = parseNovelCached(manga.url)
             val chapters = parseChapterList(result).toMutableList()
 
@@ -806,13 +809,48 @@ class JsSource(
         }
     }
 
+    // Whether the plugin's URL join (resolveUrl) ends with a slash. Probed once via a sentinel.
+    // Plugins that build URLs from a trailing-slash `site` want the path WITHOUT a leading slash;
+    // plugins that use a prefix without a trailing slash need the
+    // leading slash kept.
+    @Volatile private var resolveUrlPrefixProbe: String? = null
+    @Volatile private var resolveUrlProbed = false
+
+    private suspend fun pluginPrefixEndsWithSlash(): Boolean? {
+        if (resolveUrlProbed) return resolveUrlPrefixProbe?.endsWith("/")
+        val prefix = runCatching {
+            if (executePluginMethod("typeof plugin.resolveUrl === 'function'") != "true") return@runCatching null
+            val raw = executePluginMethod("plugin.resolveUrl('$PATH_PROBE_TOKEN')")
+            val decoded = decodeJsonStringIfQuoted(raw)
+            if (decoded.endsWith(PATH_PROBE_TOKEN)) decoded.removeSuffix(PATH_PROBE_TOKEN) else null
+        }.getOrNull()
+        resolveUrlPrefixProbe = prefix
+        resolveUrlProbed = true
+        return prefix?.endsWith("/")
+    }
+
+    /**
+     * Path passed to parseNovel/parseChapter/parsePage, with its leading slash reconciled to the
+     * plugin's URL-join convention (see [pluginPrefixEndsWithSlash]). Falls back to the legacy
+     * leading-slash strip when the plugin exposes no usable resolveUrl.
+     */
+    private suspend fun resolvePluginPath(value: String): String {
+        val base = normalizeDoubleSlashes(value.trim())
+        if (base.startsWith("http://") || base.startsWith("https://")) return base
+        return when (pluginPrefixEndsWithSlash()) {
+            true -> base.removePrefix("/")
+            false -> if (base.startsWith("/")) base else "/$base"
+            null -> base.removePrefix("/")
+        }
+    }
+
     /** Escape a value for embedding in a single-quoted JS string literal. */
     private fun escapeJsString(value: String): String =
         value.replace("\\", "\\\\").replace("'", "\\'").replace("\"", "\\\"")
 
     /** plugin.parseNovel with raw-result caching and in-flight dedup. */
     private suspend fun parseNovelCached(mangaUrl: String): String {
-        val path = escapeJsString(normalizePluginPath(mangaUrl))
+        val path = escapeJsString(resolvePluginPath(mangaUrl))
         return parseNovelMutex.withLock {
             val now = System.currentTimeMillis()
             parseNovelCache[path]?.takeIf { (now - it.second) < cacheTimeout }?.let { return@withLock it.first }
@@ -825,7 +863,7 @@ class JsSource(
 
     /** plugin.parseChapter with raw-result caching and in-flight dedup. */
     private suspend fun parseChapterCached(chapterUrl: String): String {
-        val path = escapeJsString(normalizePluginPath(chapterUrl))
+        val path = escapeJsString(resolvePluginPath(chapterUrl))
         return chapterTextMutex.withLock {
             val now = System.currentTimeMillis()
             chapterTextCache[path]?.takeIf { (now - it.second) < cacheTimeout }?.let { return@withLock it.first }


### PR DESCRIPTION
- Implement a probing mechanism using `PATH_PROBE_TOKEN` to detect whether a plugin's URL resolution logic expects a trailing slash.
- Add `resolvePluginPath` to reconcile leading slashes in manga and chapter URLs based on the plugin's detected convention.
- Update `getChapterList`, `parseNovelCached`, and `parseChapterCached` to use the new path resolution logic instead of simple normalization.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
