### PR TITLE
fix: per-tab extension update badge in browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)
+- Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
 
 
 ## [v0.2.0]
@@ -263,3 +264,4 @@ Merged from v0.19.4 [81871a3](https://github.com/mihonapp/mihon/commit/81871a346
 Forked from Mihon v0.19.3 [7161bc2](https://github.com/mihonapp/mihon/commit/7161bc2e825bdfd66a1829f7dce42bd0570b1008)
 
 [mihon]: https://github.com/mihonapp/mihon/blob/7a917968e3bf71c4a665e6655a550877d81ead1d/CHANGELOG.md
+

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -7,7 +7,6 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.extension.interactor.GetExtensionsByType
-import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.components.SEARCH_DEBOUNCE_MILLIS
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.extension.model.Extension
@@ -38,7 +37,6 @@ import uy.kohesive.injekt.api.get
 import kotlin.time.Duration.Companion.seconds
 
 class ExtensionsScreenModel(
-    preferences: SourcePreferences = Injekt.get(),
     basePreferences: BasePreferences = Injekt.get(),
     private val extensionManager: ExtensionManager = Injekt.get(),
     private val getExtensions: GetExtensionsByType = Injekt.get(),
@@ -63,10 +61,10 @@ class ExtensionsScreenModel(
                 currentDownloads,
                 getExtensions.subscribe(),
             ) { predicate, downloads, (_updates, _installed, _available, _untrusted) ->
+                val updates = _updates.filter {
+                    !it.isNovel
+                }.filter(predicate).map(extensionMapper(downloads))
                 buildMap {
-                    val updates = _updates.filter {
-                        !it.isNovel
-                    }.filter(predicate).map(extensionMapper(downloads))
                     if (updates.isNotEmpty()) {
                         put(ExtensionUiModel.Header.Resource(MR.strings.ext_updates_pending), updates)
                     }
@@ -93,23 +91,20 @@ class ExtensionsScreenModel(
                     if (languagesWithExtensions.isNotEmpty()) {
                         putAll(languagesWithExtensions)
                     }
-                }
+                } to updates.size
             }
-                .collectLatest { items ->
+                .collectLatest { (items, updatesCount) ->
                     mutableState.update { state ->
                         state.copy(
                             isLoading = false,
                             items = items,
+                            updates = updatesCount,
                         )
                     }
                 }
         }
 
         screenModelScope.launchIO { findAvailableExtensions() }
-
-        preferences.extensionUpdatesCount.changes()
-            .onEach { mutableState.update { state -> state.copy(updates = it) } }
-            .launchIn(screenModelScope)
 
         basePreferences.extensionInstaller.changes()
             .onEach { mutableState.update { state -> state.copy(installer = it) } }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionsScreenModel.kt
@@ -102,6 +102,7 @@ class NovelExtensionsScreenModel(
                 // Respect language filter for JS plugins (same as KT extensions)
                 val enabledLanguages = preferences.enabledLanguages.get()
 
+                var updatesCount = 0
                 buildMap {
 
                     // Build extensions from available plugins
@@ -173,6 +174,7 @@ class NovelExtensionsScreenModel(
 
                     val updates = (_updates.filter { it.isNovel } + jsUpdates)
                         .filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
+                    updatesCount = updates.size
                     if (updates.isNotEmpty()) {
                         put(ExtensionUiModel.Header.Resource(MR.strings.ext_updates_pending), updates)
                     }
@@ -204,23 +206,20 @@ class NovelExtensionsScreenModel(
                     if (languagesWithExtensions.isNotEmpty()) {
                         putAll(languagesWithExtensions)
                     }
-                }
+                } to updatesCount
             }
-                .collectLatest {
+                .collectLatest { (items, updates) ->
                     mutableState.update { state ->
                         state.copy(
                             isLoading = false,
-                            items = it,
+                            items = items,
+                            updates = updates,
                         )
                     }
                 }
         }
 
         screenModelScope.launchIO { findAvailableExtensions() }
-
-        preferences.extensionUpdatesCount.changes()
-            .onEach { mutableState.update { state -> state.copy(updates = it) } }
-            .launchIn(screenModelScope)
 
         basePreferences.extensionInstaller.changes()
             .onEach { mutableState.update { state -> state.copy(installer = it) } }


### PR DESCRIPTION
The manga and novel extension tabs both read the badge count from the shared extensionUpdatesCount preference, so both showed the same total. 

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
