### PR TITLE
fix: keep novel-only UI out of manga reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
+- Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)
 
 
 ## [v0.2.0]

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -31,7 +31,6 @@ object SettingsReaderScreen : SearchableSettings {
         return listOf(
             readerPref.flashDurationMillis,
             readerPref.flashPageInterval,
-            readerPref.novelAutoSplitWordCount,
             readerPref.webtoonSidePadding,
         )
     }
@@ -47,7 +46,7 @@ object SettingsReaderScreen : SearchableSettings {
         return listOf(
             Preference.PreferenceItem.ListPreference(
                 preference = readerPref.defaultReadingMode,
-                entries = ReadingMode.entries.drop(1)
+                entries = (ReadingMode.entries.drop(1) - ReadingMode.NOVEL)
                     .associate { it.flagValue to stringResource(it.stringRes) }
                     .toImmutableMap(),
                 title = stringResource(MR.strings.pref_viewer_type),
@@ -183,10 +182,6 @@ object SettingsReaderScreen : SearchableSettings {
 
     @Composable
     private fun getReadingGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
-        val autoSplitEnabled by readerPreferences.novelAutoSplitText.collectAsState()
-        val autoSplitWordCountPref = readerPreferences.novelAutoSplitWordCount
-        val autoSplitWordCount by autoSplitWordCountPref.collectAsState()
-
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_reading),
             preferenceItems = persistentListOf(
@@ -205,30 +200,6 @@ object SettingsReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.alwaysShowChapterTransition,
                     title = stringResource(MR.strings.pref_always_show_chapter_transition),
-                ),
-                Preference.PreferenceItem.InfoPreference(
-                    title = "Novel Reader Settings",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelAutoSplitText,
-                    title = "Auto-split long chapters",
-                    subtitle = "Split long novel chapters into multiple pages based on word count",
-                ),
-                Preference.PreferenceItem.ListPreference(
-                    preference = readerPreferences.novelVerticalProgressSliderSize,
-                    entries = persistentMapOf(
-                        "half" to "Vertical progress size: Half screen",
-                        "full" to "Vertical progress size: Full screen",
-                    ),
-                    title = "Vertical progress slider size",
-                ),
-                Preference.PreferenceItem.SliderPreference(
-                    value = autoSplitWordCount / 50,
-                    valueRange = 1..40,
-                    title = "Split word count (×50)",
-                    subtitle = "Split every $autoSplitWordCount words",
-                    enabled = autoSplitEnabled,
-                    onValueChanged = { autoSplitWordCountPref.set(it * 50) },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/reader/ReadingModeSelectDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReadingModeSelectDialog.kt
@@ -26,7 +26,8 @@ import tachiyomi.presentation.core.components.SettingsIconGrid
 import tachiyomi.presentation.core.components.material.IconToggleButton
 import tachiyomi.presentation.core.i18n.stringResource
 
-private val ReadingModesWithoutDefault = ReadingMode.entries - ReadingMode.DEFAULT
+// NOVEL is auto-assigned for novel sources, not a manual manga reading mode.
+private val ReadingModesWithoutDefault = ReadingMode.entries - ReadingMode.DEFAULT - ReadingMode.NOVEL
 
 @Composable
 fun ReadingModeSelectDialog(

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -34,7 +34,8 @@ internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel)
 
     val readingMode = remember(manga) { ReadingMode.fromPreference(manga?.readingMode?.toInt()) }
     SettingsChipRow(MR.strings.pref_category_reading_mode) {
-        ReadingMode.entries.map {
+        // NOVEL is auto-assigned for novel sources, not a manual manga reading mode.
+        (ReadingMode.entries - ReadingMode.NOVEL).map {
             FilterChip(
                 selected = it == readingMode,
                 onClick = { screenModel.onChangeReadingMode(it) },


### PR DESCRIPTION
manga reader mistakenly included novel reader mode. caused issues, now removed.
also the manga reader screen had novel settings that were removed also.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
