### PR TITLE
feat: add artist field to edit manga dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
+- Edit manga now has an artist field [@mrissaoussama](https://github.com/mrissaoussama) [#278](https://github.com/tsundoku-otaku/tsundoku/pull/278)
 - URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)
 
 ### Fixed

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
@@ -233,6 +233,12 @@ class UpdateManga(
         )
     }
 
+    suspend fun awaitUpdateArtist(mangaId: Long, artist: String): Boolean {
+        return mangaRepository.update(
+            MangaUpdate(id = mangaId, artist = artist),
+        )
+    }
+
     suspend fun awaitUpdateStatus(mangaId: Long, status: Long): Boolean {
         return mangaRepository.update(
             MangaUpdate(id = mangaId, status = status),

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -58,6 +58,7 @@ fun EditMangaDialog(
     onSaveTags: (List<String>) -> Unit,
     onSaveAltTitles: (List<String>) -> Unit,
     onSaveAuthor: (String) -> Unit,
+    onSaveArtist: (String) -> Unit,
     onSaveStatus: (Long) -> Unit,
     onSwapMainTitle: ((newMainTitle: String, updatedAltTitles: List<String>) -> Unit)? = null,
 ) {
@@ -67,6 +68,7 @@ fun EditMangaDialog(
     var tags by remember { mutableStateOf(manga.genre.orEmpty()) }
     var altTitles by remember { mutableStateOf(manga.alternativeTitles) }
     var author by remember { mutableStateOf(manga.author.orEmpty()) }
+    var artist by remember { mutableStateOf(manga.artist.orEmpty()) }
     var status by remember { mutableStateOf(manga.status) }
 
     val tabTitles = persistentListOf(
@@ -82,6 +84,7 @@ fun EditMangaDialog(
             onSaveTags(tags)
             onSaveAltTitles(altTitles)
             onSaveAuthor(author)
+            onSaveArtist(artist)
             onSaveStatus(status)
             onDismissRequest()
         },
@@ -117,6 +120,11 @@ fun EditMangaDialog(
                         label = stringResource(MR.strings.author),
                         value = author,
                         onValueChange = { author = it },
+                    )
+                    EditTextField(
+                        label = stringResource(MR.strings.artist),
+                        value = artist,
+                        onValueChange = { artist = it },
                     )
                     EditStatusField(
                         status = status,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -353,6 +353,7 @@ class MangaScreen(
                     onSaveTags = { screenModel.updateTags(it) },
                     onSaveAltTitles = { screenModel.updateAlternativeTitles(it) },
                     onSaveAuthor = { screenModel.updateAuthor(it) },
+                    onSaveArtist = { screenModel.updateArtist(it) },
                     onSaveStatus = { screenModel.updateStatus(it) },
                     onSwapMainTitle = { newMain, updatedAlts ->
                         screenModel.swapMainTitle(newMain, updatedAlts)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1416,6 +1416,12 @@ class MangaScreenModel(
         }
     }
 
+    fun updateArtist(artist: String) {
+        screenModelScope.launchIO {
+            updateManga.awaitUpdateArtist(mangaId, artist)
+        }
+    }
+
     /**
      * Update the Status of the manga.
      */


### PR DESCRIPTION
Allow editing the artist in the manga info edit dialog.
closes #275 
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
