### PR TITLE
Remove wasEmpty from downloads to prevent stale state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)
+- Download ahead download states should no longer get stale values [@mrissaoussama](https://github.com/mrissaoussama) [#289](https://github.com/tsundoku-otaku/tsundoku/pull/289)
 - Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -454,8 +454,6 @@ class Downloader(
         }
         logcat { "queueChapters: Source is ${source.name}, isNovelSource=${source.isNovelSource()}" }
 
-        val wasEmpty = queueState.value.isEmpty()
-
         // Use a background thread for the heavy lifting of checking file existence
         scope.launchIO {
             val (_, downloadedDirs) = provider.findChapterDirs(chapters, manga, source)
@@ -490,7 +488,7 @@ class Downloader(
                 addAllToQueue(chaptersToQueue)
 
                 // Start downloader if needed
-                if (autoStart && wasEmpty) {
+                if (autoStart && !isRunning) {
                     val queuedDownloads = queueState.value.count { it.source !is UnmeteredSource }
                     val maxDownloadsFromSource = queueState.value
                         .filter { it.source !is UnmeteredSource }


### PR DESCRIPTION
Exchange wasEmpty for !isRunning to try to prevent stale states potentially causing my earlier noted download bug.

Hopefully causes no issues.