### PR TITLE
 Custom source builder improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - Novel download queue improvements to prevent errors [@mrissaoussama](https://github.com/mrissaoussama) [#284](https://github.com/tsundoku-otaku/tsundoku/pull/284)
+- Some great improvements to custom sources, including {novelUrl} [@mrissaoussama](https://github.com/mrissaoussama) [#296](https://github.com/tsundoku-otaku/tsundoku/pull/296)
 - Improve performance on library export notifications [@mrissaoussama](https://github.com/mrissaoussama) [#285](https://github.com/tsundoku-otaku/tsundoku/pull/285)
 - Edit manga now has an artist field [@mrissaoussama](https://github.com/mrissaoussama) [#278](https://github.com/tsundoku-otaku/tsundoku/pull/278)
 - URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,10 +43,14 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    if (System.getenv("TSUNDOKU_GITHUB_RELEASE").toBoolean() && System.getenv("GITHUB_REPOSITORY_OWNER") == "tsundoku-otaku") {
+    if (System.getenv("TSUNDOKU_GITHUB_RELEASE").toBoolean() &&
+        System.getenv("GITHUB_REPOSITORY_OWNER") == "tsundoku-otaku"
+    ) {
         val tempStoreFile = file(System.getenv("RUNNER_TEMP")).resolve("tsundoku.keystore")
 
-        val storeFileBytes = System.getenv("storeFileBase64").filter { !it.isWhitespace() && it != '"' }.let(Base64::decode)
+        val storeFileBytes = System.getenv("storeFileBase64").filter {
+            !it.isWhitespace() && it != '"'
+        }.let(Base64::decode)
         tempStoreFile.outputStream().use { it.write(storeFileBytes) }
 
         signingConfigs {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -306,10 +306,8 @@ private fun sanitizeCustomSourceFilename(name: String): String {
     return name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
 }
 
-// {page} is substituted on every page including page 1, so a template like "list/{page}" yields
-// list/1, list/2, … (sites that number page 1 in the path work). When a site's first page has no
-// page segment at all, the caller passes the verbatim page-1 URL (no {page}) for page 1 and the
-// {page} template only for page 2+.
+// {page} is substituted on every page (page 1 included). For sites whose first page has no page
+// segment, the caller passes the verbatim page-1 URL and uses the {page} template only for page 2+.
 internal fun buildPagedUrlTemplate(template: String, baseUrl: String, page: Int): String {
     return template
         .replace("{baseUrl}", baseUrl)
@@ -326,9 +324,9 @@ internal fun buildPagedSearchUrlTemplate(template: String, baseUrl: String, quer
 }
 
 /**
- * Maps a site's status text to an [SManga] status constant. [mapping] (substring -> one of
- * ongoing/completed/hiatus/cancelled, case-insensitive) is consulted first so non-English sites
- * can define their own words; the built-in English keywords are the fallback.
+ * Maps a site's status text to an [SManga] status constant. [mapping] (substring -> ongoing/
+ * completed/hiatus/cancelled, case-insensitive) wins so non-English sites define their own words;
+ * built-in English keywords are the fallback.
  */
 internal fun parseCustomSourceStatus(status: String?, mapping: Map<String, String>? = null): Int {
     if (status.isNullOrBlank()) return SManga.UNKNOWN
@@ -355,18 +353,16 @@ internal fun parseCustomSourceStatus(status: String?, mapping: Map<String, Strin
     }
 }
 
-// Lazy-load / non-<img> cover sources, tried in order before the plain src. Covers a div with a
-// CSS background-image, <img srcset>, the usual data-* lazy attributes, <video poster> and og:image.
+// Cover-image attributes tried in order before plain src (lazy-load data-*, srcset, poster, og:image).
 private val IMAGE_URL_ATTRS = listOf(
     "data-src", "data-original", "data-lazy-src", "data-lazy", "data-cfsrc",
     "data-echo", "data-srcset", "srcset", "src", "poster", "content",
 )
 
 /**
- * Resolves a usable, absolute image URL from [element] (a cover image or its wrapper). Prefers the
- * absolute form (`abs:`) of each candidate attribute so relative covers like `/img/x.jpg` are not
- * returned bare, falls back to a `background-image:url(...)` style, and unwraps `srcset` to its
- * first URL. Returns null when nothing usable is present.
+ * Resolves an absolute image URL from [element]. Prefers each attribute's `abs:` form (so relative
+ * covers aren't returned bare), falls back to a `background-image:url(...)`, unwraps `srcset` to its
+ * first URL. Null when nothing usable.
  */
 internal fun resolveImageUrl(element: Element): String? {
     for (attr in IMAGE_URL_ATTRS) {
@@ -385,9 +381,8 @@ internal fun resolveImageUrl(element: Element): String? {
 }
 
 /**
- * Converts an element's inner HTML to plain text while preserving paragraph and line breaks:
- * `<br>` becomes a newline and `</p>`/`</div>` a blank line, so multi-paragraph novel synopses keep
- * their structure instead of collapsing to one space-joined line (what Jsoup `.text()` does).
+ * Inner HTML to plain text, preserving paragraph breaks (`<br>` -> newline, `</p>`/`</div>` -> blank
+ * line) so multi-paragraph synopses don't collapse to one line like Jsoup `.text()` does.
  */
 internal fun htmlToFormattedText(html: String): String {
     val withBreaks = html
@@ -403,20 +398,14 @@ internal fun htmlToFormattedText(html: String): String {
 /** Numeric chapter URL/name pair for a generated chapter list (mode B). */
 internal data class GeneratedChapterEntry(val url: String, val name: String, val number: Float)
 
-/**
- * Substitutes the `{novelUrl}` placeholder in a generated-chapter URL pattern with the current
- * novel's path, so one pattern works for every novel instead of being pinned to the novel it was
- * captured from. A pattern with no placeholder is returned unchanged (legacy behaviour).
- */
+/** Substitutes `{novelUrl}` in a generated-chapter pattern with the current novel's path. */
 internal fun applyNovelUrlToPattern(pattern: String, novelUrl: String): String =
     pattern.replace("{novelUrl}", novelUrl.trim().trimEnd('/'))
 
 /**
- * From two chapter URLs of the SAME novel, derive a portable numeric pattern plus the two chapter
- * numbers. The last digit run is treated as the chapter number (robust to a novel id earlier in the
- * path). When [novelUrl] is supplied and prefixes the pattern, that prefix is replaced with the
- * `{novelUrl}` placeholder so the pattern generalizes to other novels. Returns
- * (pattern, firstNumber, lastNumber) or null when no numeric difference is found.
+ * From two chapter URLs of the SAME novel, derive a portable numeric pattern + the two numbers. The
+ * last digit run is the chapter number (robust to a novel id earlier in the path); a [novelUrl]
+ * prefix is replaced with `{novelUrl}` to generalize. Returns (pattern, first, last) or null.
  */
 internal fun deriveGenericChapterPattern(
     chapterUrl1: String,
@@ -442,10 +431,7 @@ internal fun deriveGenericChapterPattern(
     return Triple(pattern, n1, n2)
 }
 
-/**
- * Builds the [start]..[end] generated chapter entries from a numeric URL [pattern]. URLs are kept
- * as the raw substituted template; callers normalize them against the base URL.
- */
+/** Builds [start]..[end] chapter entries from a numeric URL [pattern]; callers normalize the URLs. */
 internal fun generatedChapterEntries(
     pattern: String,
     start: Int,
@@ -464,15 +450,9 @@ internal fun generatedChapterEntries(
 }
 
 /**
- * Custom Novel Extension - User-defined novel source
- *
- * This class allows users to create custom novel sources by defining:
- * - CSS selectors for different page elements
- * - URL patterns for navigation
- * - Custom headers if needed
- *
- * The configuration is stored as JSON and can be edited through the app UI
- * or shared with other users.
+ * User-defined novel source driven by [CustomSourceConfig] (CSS selectors, URL patterns, headers).
+ * Config is JSON, editable in-app and shareable. When [CustomSourceConfig.basedOnSourceId] is set,
+ * delegates to an installed extension and only rebases its base URL.
  */
 class CustomNovelSource(
     val config: CustomSourceConfig,
@@ -610,10 +590,8 @@ class CustomNovelSource(
         return getChapterList(manga)
     }
 
-    // Mode B: build the chapter list from a numeric URL pattern instead of scraping it. start is the
-    // numbering base (constant for the site). The END is read PER NOVEL from countSelector on the
-    // details page so each novel loads its own length; lastNumber is only a fallback for the rare
-    // single-novel source with no count element. One fetch at most (only when a count must be read).
+    // Mode B: build the list from a numeric URL pattern. start = numbering base; end is read per
+    // novel from countSelector (lastNumber is the fallback). At most one fetch (to read the count).
     private suspend fun generateChapterList(manga: SManga): List<SChapter> {
         val sel = config.selectors.chapters
         val pattern = sel.urlPattern ?: return emptyList()
@@ -641,23 +619,19 @@ class CustomNovelSource(
         return if (config.reverseChapters) chapters else chapters.reversed()
     }
 
-    // Resolves the chapter list across these optional dimensions:
-    //  - indexLinkSelector: the chapter list lives on a separate page linked from the details page.
-    //  - pagedUrlPattern: numbered pages reached by URL (e.g. "{novelUrl}?page={page}"). Preferred
-    //    over the next-button because it can't be fooled by an ambiguous prev/next selector.
-    //  - nextPage: fallback — follow the "next page" link.
-    // Chapters are de-duplicated by URL across pages (sites often repeat a "Newest" block on every
-    // page), and reversal is applied once at the end so multi-page lists keep one consistent order.
+    // Resolves the chapter list across optional dimensions: indexLinkSelector (list on a separate
+    // linked page), pagedUrlPattern (numbered URL pages, preferred over the next-button since it
+    // can't be fooled by an ambiguous prev/next selector), and nextPage (follow the link, fallback).
+    // De-dupes by URL across pages and reverses once at the end.
     private suspend fun fetchResolvedChapterList(
         manga: SManga,
         context: eu.kanade.tachiyomi.source.model.RefreshContext?,
     ): List<SChapter> {
         val selectors = config.selectors.chapters
 
-        // Skip walking the whole back-catalog when nothing is new: if the first page introduces no
-        // chapter the library doesn't already have (and this isn't a forced refresh), return the
-        // existing list as-is. The result replaces the stored list, so we must return the full set
-        // — hence we only short-circuit on the "no new chapters" case.
+        // If the first page introduces no chapter the library lacks (and not a forced refresh),
+        // keep the existing list. We only short-circuit this "no new chapters" case since the
+        // result replaces the stored list and must otherwise be the full set.
         val knownUrls = context?.takeIf { !it.forceRefresh }
             ?.existingChapters?.mapNotNull { it.url.ifBlank { null } }?.toSet().orEmpty()
 
@@ -840,10 +814,8 @@ class CustomNovelSource(
         return if (config.reverseChapters) chapters.reversed() else chapters
     }
 
-    // Picks the real "next page" link when [selector] is ambiguous (e.g. a shared ".btn-page" class
-    // on both « Prev and Next »). selectFirst would grab Prev and bounce back to an already-visited
-    // page, capping the walk at 2 pages. Skip prev links and pages we've seen; prefer explicit
-    // next markers (rel=next, "next"/»/›/→ in text or class).
+    // Picks the real "next page" link when [selector] is ambiguous (shared prev/next class).
+    // Skips prev links and visited pages; prefers explicit next markers (rel=next, next/»/›/→).
     private fun resolveNextPageUrl(
         document: Document,
         selector: String,
@@ -972,11 +944,7 @@ class CustomNovelSource(
         return element.html()
     }
 
-    /**
-     * Strips common boilerplate from a content element: scripts/styles, ad and share widgets,
-     * WordPress cruft, next/prev chapter navigation links and empty leftover nodes.
-     * Mirrors the cleanup an extension parser would normally hardcode.
-     */
+    /** Strips boilerplate: scripts/styles, ad/share widgets, chapter-nav links, empty nodes. */
     private fun cleanContentElement(element: Element) {
         element.select(BOILERPLATE_SELECTOR).remove()
 
@@ -1276,8 +1244,7 @@ data class CustomSourceConfig(
     val popularUrl: String,
     val latestUrl: String? = null,
     val searchUrl: String,
-    // Page-2+ templates (with {page}). When set, page 1 uses the plain *Url above (verbatim, so it
-    // keeps or omits the page param exactly as the site's first page does) and later pages use these.
+    // Page-2+ templates (with {page}). When set, page 1 uses the plain *Url above verbatim.
     val popularPagedUrl: String? = null,
     val latestPagedUrl: String? = null,
     val searchPagedUrl: String? = null,
@@ -1287,16 +1254,13 @@ data class CustomSourceConfig(
     val postSearch: Boolean = false,
     val basedOnSourceId: Long? = null,
     val isNovel: Boolean = true,
-    // Query used when testing this source. Set from the search probe word in the wizard.
+    // Test query; set from the wizard's search probe word.
     val testSearchQuery: String? = null,
-    // Date format used to parse chapter dates, e.g. "yyyy-MM-dd". Required for worded/relative
-    // dates (no built-in language-specific parsing); use the site's own locale pattern.
+    // SimpleDateFormat pattern for chapter dates, e.g. "yyyy-MM-dd". Required for worded dates.
     val dateFormat: String? = null,
-    // Optional status-text mapping: site word (substring, case-insensitive) -> ongoing / completed
-    // / hiatus / cancelled. Lets non-English sites map their own status labels.
+    // Status-word mapping (substring, case-insensitive) -> ongoing/completed/hiatus/cancelled.
     val statusMapping: Map<String, String>? = null,
-    // Optional novel URL used by the wizard's reading test to open a known novel directly
-    // (so the reading section can be tested without a working popular/latest/search listing).
+    // Novel URL the wizard's reading test opens directly, so it works without a working listing.
     val sampleNovelUrl: String? = null,
 )
 
@@ -1336,25 +1300,21 @@ data class ChapterSelectors(
     val link: String? = null,
     val name: String? = null,
     val date: String? = null,
-    // Optional selector for the "next page" link when the chapter list spans multiple pages.
+    // "Next page" link selector when the chapter list spans multiple pages.
     val nextPage: String? = null,
-    // Optional selector, on the DETAILS page, pointing to a separate chapter-list/index page.
-    // When set, chapters are read from the linked page instead of the details page.
+    // Details-page selector for a separate chapter-list/index page; chapters read from there.
     val indexLinkSelector: String? = null,
-    // Optional numbered-pagination URL template for the chapter list, e.g. "{novelUrl}?page={page}".
-    // {novelUrl} is replaced with the current novel path. Preferred over nextPage (it can't be
-    // fooled by a shared prev/next selector); pages are walked until one adds no new chapters.
+    // Numbered-pagination URL template, e.g. "{novelUrl}?page={page}". Preferred over nextPage.
     val pagedUrlPattern: String? = null,
-    // ---- Generated chapter list (mode B): build chapter URLs from a numeric pattern instead of
-    // scraping the list. Used for sites with sequential URLs like /novel/chapter-{n}. ----
-    // Chapter URL template with {n} for the chapter number, e.g. "/novel/abc/chapter-{n}".
+    // ---- Mode B: generate chapter URLs from a numeric pattern (e.g. /novel/chapter-{n}). ----
+    // Chapter URL template with {n}.
     val urlPattern: String? = null,
-    // Selector (on the details page) for an element whose text holds the total chapter count.
+    // Details-page selector whose text holds the total chapter count.
     val countSelector: String? = null,
-    // Explicit numeric range; lastNumber falls back to the parsed countSelector value.
+    // Explicit range; lastNumber falls back to the parsed countSelector value.
     val firstNumber: Int? = null,
     val lastNumber: Int? = null,
-    // Chapter name template with {n}, e.g. "Chapter {n}". Defaults to "Chapter {n}".
+    // Name template with {n}. Defaults to "Chapter {n}".
     val nameTemplate: String? = null,
 )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -404,6 +404,45 @@ internal fun htmlToFormattedText(html: String): String {
 internal data class GeneratedChapterEntry(val url: String, val name: String, val number: Float)
 
 /**
+ * Substitutes the `{novelUrl}` placeholder in a generated-chapter URL pattern with the current
+ * novel's path, so one pattern works for every novel instead of being pinned to the novel it was
+ * captured from. A pattern with no placeholder is returned unchanged (legacy behaviour).
+ */
+internal fun applyNovelUrlToPattern(pattern: String, novelUrl: String): String =
+    pattern.replace("{novelUrl}", novelUrl.trim().trimEnd('/'))
+
+/**
+ * From two chapter URLs of the SAME novel, derive a portable numeric pattern plus the two chapter
+ * numbers. The last digit run is treated as the chapter number (robust to a novel id earlier in the
+ * path). When [novelUrl] is supplied and prefixes the pattern, that prefix is replaced with the
+ * `{novelUrl}` placeholder so the pattern generalizes to other novels. Returns
+ * (pattern, firstNumber, lastNumber) or null when no numeric difference is found.
+ */
+internal fun deriveGenericChapterPattern(
+    chapterUrl1: String,
+    chapterUrl2: String,
+    baseUrl: String,
+    novelUrl: String?,
+): Triple<String, Int, Int>? {
+    if (chapterUrl1.isBlank() || chapterUrl2.isBlank()) return null
+    val rx = Regex("""\d+""")
+    val m1 = rx.findAll(chapterUrl1).lastOrNull() ?: return null
+    val m2 = rx.findAll(chapterUrl2).lastOrNull() ?: return null
+    val n1 = m1.value.toIntOrNull() ?: return null
+    val n2 = m2.value.toIntOrNull() ?: return null
+    if (n1 == n2) return null
+    val patternAbs = chapterUrl1.substring(0, m1.range.first) + "{n}" + chapterUrl1.substring(m1.range.last + 1)
+    val base = baseUrl.trim().trimEnd('/')
+    var pattern = if (patternAbs.startsWith(base)) patternAbs.removePrefix(base) else patternAbs
+    val novelRel = novelUrl?.trim()?.let { if (it.startsWith(base)) it.removePrefix(base) else it }
+        ?.trimEnd('/')
+    if (!novelRel.isNullOrBlank() && pattern.startsWith(novelRel)) {
+        pattern = "{novelUrl}" + pattern.removePrefix(novelRel)
+    }
+    return Triple(pattern, n1, n2)
+}
+
+/**
  * Builds the [start]..[end] generated chapter entries from a numeric URL [pattern]. URLs are kept
  * as the raw substituted template; callers normalize them against the base URL.
  */
@@ -449,7 +488,7 @@ class CustomNovelSource(
     override val supportsLatest: Boolean
         get() = config.latestUrl != null || baseSource?.supportsLatest == true
 
-    override val client = if (config.useCloudflare) network.cloudflareClient else network.client
+    override val client = network.cloudflareClient
 
     /**
      * When basedOnSourceId is set, we delegate all fetching/parsing to the base
@@ -581,7 +620,8 @@ class CustomNovelSource(
                     ?: start
             }
         }
-        val chapters = generatedChapterEntries(pattern, start, end, sel.nameTemplate).map { entry ->
+        val resolvedPattern = applyNovelUrlToPattern(pattern, manga.url)
+        val chapters = generatedChapterEntries(resolvedPattern, start, end, sel.nameTemplate).map { entry ->
             SChapter.create().apply {
                 // Normalize to a path relative to baseUrl (getPageList rebuilds the absolute URL).
                 url = buildAbsoluteUrl(entry.url).removePrefix(baseUrl.trimEnd('/')).ifBlank { entry.url }
@@ -734,20 +774,7 @@ class CustomNovelSource(
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
-        val selectors = config.selectors.chapters
-
-        // Check if we need to make an AJAX request for chapters
-        if (config.chapterAjax != null) {
-            val novelId = extractNovelId(document, response.request.url.toString())
-            if (novelId != null) {
-                val ajaxResponse = client.newCall(
-                    GET(config.chapterAjax!!.buildAjaxUrl(baseUrl, novelId), headers),
-                ).execute()
-                return ajaxResponse.use { parseChapterList(it.asJsoup(), selectors) }
-            }
-        }
-
-        return parseChapterList(document, selectors)
+        return parseChapterList(document, config.selectors.chapters)
     }
 
     fun chapterPageParse(response: Response): SChapter {
@@ -1036,35 +1063,11 @@ class CustomNovelSource(
         return 0L
     }
 
-    private fun extractNovelId(document: Document, url: String): String? {
-        // Try config-defined ID extraction
-        config.novelIdSelector?.let { selector ->
-            document.selectFirst(selector)?.let { element ->
-                config.novelIdAttr?.let { attr ->
-                    return element.attr(attr).ifBlank { null }
-                }
-                return element.text().trim().ifBlank { null }
-            }
-        }
-
-        // Fallback: extract from URL
-        config.novelIdPattern?.let { pattern ->
-            Regex(pattern).find(url)?.groupValues?.getOrNull(1)?.let { return it }
-        }
-
-        return null
-    }
-
     private fun String.buildUrl(baseUrl: String, page: Int): String =
         buildPagedUrlTemplate(this, baseUrl, page)
 
     private fun String.buildSearchUrl(baseUrl: String, query: String, page: Int): String =
         buildPagedSearchUrlTemplate(this, baseUrl, query, page)
-
-    private fun String.buildAjaxUrl(baseUrl: String, novelId: String): String {
-        return this.replace("{baseUrl}", baseUrl)
-            .replace("{novelId}", novelId)
-    }
 
     internal fun rebaseMangasPage(
         mangasPage: MangasPage,
@@ -1234,25 +1237,12 @@ class CustomNovelSource(
 
 // ======================== Configuration Data Classes ========================
 
-/**
- * Source type enum for different multisrc configurations
- */
-@Serializable
-enum class CustomSourceType {
-    GENERIC, // Generic CSS selector based
-    MADARA, // Madara WordPress theme (uses AJAX for chapters)
-    READNOVELFULL, // ReadNovelFull style sites
-    LIGHTNOVELWP, // LightNovelWP theme
-    READWN, // ReadWN style sites
-}
-
 @Serializable
 data class CustomSourceConfig(
     val name: String,
     val baseUrl: String,
     val language: String = "en",
     val id: Long? = null,
-    val sourceType: CustomSourceType = CustomSourceType.GENERIC,
     val popularUrl: String,
     val latestUrl: String? = null,
     val searchUrl: String,
@@ -1263,12 +1253,7 @@ data class CustomSourceConfig(
     val searchPagedUrl: String? = null,
     val headers: Map<String, String> = emptyMap(),
     val selectors: SourceSelectors,
-    val chapterAjax: String? = null,
-    val novelIdSelector: String? = null,
-    val novelIdAttr: String? = null,
-    val novelIdPattern: String? = null,
     val reverseChapters: Boolean = false,
-    val useCloudflare: Boolean = true,
     val postSearch: Boolean = false,
     val basedOnSourceId: Long? = null,
     val isNovel: Boolean = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -602,23 +602,22 @@ class CustomNovelSource(
         return getChapterList(manga)
     }
 
-    // Mode B: build the chapter list from a numeric URL pattern instead of scraping it. The range
-    // is [firstNumber..lastNumber]; lastNumber falls back to the total parsed from countSelector on
-    // the details page. One fetch at most (only when a count must be read).
+    // Mode B: build the chapter list from a numeric URL pattern instead of scraping it. start is the
+    // numbering base (constant for the site). The END is read PER NOVEL from countSelector on the
+    // details page so each novel loads its own length; lastNumber is only a fallback for the rare
+    // single-novel source with no count element. One fetch at most (only when a count must be read).
     private suspend fun generateChapterList(manga: SManga): List<SChapter> {
         val sel = config.selectors.chapters
         val pattern = sel.urlPattern ?: return emptyList()
         val start = sel.firstNumber ?: 1
-        val end = sel.lastNumber ?: run {
-            val countSel = sel.countSelector
-            if (countSel.isNullOrBlank()) {
-                start
-            } else {
-                val doc = client.newCall(GET(buildAbsoluteUrl(manga.url), headers)).awaitSuccess().asJsoup()
-                doc.selectFirst(countSel)?.text()
-                    ?.let { Regex("""\d+""").find(it.replace(",", ""))?.value?.toIntOrNull() }
-                    ?: start
-            }
+        val countSel = sel.countSelector
+        val end = if (!countSel.isNullOrBlank()) {
+            val doc = client.newCall(GET(buildAbsoluteUrl(manga.url), headers)).awaitSuccess().asJsoup()
+            doc.selectFirst(countSel)?.text()
+                ?.let { Regex("""\d+""").find(it.replace(",", ""))?.value?.toIntOrNull() }
+                ?: sel.lastNumber ?: start
+        } else {
+            sel.lastNumber ?: start
         }
         val resolvedPattern = applyNovelUrlToPattern(pattern, manga.url)
         val chapters = generatedChapterEntries(resolvedPattern, start, end, sel.nameTemplate).map { entry ->

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -581,7 +581,11 @@ class CustomNovelSource(
         if (isNovelSource && !chSel.urlPattern.isNullOrBlank()) {
             return generateChapterList(manga)
         }
-        if (isNovelSource && (!chSel.nextPage.isNullOrBlank() || !chSel.indexLinkSelector.isNullOrBlank())) {
+        if (isNovelSource && (
+                !chSel.nextPage.isNullOrBlank() || !chSel.indexLinkSelector.isNullOrBlank() ||
+                    !chSel.pagedUrlPattern.isNullOrBlank()
+                )
+        ) {
             return fetchResolvedChapterList(manga, null)
         }
         return super.getChapterList(manga)
@@ -596,7 +600,11 @@ class CustomNovelSource(
         if (isNovelSource && !chSel.urlPattern.isNullOrBlank()) {
             return generateChapterList(manga)
         }
-        if (isNovelSource && (!chSel.nextPage.isNullOrBlank() || !chSel.indexLinkSelector.isNullOrBlank())) {
+        if (isNovelSource && (
+                !chSel.nextPage.isNullOrBlank() || !chSel.indexLinkSelector.isNullOrBlank() ||
+                    !chSel.pagedUrlPattern.isNullOrBlank()
+                )
+        ) {
             return fetchResolvedChapterList(manga, context)
         }
         return getChapterList(manga)
@@ -633,15 +641,58 @@ class CustomNovelSource(
         return if (config.reverseChapters) chapters else chapters.reversed()
     }
 
-    // Resolves the chapter list across two optional dimensions:
+    // Resolves the chapter list across these optional dimensions:
     //  - indexLinkSelector: the chapter list lives on a separate page linked from the details page.
-    //  - nextPage: the chapter list spans multiple pages.
-    // Reversal is applied once at the end so multi-page lists keep a single consistent order.
+    //  - pagedUrlPattern: numbered pages reached by URL (e.g. "{novelUrl}?page={page}"). Preferred
+    //    over the next-button because it can't be fooled by an ambiguous prev/next selector.
+    //  - nextPage: fallback — follow the "next page" link.
+    // Chapters are de-duplicated by URL across pages (sites often repeat a "Newest" block on every
+    // page), and reversal is applied once at the end so multi-page lists keep one consistent order.
     private suspend fun fetchResolvedChapterList(
         manga: SManga,
         context: eu.kanade.tachiyomi.source.model.RefreshContext?,
     ): List<SChapter> {
         val selectors = config.selectors.chapters
+
+        // Skip walking the whole back-catalog when nothing is new: if the first page introduces no
+        // chapter the library doesn't already have (and this isn't a forced refresh), return the
+        // existing list as-is. The result replaces the stored list, so we must return the full set
+        // — hence we only short-circuit on the "no new chapters" case.
+        val knownUrls = context?.takeIf { !it.forceRefresh }
+            ?.existingChapters?.mapNotNull { it.url.ifBlank { null } }?.toSet().orEmpty()
+
+        val seen = mutableSetOf<String>()
+        val all = mutableListOf<SChapter>()
+        fun addNew(chapters: List<SChapter>): List<SChapter> {
+            val fresh = chapters.filter { seen.add(it.url) }
+            all += fresh
+            return fresh
+        }
+
+        // URL-pattern pagination: build page URLs directly instead of chasing a next link.
+        val pagePattern = selectors.pagedUrlPattern
+        if (!pagePattern.isNullOrBlank()) {
+            val resolved = applyNovelUrlToPattern(pagePattern, manga.url)
+            val visited = mutableSetOf<String>()
+            var page = 1
+            while (page <= MAX_CHAPTER_PAGES) {
+                val pageUrl = buildAbsoluteUrl(resolved.replace("{page}", page.toString()))
+                if (!visited.add(pageUrl)) break
+                val doc = client.newCall(GET(pageUrl, headers)).awaitSuccess().asJsoup()
+                val fresh = addNew(parseChapterElements(doc, selectors))
+                // First page with nothing new => no updates; keep the existing list.
+                if (page == 1 && knownUrls.isNotEmpty() && all.isNotEmpty() &&
+                    all.none { it.url !in knownUrls }
+                ) {
+                    return context!!.existingChapters
+                }
+                // A page that added no new chapters means we've run past the end.
+                if (fresh.isEmpty()) break
+                page++
+            }
+            return if (config.reverseChapters) all.reversed() else all
+        }
+
         val detailsUrl = buildAbsoluteUrl(manga.url)
         val detailsDoc = client.newCall(GET(detailsUrl, headers)).awaitSuccess().asJsoup()
 
@@ -652,17 +703,9 @@ class CustomNovelSource(
             detailsUrl
         }
 
-        // Skip walking the whole back-catalog when nothing is new: if the first page introduces no
-        // chapter the library doesn't already have (and this isn't a forced refresh), return the
-        // existing list as-is. The result replaces the stored list, so we must return the full set
-        // — hence we only short-circuit on the "no new chapters" case.
-        val knownUrls = context?.takeIf { !it.forceRefresh }
-            ?.existingChapters?.mapNotNull { it.url.ifBlank { null } }?.toSet().orEmpty()
-
-        val all = mutableListOf<SChapter>()
         if (url == null) {
             // Index link configured but missing on the page: fall back to the details doc.
-            all += parseChapterElements(detailsDoc, selectors)
+            addNew(parseChapterElements(detailsDoc, selectors))
         } else {
             val visited = mutableSetOf<String>()
             var guard = 0
@@ -670,12 +713,12 @@ class CustomNovelSource(
             while (url != null && guard++ < MAX_CHAPTER_PAGES && visited.add(url)) {
                 val doc = firstDoc ?: client.newCall(GET(url, headers)).awaitSuccess().asJsoup()
                 firstDoc = null
-                val pageChapters = parseChapterElements(doc, selectors)
-                all += pageChapters
+                val firstPage = guard == 1
+                addNew(parseChapterElements(doc, selectors))
 
                 // First page, all already known => no updates; stop and keep the existing list.
-                if (knownUrls.isNotEmpty() && all.size == pageChapters.size &&
-                    pageChapters.isNotEmpty() && pageChapters.none { it.url !in knownUrls }
+                if (firstPage && knownUrls.isNotEmpty() && all.isNotEmpty() &&
+                    all.none { it.url !in knownUrls }
                 ) {
                     return context!!.existingChapters
                 }
@@ -683,7 +726,7 @@ class CustomNovelSource(
                 val next = if (selectors.nextPage.isNullOrBlank()) {
                     null
                 } else {
-                    doc.selectFirst(selectors.nextPage)?.absUrl("href")?.ifBlank { null }
+                    resolveNextPageUrl(doc, selectors.nextPage, url, visited)
                 }
                 url = if (next == null || next == url) null else next
             }
@@ -795,6 +838,33 @@ class CustomNovelSource(
     private fun parseChapterList(document: Document, selectors: ChapterSelectors): List<SChapter> {
         val chapters = parseChapterElements(document, selectors)
         return if (config.reverseChapters) chapters.reversed() else chapters
+    }
+
+    // Picks the real "next page" link when [selector] is ambiguous (e.g. a shared ".btn-page" class
+    // on both « Prev and Next »). selectFirst would grab Prev and bounce back to an already-visited
+    // page, capping the walk at 2 pages. Skip prev links and pages we've seen; prefer explicit
+    // next markers (rel=next, "next"/»/›/→ in text or class).
+    private fun resolveNextPageUrl(
+        document: Document,
+        selector: String,
+        currentUrl: String?,
+        visited: Set<String>,
+    ): String? {
+        var fallback: String? = null
+        for (el in document.select(selector)) {
+            val href = el.absUrl("href").ifBlank { null } ?: continue
+            if (href == currentUrl || href in visited) continue
+            val text = el.text().trim().lowercase()
+            val rel = el.attr("rel").lowercase()
+            val cls = el.className().lowercase()
+            val isPrev = rel == "prev" || rel == "previous" || "prev" in text || "previous" in text ||
+                "prev" in cls || "«" in text || "‹" in text
+            val isNext = rel == "next" || "next" in text || "next" in cls ||
+                "»" in text || "›" in text || "→" in text
+            if (isNext && !isPrev) return href
+            if (!isPrev && fallback == null) fallback = href
+        }
+        return fallback
     }
 
     // Parses a single chapter-list page without applying reversal (callers reverse once).
@@ -1068,57 +1138,25 @@ class CustomNovelSource(
     private fun String.buildSearchUrl(baseUrl: String, query: String, page: Int): String =
         buildPagedSearchUrlTemplate(this, baseUrl, query, page)
 
+    // These delegate to the top-level rebaseCustomSource* helpers (same logic, unit-tested there),
+    // resolving customBase = this source's baseUrl and sourceBase = the delegated source URL.
     internal fun rebaseMangasPage(
         mangasPage: MangasPage,
         sourceBaseUrlOverride: String? = null,
-    ): MangasPage {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        return MangasPage(mangasPage.mangas.map { rebaseManga(it, override) }, mangasPage.hasNextPage)
-    }
+    ): MangasPage =
+        rebaseCustomSourceMangasPage(mangasPage, baseUrl, sourceBaseUrlOverride ?: effectiveRebaseUrl)
 
-    internal fun rebaseManga(manga: SManga, sourceBaseUrlOverride: String? = null): SManga {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        return safeCopyManga(manga).apply {
-            val originalUrl = runCatching { manga.url }.getOrNull()
-            url = rebaseUrl(originalUrl, override) ?: (originalUrl ?: "")
-            val originalThumb = runCatching { manga.thumbnail_url }.getOrNull()
-            thumbnail_url = rebaseUrl(originalThumb, override) ?: originalThumb
-        }
-    }
+    internal fun rebaseManga(manga: SManga, sourceBaseUrlOverride: String? = null): SManga =
+        rebaseCustomSourceManga(manga, baseUrl, sourceBaseUrlOverride ?: effectiveRebaseUrl)
 
-    internal fun rebaseChapter(chapter: SChapter, sourceBaseUrlOverride: String? = null): SChapter {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        return SChapter.create().also { rebased ->
-            rebased.copyFrom(chapter)
-            rebased.url = rebaseUrl(chapter.url, override) ?: chapter.url
-        }
-    }
+    internal fun rebaseChapter(chapter: SChapter, sourceBaseUrlOverride: String? = null): SChapter =
+        rebaseCustomSourceChapter(chapter, baseUrl, sourceBaseUrlOverride ?: effectiveRebaseUrl)
 
-    internal fun rebasePage(page: Page, sourceBaseUrlOverride: String? = null): Page {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        return Page(page.index, rebaseUrl(page.url, override).orEmpty(), page.imageUrl, page.uri).also {
-            it.text = page.text
-        }
-    }
+    internal fun rebasePage(page: Page, sourceBaseUrlOverride: String? = null): Page =
+        rebaseCustomSourcePage(page, baseUrl, sourceBaseUrlOverride ?: effectiveRebaseUrl)
 
-    internal fun rebaseUrl(url: String?, sourceBaseUrlOverride: String? = null): String? {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        val value = normalizeCustomUrl(url).orEmpty()
-        if (value.isBlank()) return url
-
-        val customBase = baseUrl.trimEnd('/')
-        val sourceBase = override
-
-        if (sourceBase != null && value.startsWith(sourceBase)) {
-            return customBase + value.removePrefix(sourceBase)
-        }
-
-        if (value.startsWith("http://") || value.startsWith("https://")) {
-            return value
-        }
-
-        return customBase + "/" + value.removePrefix("/")
-    }
+    internal fun rebaseUrl(url: String?, sourceBaseUrlOverride: String? = null): String? =
+        rebaseCustomSourceUrl(url, baseUrl, sourceBaseUrlOverride ?: effectiveRebaseUrl)
 
     internal fun toBaseSourceUrl(url: String?, sourceBaseUrlOverride: String? = null): String? {
         val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
@@ -1159,13 +1197,6 @@ class CustomNovelSource(
         return SChapter.create().also { sourceChapter ->
             sourceChapter.copyFrom(chapter)
             sourceChapter.url = toBaseSourceUrl(chapter.url, override) ?: chapter.url
-        }
-    }
-
-    private fun toBaseSourcePage(page: Page, sourceBaseUrlOverride: String? = null): Page {
-        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
-        return Page(page.index, toBaseSourceUrl(page.url, override).orEmpty(), page.imageUrl, page.uri).also {
-            it.text = page.text
         }
     }
 
@@ -1310,6 +1341,10 @@ data class ChapterSelectors(
     // Optional selector, on the DETAILS page, pointing to a separate chapter-list/index page.
     // When set, chapters are read from the linked page instead of the details page.
     val indexLinkSelector: String? = null,
+    // Optional numbered-pagination URL template for the chapter list, e.g. "{novelUrl}?page={page}".
+    // {novelUrl} is replaced with the current novel path. Preferred over nextPage (it can't be
+    // fooled by a shared prev/next selector); pages are walked until one adds no new chapters.
+    val pagedUrlPattern: String? = null,
     // ---- Generated chapter list (mode B): build chapter URLs from a numeric pattern instead of
     // scraping the list. Used for sites with sequential URLs like /novel/chapter-{n}. ----
     // Chapter URL template with {n} for the chapter number, e.g. "/novel/abc/chapter-{n}".

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -61,19 +61,11 @@ class CustomSourceManager(
      */
     fun createSource(config: CustomSourceConfig): Result<CustomNovelSource> {
         return try {
-            // Validate config
             val normalizedConfig = config.withStableId()
             validateConfig(normalizedConfig)
-
-            // Create source
             val source = CustomNovelSource(normalizedConfig)
-
-            // Save to disk
             saveSourceConfig(normalizedConfig)
-
-            // Add to list
             _customSources.update { it + source }
-
             Result.success(source)
         } catch (e: Exception) {
             Result.failure(e)
@@ -87,11 +79,7 @@ class CustomSourceManager(
         return try {
             val normalizedConfig = newConfig.withStableId(oldId)
             validateConfig(normalizedConfig)
-
-            // Remove old source
             deleteSource(oldId)
-
-            // Create new source
             createSource(normalizedConfig)
         } catch (e: Exception) {
             Result.failure(e)
@@ -107,7 +95,7 @@ class CustomSourceManager(
         // Remove from list
         _customSources.update { it.filter { s -> s.id != sourceId } }
 
-        // Delete both the stable id file and the legacy name-based file.
+        // Delete both the stable-id file and the legacy name-based file.
         val filesToDelete = customSourceStorageFileCandidates(customSourcesDir, source.id, source.name)
         return filesToDelete.any { it.delete() }
     }
@@ -141,15 +129,10 @@ class CustomSourceManager(
 
     private fun friendlyParseError(e: Throwable): String = customSourceFriendlyParseError(e)
 
-    /**
-     * A documented, hand-editable skeleton config. Placeholder selectors show the expected shape.
-     */
+    /** Hand-editable skeleton config; placeholder selectors show the expected shape. */
     fun blankTemplateJson(): String = json.encodeToString(customSourceBlankTemplate())
 
-    /**
-     * Create a blank config with the given name and base URL.
-     * Templates have been removed — use extension repos for pre-built themes.
-     */
+    /** Blank config with the given name and base URL. */
     fun createBlankConfig(name: String, baseUrl: String): CustomSourceConfig {
         return CustomSourceConfig(
             name = name,
@@ -166,9 +149,8 @@ class CustomSourceManager(
     }
 
     /**
-     * Validate a source configuration. Throws [IllegalArgumentException] with joined, field-level
-     * messages when invalid. Delegates the field rules to [customSourceValidationErrors] so they can
-     * be unit-tested without a [Context].
+     * Throws [IllegalArgumentException] with joined field-level messages when invalid. Rules live in
+     * [customSourceValidationErrors] so they can be unit-tested without a [Context].
      */
     fun validateConfig(config: CustomSourceConfig): List<String> {
         val errors = customSourceValidationErrors(config, _customSources.value.map { it.config })
@@ -179,10 +161,8 @@ class CustomSourceManager(
     }
 
     /**
-     * Test a source configuration by making actual requests. [section] scopes the test so the
-     * wizard can validate one part at a time (after each step) instead of only at the very end;
-     * [SourceTestSection.ALL] runs every endpoint. Always runs off the main thread so the WebView
-     * wizard never triggers NetworkOnMainThreadException.
+     * Test a config with real requests. [section] scopes the test to one part so the wizard can
+     * validate per-step; [SourceTestSection.ALL] runs every endpoint. Off-main-thread.
      */
     suspend fun testSource(
         config: CustomSourceConfig,
@@ -433,12 +413,9 @@ class CustomSourceManager(
 }
 
 /**
- * Pure, feature-aware validation of a custom source config. Returns the list of human-readable
- * errors (empty when valid). Unlike the old rules, this only requires what the config actually uses:
- *  - At least one listing URL (popular / latest / search) must be present.
- *  - A listing's list selector is only required when that listing's URL is set.
- *  - Chapters need either a list selector OR a generated URL pattern.
- * [existing] is the set of already-saved configs, used for duplicate name / base URL detection.
+ * Validates only what the config actually uses: one listing URL (popular/latest/search), each
+ * listing's list selector only when its URL is set, and chapters via a list selector OR a generated
+ * URL pattern. [existing] is checked for duplicate name / base URL.
  */
 internal fun customSourceValidationErrors(
     config: CustomSourceConfig,

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -155,44 +155,7 @@ class CustomSourceManager(
     /**
      * A documented, hand-editable skeleton config. Placeholder selectors show the expected shape.
      */
-    fun blankTemplateJson(): String {
-        val template = CustomSourceConfig(
-            name = "My Source",
-            baseUrl = "https://example.com",
-            language = "en",
-            popularUrl = "https://example.com/page/{page}",
-            latestUrl = "https://example.com/latest/page/{page}",
-            searchUrl = "https://example.com/?s={query}",
-            selectors = SourceSelectors(
-                popular = MangaListSelectors(
-                    list = ".novel-item",
-                    link = "a",
-                    title = ".novel-title",
-                    cover = "img",
-                    nextPage = ".pagination .next",
-                ),
-                details = DetailSelectors(
-                    title = "h1.title",
-                    author = ".author a",
-                    description = ".description",
-                    genre = ".genre a",
-                    status = ".status",
-                    cover = ".cover img",
-                ),
-                chapters = ChapterSelectors(
-                    list = ".chapter-list li",
-                    link = "a",
-                    name = "a",
-                    date = ".date",
-                ),
-                content = ContentSelectors(
-                    primary = ".chapter-content",
-                ),
-            ),
-            reverseChapters = false,
-        )
-        return json.encodeToString(template)
-    }
+    fun blankTemplateJson(): String = json.encodeToString(customSourceBlankTemplate())
 
     /**
      * Create a blank config with the given name and base URL.
@@ -214,65 +177,15 @@ class CustomSourceManager(
     }
 
     /**
-     * Validate a source configuration
+     * Validate a source configuration. Throws [IllegalArgumentException] with joined, field-level
+     * messages when invalid. Delegates the field rules to [customSourceValidationErrors] so they can
+     * be unit-tested without a [Context].
      */
     fun validateConfig(config: CustomSourceConfig): List<String> {
-        val errors = mutableListOf<String>()
-
-        if (config.name.isBlank()) {
-            errors.add("Name is required")
-        }
-
-        if (config.baseUrl.isBlank()) {
-            errors.add("Base URL is required")
-        } else if (!config.baseUrl.startsWith("http://") && !config.baseUrl.startsWith("https://")) {
-            errors.add("Base URL must start with http:// or https://")
-        }
-
-        // Skip URL and selector validation when based on an extension
-        if (config.basedOnSourceId == null) {
-            if (config.popularUrl.isBlank()) {
-                errors.add("Popular URL is required")
-            }
-
-            if (config.searchUrl.isBlank()) {
-                errors.add("Search URL is required")
-            }
-
-            if (config.selectors.popular.list.isBlank()) {
-                errors.add("Popular list selector is required")
-            }
-
-            if (config.selectors.details.title.isBlank()) {
-                errors.add("Details title selector is required")
-            }
-
-            if (config.selectors.chapters.list.isBlank()) {
-                errors.add("Chapters list selector is required")
-            }
-
-            if (config.selectors.content.primary.isBlank()) {
-                errors.add("Content primary selector is required")
-            }
-        }
-
-        // Check for duplicate name
-        if (_customSources.value.any { it.name == config.name && it.id != config.id }) {
-            errors.add("A source with this name already exists")
-        }
-        val normalizedBase = config.baseUrl.trim().trimEnd('/').lowercase()
-        if (normalizedBase.isNotBlank() &&
-            _customSources.value.any {
-                it.id != config.id && it.config.baseUrl.trim().trimEnd('/').lowercase() == normalizedBase
-            }
-        ) {
-            errors.add("A source with this base URL already exists")
-        }
-
+        val errors = customSourceValidationErrors(config, _customSources.value.map { it.config })
         if (errors.isNotEmpty()) {
             throw IllegalArgumentException(errors.joinToString("; "))
         }
-
         return errors
     }
 
@@ -602,6 +515,119 @@ class CustomSourceManager(
         }
     }
 }
+
+/**
+ * Pure, feature-aware validation of a custom source config. Returns the list of human-readable
+ * errors (empty when valid). Unlike the old rules, this only requires what the config actually uses:
+ *  - At least one listing URL (popular / latest / search) must be present.
+ *  - A listing's list selector is only required when that listing's URL is set.
+ *  - Chapters need either a list selector OR a generated URL pattern.
+ * [existing] is the set of already-saved configs, used for duplicate name / base URL detection.
+ */
+internal fun customSourceValidationErrors(
+    config: CustomSourceConfig,
+    existing: List<CustomSourceConfig> = emptyList(),
+): List<String> {
+    val errors = mutableListOf<String>()
+
+    if (config.name.isBlank()) {
+        errors.add("Name is required")
+    }
+
+    if (config.baseUrl.isBlank()) {
+        errors.add("Base URL is required")
+    } else if (!config.baseUrl.startsWith("http://") && !config.baseUrl.startsWith("https://")) {
+        errors.add("Base URL must start with http:// or https://")
+    }
+
+    // Skip URL and selector validation when delegating to an installed extension.
+    if (config.basedOnSourceId == null) {
+        val hasPopular = config.popularUrl.isNotBlank()
+        val hasLatest = !config.latestUrl.isNullOrBlank()
+        val hasSearch = config.searchUrl.isNotBlank()
+        if (!hasPopular && !hasLatest && !hasSearch) {
+            errors.add("At least one listing URL (popular, latest or search) is required")
+        }
+
+        // A listing's list selector is only needed if that listing is enabled. Latest and search
+        // fall back to the popular list selector, so the popular list selector covers them.
+        if (hasPopular && config.selectors.popular.list.isBlank()) {
+            errors.add("Popular list selector is required")
+        }
+        if (!hasPopular && (hasLatest || hasSearch) &&
+            config.selectors.popular.list.isBlank() &&
+            config.selectors.latest?.list.isNullOrBlank() &&
+            config.selectors.search?.list.isNullOrBlank()
+        ) {
+            errors.add("A list selector is required for the latest/search listing")
+        }
+
+        if (config.selectors.details.title.isBlank()) {
+            errors.add("Details title selector is required")
+        }
+
+        val hasChapterList = config.selectors.chapters.list.isNotBlank()
+        val hasChapterPattern = !config.selectors.chapters.urlPattern.isNullOrBlank()
+        if (!hasChapterList && !hasChapterPattern) {
+            errors.add("A chapter list selector or chapter URL pattern is required")
+        }
+
+        if (config.selectors.content.primary.isBlank()) {
+            errors.add("Content primary selector is required")
+        }
+    }
+
+    if (existing.any { it.name == config.name && it.id != config.id }) {
+        errors.add("A source with this name already exists")
+    }
+    val normalizedBase = config.baseUrl.trim().trimEnd('/').lowercase()
+    if (normalizedBase.isNotBlank() &&
+        existing.any {
+            it.id != config.id && it.baseUrl.trim().trimEnd('/').lowercase() == normalizedBase
+        }
+    ) {
+        errors.add("A source with this base URL already exists")
+    }
+
+    return errors
+}
+
+/** Documented skeleton config used by the import dialog's "paste template" action. */
+internal fun customSourceBlankTemplate(): CustomSourceConfig = CustomSourceConfig(
+    name = "My Source",
+    baseUrl = "https://example.com",
+    language = "en",
+    popularUrl = "https://example.com/page/{page}",
+    latestUrl = "https://example.com/latest/page/{page}",
+    searchUrl = "https://example.com/?s={query}",
+    selectors = SourceSelectors(
+        popular = MangaListSelectors(
+            list = ".novel-item",
+            link = "a",
+            title = ".novel-title",
+            cover = "img",
+            nextPage = ".pagination .next",
+        ),
+        details = DetailSelectors(
+            title = "h1.title",
+            author = ".author a",
+            description = ".description",
+            genre = ".genre a",
+            status = ".status",
+            cover = ".cover img",
+        ),
+        chapters = ChapterSelectors(
+            list = ".chapter-list li",
+            link = "a",
+            name = "a",
+            date = ".date",
+        ),
+        content = ContentSelectors(
+            primary = ".chapter-content",
+        ),
+    ),
+    reverseChapters = false,
+)
 
 /** Scopes [CustomSourceManager.testSource] so each wizard step can validate just its own section. */
 enum class SourceTestSection { POPULAR, LATEST, SEARCH, READING, ALL }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.source.custom
 
 import android.content.Context
-import eu.kanade.tachiyomi.source.CatalogueSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,13 +14,8 @@ import tachiyomi.core.common.util.system.logcat
 import java.io.File
 
 /**
- * Manager for custom user-defined novel sources
- *
- * Handles:
- * - Loading/saving custom source configurations
- * - Creating CustomNovelSource instances from configs
- * - Validating source configurations
- * - Providing templates for common site structures
+ * Manager for custom user-defined novel sources: loads/saves configs, creates [CustomNovelSource]
+ * instances, validates and tests configurations.
  */
 class CustomSourceManager(
     private val context: Context,
@@ -61,11 +55,6 @@ class CustomSourceManager(
 
         _customSources.value = sources
     }
-
-    /**
-     * Get all custom sources as CatalogueSource list
-     */
-    fun getSources(): List<CatalogueSource> = _customSources.value
 
     /**
      * Create a new custom source from configuration
@@ -206,45 +195,17 @@ class CustomSourceManager(
 
         val all = section == SourceTestSection.ALL
 
-        // Verifies listing pagination by fetching page 2 when the listing reports a next page.
-        // Returns null when there's no page 2 to test; otherwise (ok, human-readable note).
-        suspend fun verifyPage2(
-            hasNextPage: Boolean,
-            fetch: suspend () -> eu.kanade.tachiyomi.source.model.MangasPage,
-        ): Pair<Boolean, String>? {
-            if (!hasNextPage) return null
-            return try {
-                val p2 = fetch()
-                if (p2.mangas.isNotEmpty()) {
-                    true to "Page 2: ${p2.mangas.size} found"
-                } else {
-                    false to "Page 2 returned nothing"
-                }
-            } catch (e: Exception) {
-                false to "Page 2 error: ${e.message}"
-            }
-        }
-
         // Popular
         if (all || section == SourceTestSection.POPULAR) {
             try {
                 val popular = source.getPopularManga(1)
                 val success = popular.mangas.isNotEmpty()
-                val page2 = if (success) verifyPage2(popular.hasNextPage) { source.getPopularManga(2) } else null
                 results["popular"] = TestStepResult(
-                    success = success && (page2?.first ?: true),
-                    message = buildString {
-                        append(
-                            if (success) {
-                                "Found ${popular.mangas.size} novels"
-                            } else {
-                                "No novels found (URL may need adjustment - some sites have novels on homepage without page param)"
-                            },
-                        )
-                        page2?.let {
-                            append(" · ")
-                            append(it.second)
-                        }
+                    success = success,
+                    message = if (success) {
+                        "Found ${popular.mangas.size} novels"
+                    } else {
+                        "No novels found (URL may need adjustment - some sites have novels on homepage without page param)"
                     },
                     data = buildMap {
                         popular.mangas.firstOrNull()?.let {
@@ -252,7 +213,6 @@ class CustomSourceManager(
                             put("First URL", it.url)
                             put("First Cover", it.thumbnail_url ?: "None")
                         }
-                        page2?.let { put("Page 2", it.second) }
                     }.ifEmpty { null },
                 )
                 if (success && testManga == null) {
@@ -269,22 +229,14 @@ class CustomSourceManager(
             try {
                 val latest = source.getLatestUpdates(1)
                 val success = latest.mangas.isNotEmpty()
-                val page2 = if (success) verifyPage2(latest.hasNextPage) { source.getLatestUpdates(2) } else null
                 results["latest"] = TestStepResult(
-                    success = success && (page2?.first ?: true),
-                    message = buildString {
-                        append(if (success) "Found ${latest.mangas.size} novels" else "No novels found")
-                        page2?.let {
-                            append(" · ")
-                            append(it.second)
-                        }
-                    },
+                    success = success,
+                    message = if (success) "Found ${latest.mangas.size} novels" else "No novels found",
                     data = buildMap {
                         latest.mangas.firstOrNull()?.let {
                             put("First Title", it.title)
                             put("First URL", it.url)
                         }
-                        page2?.let { put("Page 2", it.second) }
                     }.ifEmpty { null },
                 )
                 if (success && testManga == null) {
@@ -302,33 +254,17 @@ class CustomSourceManager(
                 val searchQuery = config.testSearchQuery?.ifBlank { null } ?: DEFAULT_TEST_QUERY
                 val search = source.getSearchManga(1, searchQuery, eu.kanade.tachiyomi.source.model.FilterList())
                 val success = search.mangas.isNotEmpty()
-                val page2 = if (success) {
-                    verifyPage2(search.hasNextPage) {
-                        source.getSearchManga(2, searchQuery, eu.kanade.tachiyomi.source.model.FilterList())
-                    }
-                } else {
-                    null
-                }
                 results["search"] = TestStepResult(
-                    success = success && (page2?.first ?: true),
-                    message = buildString {
-                        append(
-                            if (success) {
-                                "Found ${search.mangas.size} results for '$searchQuery'"
-                            } else {
-                                "No results found for '$searchQuery'"
-                            },
-                        )
-                        page2?.let {
-                            append(" · ")
-                            append(it.second)
-                        }
+                    success = success,
+                    message = if (success) {
+                        "Found ${search.mangas.size} results for '$searchQuery'"
+                    } else {
+                        "No results found for '$searchQuery'"
                     },
                     data = buildMap {
                         search.mangas.take(3).forEachIndexed { index, manga ->
                             put("Result ${index + 1}", manga.title)
                         }
-                        page2?.let { put("Page 2", it.second) }
                     }.ifEmpty { null },
                 )
                 if (success && testManga == null) {
@@ -472,26 +408,6 @@ class CustomSourceManager(
                     }
                 } catch (e: Exception) {
                     results["content"] = TestStepResult(success = false, message = "Error: ${e.message}")
-                }
-
-                // "Page 2" of reading: confirm a second chapter's content also resolves.
-                if (chapters.size > 1) {
-                    try {
-                        val secondChapter = chapters[chapters.size - 2]
-                        val pages2 = source.getPageList(secondChapter)
-                        val content2 = pages2.firstOrNull()?.let { source.fetchPageText(it) }.orEmpty()
-                        results["content_page2"] = TestStepResult(
-                            success = content2.isNotBlank(),
-                            message = if (content2.isNotBlank()) {
-                                "Second chapter content: ${content2.length} chars"
-                            } else {
-                                "Second chapter returned empty content"
-                            },
-                            data = mapOf("Chapter" to secondChapter.name),
-                        )
-                    } catch (e: Exception) {
-                        results["content_page2"] = TestStepResult(success = false, message = "Error: ${e.message}")
-                    }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -142,7 +142,6 @@ class CustomSourcesScreen : Screen {
                         }
                     },
                     actions = {
-                        // Import button
                         IconButton(onClick = {
                             importJsonText = ""
                             importError = null
@@ -256,7 +255,6 @@ class CustomSourcesScreen : Screen {
             }
         }
 
-        // Create dialog
         if (showCreateDialog) {
             CreateSourceDialog(
                 onDismiss = { showCreateDialog = false },
@@ -289,7 +287,6 @@ class CustomSourcesScreen : Screen {
             )
         }
 
-        // Import dialog (paste / from file / copy template, with inline validation errors)
         if (showImportDialog) {
             ImportSourceDialog(
                 jsonText = importJsonText,
@@ -322,7 +319,6 @@ class CustomSourcesScreen : Screen {
             )
         }
 
-        // Delete confirmation
         sourceToDelete?.let { id ->
             AlertDialog(
                 onDismissRequest = { sourceToDelete = null },
@@ -567,7 +563,6 @@ private fun CreateSourceDialog(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                // WebView selector option
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -592,7 +587,6 @@ private fun CreateSourceDialog(
                     }
                 }
 
-                // Base on Extension option
                 Spacer(modifier = Modifier.height(4.dp))
                 Button(
                     onClick = { showExtensionPicker = true },
@@ -607,7 +601,6 @@ private fun CreateSourceDialog(
                     modifier = Modifier.padding(top = 4.dp),
                 )
 
-                // Hint about extension repos for pre-built themes
                 if (!useWebView) {
                     Text(
                         text = stringResource(TDMR.strings.custom_source_use_repos_hint),
@@ -646,7 +639,6 @@ private fun CreateSourceDialog(
         },
     )
 
-    // Extension picker dialog
     if (showExtensionPicker) {
         BaseSourcePickerDialog(
             selectedSourceId = null,
@@ -1037,7 +1029,6 @@ class CustomSourceEditorScreen(
                     .padding(16.dp)
                     .verticalScroll(rememberScrollState()),
             ) {
-                // Basic Info Section
                 Text(
                     text = stringResource(TDMR.strings.custom_source_basic_info),
                     style = MaterialTheme.typography.titleMedium,
@@ -1114,7 +1105,6 @@ class CustomSourceEditorScreen(
                     }
                 }
 
-                // Source Options Section
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = stringResource(TDMR.strings.custom_source_options),
@@ -1123,7 +1113,6 @@ class CustomSourceEditorScreen(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
 
-                // Reverse chapters option
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1148,7 +1137,6 @@ class CustomSourceEditorScreen(
                     }
                 }
 
-                // POST search option
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1173,7 +1161,6 @@ class CustomSourceEditorScreen(
                     }
                 }
 
-                // Novel source type option
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -1277,7 +1264,6 @@ class CustomSourceEditorScreen(
                     }
                 }
 
-                // URLs Section (only for manual/selector-based sources)
                 if (selectedBasedOnSourceId == null && isNovel) {
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
@@ -1321,7 +1307,6 @@ class CustomSourceEditorScreen(
                         )
                     }
 
-                    // Selectors Section
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
                         text = stringResource(TDMR.strings.custom_source_css_selectors),
@@ -1330,7 +1315,6 @@ class CustomSourceEditorScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    // Popular/List selectors
                     Text(stringResource(TDMR.strings.custom_source_novel_list), fontWeight = FontWeight.Medium)
                     OutlinedTextField(
                         value = popularListSelector,
@@ -1424,7 +1408,6 @@ class CustomSourceEditorScreen(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    // Details selectors
                     Text(stringResource(TDMR.strings.custom_source_novel_details), fontWeight = FontWeight.Medium)
                     OutlinedTextField(
                         value = detailsTitleSelector,
@@ -1523,7 +1506,6 @@ class CustomSourceEditorScreen(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    // Chapter selectors
                     Text(stringResource(TDMR.strings.custom_source_chapters), fontWeight = FontWeight.Medium)
                     if (features.chapterGenerateFromPattern) {
                         // Generated chapter list (mode B): numeric URL pattern + range/count.
@@ -1674,7 +1656,6 @@ class CustomSourceEditorScreen(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    // Content selector
                     Text(stringResource(TDMR.strings.custom_source_chapter_content), fontWeight = FontWeight.Medium)
                     OutlinedTextField(
                         value = contentPrimarySelector,
@@ -1757,7 +1738,6 @@ class CustomSourceEditorScreen(
                     )
                 } // end if (selectedBasedOnSourceId == null)
 
-                // Error message
                 errorMessage?.let {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
@@ -1767,7 +1747,6 @@ class CustomSourceEditorScreen(
                     )
                 }
 
-                // Save button
                 Spacer(modifier = Modifier.height(24.dp))
                 @Suppress("ktlint:standard:max-line-length")
                 Button(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1535,23 +1535,29 @@ class CustomSourceEditorScreen(
                     OutlinedTextField(
                         value = detailsArtistSelector,
                         onValueChange = { detailsArtistSelector = it },
-                        label = { Text("Artist selector") },
-                        trailingIcon = pickTrailing(baseUrl, "Artist selector") { detailsArtistSelector = it },
+                        label = { Text(stringResource(TDMR.strings.custom_source_artist_selector)) },
+                        trailingIcon = pickTrailing(
+                            baseUrl,
+                            stringResource(TDMR.strings.custom_source_artist_selector),
+                        ) { detailsArtistSelector = it },
                         modifier = Modifier.fillMaxWidth(),
                     )
                     OutlinedTextField(
                         value = detailsStatusSelector,
                         onValueChange = { detailsStatusSelector = it },
-                        label = { Text("Status selector") },
-                        trailingIcon = pickTrailing(baseUrl, "Status selector") { detailsStatusSelector = it },
+                        label = { Text(stringResource(TDMR.strings.custom_source_status_selector)) },
+                        trailingIcon = pickTrailing(
+                            baseUrl,
+                            stringResource(TDMR.strings.custom_source_status_selector),
+                        ) { detailsStatusSelector = it },
                         modifier = Modifier.fillMaxWidth(),
                     )
                     OutlinedTextField(
                         value = statusMappingText,
                         onValueChange = { statusMappingText = it },
-                        label = { Text("Status mapping (word=ongoing, word=completed)") },
+                        label = { Text(stringResource(TDMR.strings.custom_source_status_mapping)) },
                         supportingText = {
-                            Text("Optional. Map this site's status words to ongoing/completed/hiatus/cancelled.")
+                            Text(stringResource(TDMR.strings.custom_source_status_mapping_desc))
                         },
                         modifier = Modifier.fillMaxWidth(),
                     )
@@ -1567,7 +1573,10 @@ class CustomSourceEditorScreen(
                             onValueChange = { chapterUrlPattern = it },
                             label = { Text(stringResource(TDMR.strings.custom_source_chapter_url_pattern)) },
                             modifier = Modifier.fillMaxWidth(),
-                            placeholder = { Text("/novel/abc/chapter-{n}") },
+                            placeholder = { Text("{novelUrl}/chapter-{n}") },
+                            supportingText = {
+                                Text(stringResource(TDMR.strings.custom_source_chapter_url_pattern_desc))
+                            },
                         )
                         OutlinedTextField(
                             value = chapterCountSelector,
@@ -1601,14 +1610,12 @@ class CustomSourceEditorScreen(
                         OutlinedTextField(
                             value = chapterNameTemplate,
                             onValueChange = { chapterNameTemplate = it },
-                            label = { Text("Chapter name template") },
+                            label = { Text(stringResource(TDMR.strings.custom_source_chapter_name_template)) },
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
                             placeholder = { Text("Chapter {n}") },
                             supportingText = {
-                                Text(
-                                    "Use {n} for the chapter number. Use {novelUrl} in the URL pattern for portability.",
-                                )
+                                Text(stringResource(TDMR.strings.custom_source_chapter_name_template_desc))
                             },
                         )
                     } else {
@@ -1731,51 +1738,54 @@ class CustomSourceEditorScreen(
                     OutlinedTextField(
                         value = contentRemoveSelectors,
                         onValueChange = { contentRemoveSelectors = it },
-                        label = { Text("Remove selectors") },
-                        trailingIcon = pickTrailing(baseUrl, "Remove selectors") { contentRemoveSelectors = it },
+                        label = { Text(stringResource(TDMR.strings.custom_source_remove_selectors)) },
+                        trailingIcon = pickTrailing(
+                            baseUrl,
+                            stringResource(TDMR.strings.custom_source_remove_selectors),
+                        ) { contentRemoveSelectors = it },
                         modifier = Modifier.fillMaxWidth(),
                         supportingText = {
-                            Text("Comma-separated selectors stripped from the content before display.")
+                            Text(stringResource(TDMR.strings.custom_source_remove_selectors_desc))
                         },
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
-                        text = "Advanced",
+                        text = stringResource(TDMR.strings.custom_source_advanced),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                     )
                     OutlinedTextField(
                         value = dateFormat,
                         onValueChange = { dateFormat = it },
-                        label = { Text("Chapter date format") },
+                        label = { Text(stringResource(TDMR.strings.custom_source_date_format)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         placeholder = { Text("yyyy-MM-dd") },
-                        supportingText = { Text("Optional. Needed for worded dates; uses the site's locale pattern.") },
+                        supportingText = { Text(stringResource(TDMR.strings.custom_source_date_format_desc)) },
                     )
                     OutlinedTextField(
                         value = headersText,
                         onValueChange = { headersText = it },
-                        label = { Text("Custom headers") },
+                        label = { Text(stringResource(TDMR.strings.custom_source_headers)) },
                         modifier = Modifier.fillMaxWidth(),
-                        supportingText = { Text("One per line, e.g. Referer: https://example.com") },
+                        supportingText = { Text(stringResource(TDMR.strings.custom_source_headers_desc)) },
                     )
                     OutlinedTextField(
                         value = testSearchQuery,
                         onValueChange = { testSearchQuery = it },
-                        label = { Text("Test search query") },
+                        label = { Text(stringResource(TDMR.strings.custom_source_test_search_query)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
-                        supportingText = { Text("Optional. Query used when testing this source.") },
+                        supportingText = { Text(stringResource(TDMR.strings.custom_source_test_search_query_desc)) },
                     )
                     OutlinedTextField(
                         value = sampleNovelUrl,
                         onValueChange = { sampleNovelUrl = it },
-                        label = { Text("Sample novel URL") },
+                        label = { Text(stringResource(TDMR.strings.custom_source_sample_novel_url)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
-                        supportingText = { Text("Optional. Lets the reading test open a known novel directly.") },
+                        supportingText = { Text(stringResource(TDMR.strings.custom_source_sample_novel_url_desc)) },
                     )
                 } // end if (selectedBasedOnSourceId == null)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1590,6 +1590,9 @@ class CustomSourceEditorScreen(
                                     it
                             },
                             modifier = Modifier.fillMaxWidth(),
+                            supportingText = {
+                                Text(stringResource(TDMR.strings.custom_source_chapter_count_selector_desc))
+                            },
                         )
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             OutlinedTextField(
@@ -1598,6 +1601,9 @@ class CustomSourceEditorScreen(
                                 label = { Text(stringResource(TDMR.strings.custom_source_chapter_first_number)) },
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
+                                supportingText = {
+                                    Text(stringResource(TDMR.strings.custom_source_chapter_first_number_desc))
+                                },
                             )
                             OutlinedTextField(
                                 value = chapterLastNumber,
@@ -1605,6 +1611,9 @@ class CustomSourceEditorScreen(
                                 label = { Text(stringResource(TDMR.strings.custom_source_chapter_last_number)) },
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
+                                supportingText = {
+                                    Text(stringResource(TDMR.strings.custom_source_chapter_last_number_desc))
+                                },
                             )
                         }
                         OutlinedTextField(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -857,8 +857,6 @@ class CustomSourceEditorScreen(
         var latestUrl by remember { mutableStateOf(initialConfig?.latestUrl ?: "") }
         var searchUrl by remember { mutableStateOf(initialConfig?.searchUrl ?: "") }
 
-        // New fields for source type and cloudflare
-        var useCloudflare by remember { mutableStateOf(initialConfig?.useCloudflare ?: true) }
         var reverseChapters by remember { mutableStateOf(initialConfig?.reverseChapters ?: false) }
         var postSearch by remember { mutableStateOf(initialConfig?.postSearch ?: false) }
         var isNovel by remember { mutableStateOf(initialConfig?.isNovel ?: true) }
@@ -916,6 +914,9 @@ class CustomSourceEditorScreen(
         var detailsGenreSelector by remember {
             mutableStateOf(initialConfig?.selectors?.details?.genre ?: "")
         }
+        var detailsArtistSelector by remember {
+            mutableStateOf(initialConfig?.selectors?.details?.artist ?: "")
+        }
         var detailsStatusSelector by remember {
             mutableStateOf(initialConfig?.selectors?.details?.status ?: "")
         }
@@ -963,6 +964,23 @@ class CustomSourceEditorScreen(
         var contentFallbacksSelector by remember {
             mutableStateOf(initialConfig?.selectors?.content?.fallbacks?.joinToString(", ") ?: "")
         }
+        var contentRemoveSelectors by remember {
+            mutableStateOf(initialConfig?.selectors?.content?.removeSelectors?.joinToString(", ") ?: "")
+        }
+        var chapterNameTemplate by remember {
+            mutableStateOf(initialConfig?.selectors?.chapters?.nameTemplate ?: "")
+        }
+        // Advanced fields, previously only reachable via JSON import.
+        var dateFormat by remember { mutableStateOf(initialConfig?.dateFormat ?: "") }
+        var headersText by remember {
+            mutableStateOf(
+                initialConfig?.headers
+                    ?.entries?.joinToString("\n") { "${it.key}: ${it.value}" }
+                    ?: "",
+            )
+        }
+        var testSearchQuery by remember { mutableStateOf(initialConfig?.testSearchQuery ?: "") }
+        var sampleNovelUrl by remember { mutableStateOf(initialConfig?.sampleNovelUrl ?: "") }
 
         var isSaving by remember { mutableStateOf(false) }
         var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -1140,31 +1158,6 @@ class CustomSourceEditorScreen(
                     fontWeight = FontWeight.Bold,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-
-                // Cloudflare option
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    androidx.compose.material3.Checkbox(
-                        checked = useCloudflare,
-                        onCheckedChange = { useCloudflare = it },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Text(
-                            stringResource(TDMR.strings.custom_source_use_cloudflare),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                        Text(
-                            stringResource(TDMR.strings.custom_source_use_cloudflare_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
 
                 // Reverse chapters option
                 Row(
@@ -1540,6 +1533,13 @@ class CustomSourceEditorScreen(
                         modifier = Modifier.fillMaxWidth(),
                     )
                     OutlinedTextField(
+                        value = detailsArtistSelector,
+                        onValueChange = { detailsArtistSelector = it },
+                        label = { Text("Artist selector") },
+                        trailingIcon = pickTrailing(baseUrl, "Artist selector") { detailsArtistSelector = it },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedTextField(
                         value = detailsStatusSelector,
                         onValueChange = { detailsStatusSelector = it },
                         label = { Text("Status selector") },
@@ -1598,6 +1598,19 @@ class CustomSourceEditorScreen(
                                 singleLine = true,
                             )
                         }
+                        OutlinedTextField(
+                            value = chapterNameTemplate,
+                            onValueChange = { chapterNameTemplate = it },
+                            label = { Text("Chapter name template") },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            placeholder = { Text("Chapter {n}") },
+                            supportingText = {
+                                Text(
+                                    "Use {n} for the chapter number. Use {novelUrl} in the URL pattern for portability.",
+                                )
+                            },
+                        )
                     } else {
                         OutlinedTextField(
                             value = chaptersListSelector,
@@ -1715,6 +1728,55 @@ class CustomSourceEditorScreen(
                         },
                         modifier = Modifier.fillMaxWidth(),
                     )
+                    OutlinedTextField(
+                        value = contentRemoveSelectors,
+                        onValueChange = { contentRemoveSelectors = it },
+                        label = { Text("Remove selectors") },
+                        trailingIcon = pickTrailing(baseUrl, "Remove selectors") { contentRemoveSelectors = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        supportingText = {
+                            Text("Comma-separated selectors stripped from the content before display.")
+                        },
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Advanced",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    OutlinedTextField(
+                        value = dateFormat,
+                        onValueChange = { dateFormat = it },
+                        label = { Text("Chapter date format") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        placeholder = { Text("yyyy-MM-dd") },
+                        supportingText = { Text("Optional. Needed for worded dates; uses the site's locale pattern.") },
+                    )
+                    OutlinedTextField(
+                        value = headersText,
+                        onValueChange = { headersText = it },
+                        label = { Text("Custom headers") },
+                        modifier = Modifier.fillMaxWidth(),
+                        supportingText = { Text("One per line, e.g. Referer: https://example.com") },
+                    )
+                    OutlinedTextField(
+                        value = testSearchQuery,
+                        onValueChange = { testSearchQuery = it },
+                        label = { Text("Test search query") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        supportingText = { Text("Optional. Query used when testing this source.") },
+                    )
+                    OutlinedTextField(
+                        value = sampleNovelUrl,
+                        onValueChange = { sampleNovelUrl = it },
+                        label = { Text("Sample novel URL") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        supportingText = { Text("Optional. Lets the reading test open a known novel directly.") },
+                    )
                 } // end if (selectedBasedOnSourceId == null)
 
                 // Error message
@@ -1737,18 +1799,47 @@ class CustomSourceEditorScreen(
                             errorMessage = null
 
                             val config = buildConfig(
-                                name, baseUrl, popularUrl, latestUrl, searchUrl,
-                                popularListSelector, popularTitleSelector, popularCoverSelector,
-                                popularNextPageSelector, latestNextPageSelector, searchNextPageSelector,
-                                detailsTitleSelector, detailsDescriptionSelector,
-                                detailsCoverSelector, detailsAuthorSelector, detailsGenreSelector,
-                                detailsStatusSelector, statusMappingText,
-                                chaptersListSelector, chapterLinkSelector, chapterNameSelector,
-                                chapterDateSelector, chapterNextPageSelector, chapterIndexLinkSelector,
-                                chapterUrlPattern, chapterCountSelector, chapterFirstNumber, chapterLastNumber,
-                                contentPrimarySelector, contentFallbacksSelector,
-                                sourceId, useCloudflare, reverseChapters, postSearch,
-                                selectedBasedOnSourceId, isNovel, language,
+                                existing = initialConfig,
+                                name = name, baseUrl = baseUrl, popularUrl = popularUrl,
+                                latestUrl = latestUrl, searchUrl = searchUrl,
+                                popularListSelector = popularListSelector,
+                                popularTitleSelector = popularTitleSelector,
+                                popularCoverSelector = popularCoverSelector,
+                                popularNextPageSelector = popularNextPageSelector,
+                                latestNextPageSelector = latestNextPageSelector,
+                                searchNextPageSelector = searchNextPageSelector,
+                                detailsTitleSelector = detailsTitleSelector,
+                                detailsDescriptionSelector = detailsDescriptionSelector,
+                                detailsCoverSelector = detailsCoverSelector,
+                                detailsAuthorSelector = detailsAuthorSelector,
+                                detailsArtistSelector = detailsArtistSelector,
+                                detailsGenreSelector = detailsGenreSelector,
+                                detailsStatusSelector = detailsStatusSelector,
+                                statusMappingText = statusMappingText,
+                                chaptersListSelector = chaptersListSelector,
+                                chapterLinkSelector = chapterLinkSelector,
+                                chapterNameSelector = chapterNameSelector,
+                                chapterDateSelector = chapterDateSelector,
+                                chapterNextPageSelector = chapterNextPageSelector,
+                                chapterIndexLinkSelector = chapterIndexLinkSelector,
+                                chapterUrlPattern = chapterUrlPattern,
+                                chapterCountSelector = chapterCountSelector,
+                                chapterFirstNumber = chapterFirstNumber,
+                                chapterLastNumber = chapterLastNumber,
+                                chapterNameTemplate = chapterNameTemplate,
+                                contentPrimarySelector = contentPrimarySelector,
+                                contentFallbacksSelector = contentFallbacksSelector,
+                                contentRemoveSelectors = contentRemoveSelectors,
+                                dateFormat = dateFormat,
+                                headersText = headersText,
+                                testSearchQuery = testSearchQuery,
+                                sampleNovelUrl = sampleNovelUrl,
+                                existingId = sourceId,
+                                reverseChapters = reverseChapters,
+                                postSearch = postSearch,
+                                basedOnSourceId = selectedBasedOnSourceId,
+                                isNovel = isNovel,
+                                language = language,
                             )
 
                             val result = if (sourceId != null) {
@@ -1831,7 +1922,24 @@ class CustomSourceEditorScreen(
         return map.ifEmpty { null }
     }
 
+    private fun parseHeaders(text: String): Map<String, String> {
+        return text.lines().mapNotNull { line ->
+            val trimmed = line.trim()
+            if (trimmed.isBlank()) return@mapNotNull null
+            val sep = trimmed.indexOfFirst { it == ':' || it == '=' }
+            if (sep <= 0) return@mapNotNull null
+            val key = trimmed.substring(0, sep).trim()
+            val value = trimmed.substring(sep + 1).trim()
+            if (key.isBlank() || value.isBlank()) null else key to value
+        }.toMap()
+    }
+
+    private fun splitSelectorList(text: String): List<String>? =
+        text.split(",").map { it.trim() }.filter { it.isNotEmpty() }.ifEmpty { null }
+
+    @Suppress("LongParameterList")
     private fun buildConfig(
+        existing: CustomSourceConfig?,
         name: String,
         baseUrl: String,
         popularUrl: String,
@@ -1847,6 +1955,7 @@ class CustomSourceEditorScreen(
         detailsDescriptionSelector: String,
         detailsCoverSelector: String,
         detailsAuthorSelector: String,
+        detailsArtistSelector: String,
         detailsGenreSelector: String,
         detailsStatusSelector: String,
         statusMappingText: String,
@@ -1860,17 +1969,83 @@ class CustomSourceEditorScreen(
         chapterCountSelector: String,
         chapterFirstNumber: String,
         chapterLastNumber: String,
+        chapterNameTemplate: String,
         contentPrimarySelector: String,
         contentFallbacksSelector: String,
+        contentRemoveSelectors: String,
+        dateFormat: String,
+        headersText: String,
+        testSearchQuery: String,
+        sampleNovelUrl: String,
         existingId: Long?,
-        useCloudflare: Boolean,
         reverseChapters: Boolean,
         postSearch: Boolean,
         basedOnSourceId: Long? = null,
         isNovel: Boolean = true,
         language: String = "en",
     ): CustomSourceConfig {
-        return CustomSourceConfig(
+        val selectors = eu.kanade.tachiyomi.source.custom.SourceSelectors(
+            popular = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
+                list = popularListSelector,
+                title = popularTitleSelector.ifBlank { null },
+                cover = popularCoverSelector.ifBlank { null },
+                nextPage = popularNextPageSelector.ifBlank { null },
+            ),
+            // Separate latest pagination only; latest reuses the popular card layout + URL.
+            latest = latestNextPageSelector.ifBlank { null }?.let {
+                eu.kanade.tachiyomi.source.custom.MangaListSelectors(
+                    list = popularListSelector,
+                    title = popularTitleSelector.ifBlank { null },
+                    cover = popularCoverSelector.ifBlank { null },
+                    nextPage = it,
+                )
+            },
+            // Search reuses the popular list layout; pagination can differ.
+            search = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
+                list = popularListSelector,
+                title = popularTitleSelector.ifBlank { null },
+                cover = popularCoverSelector.ifBlank { null },
+                nextPage = searchNextPageSelector.ifBlank { null },
+            ),
+            details = eu.kanade.tachiyomi.source.custom.DetailSelectors(
+                title = detailsTitleSelector,
+                description = detailsDescriptionSelector.ifBlank { null },
+                cover = detailsCoverSelector.ifBlank { null },
+                author = detailsAuthorSelector.ifBlank { null },
+                artist = detailsArtistSelector.ifBlank { null },
+                genre = detailsGenreSelector.ifBlank { null },
+                status = detailsStatusSelector.ifBlank { null },
+            ),
+            chapters = eu.kanade.tachiyomi.source.custom.ChapterSelectors(
+                list = chaptersListSelector,
+                link = chapterLinkSelector.ifBlank { null },
+                name = chapterNameSelector.ifBlank { null },
+                date = chapterDateSelector.ifBlank { null },
+                nextPage = chapterNextPageSelector.ifBlank { null },
+                indexLinkSelector = chapterIndexLinkSelector.ifBlank { null },
+                urlPattern = chapterUrlPattern.ifBlank { null },
+                countSelector = chapterCountSelector.ifBlank { null },
+                firstNumber = chapterFirstNumber.toIntOrNull(),
+                lastNumber = chapterLastNumber.toIntOrNull(),
+                nameTemplate = chapterNameTemplate.ifBlank { null },
+            ),
+            content = eu.kanade.tachiyomi.source.custom.ContentSelectors(
+                primary = contentPrimarySelector,
+                fallbacks = splitSelectorList(contentFallbacksSelector),
+                removeSelectors = splitSelectorList(contentRemoveSelectors),
+            ),
+        )
+
+        // Start from the existing config so fields without a dedicated input (the per-section paged
+        // URLs derived by the wizard) survive a round-trip edit instead of being silently dropped.
+        val base = existing ?: CustomSourceConfig(
+            name = name,
+            baseUrl = baseUrl.trimEnd('/'),
+            popularUrl = popularUrl,
+            searchUrl = searchUrl,
+            selectors = selectors,
+        )
+        return base.copy(
             name = name,
             baseUrl = baseUrl.trimEnd('/'),
             language = language,
@@ -1879,56 +2054,11 @@ class CustomSourceEditorScreen(
             latestUrl = latestUrl.ifBlank { null },
             searchUrl = searchUrl,
             statusMapping = parseStatusMapping(statusMappingText),
-            selectors = eu.kanade.tachiyomi.source.custom.SourceSelectors(
-                popular = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
-                    list = popularListSelector,
-                    title = popularTitleSelector.ifBlank { null },
-                    cover = popularCoverSelector.ifBlank { null },
-                    nextPage = popularNextPageSelector.ifBlank { null },
-                ),
-                // Separate latest pagination only; latest reuses the popular card layout + URL.
-                latest = latestNextPageSelector.ifBlank { null }?.let {
-                    eu.kanade.tachiyomi.source.custom.MangaListSelectors(
-                        list = popularListSelector,
-                        title = popularTitleSelector.ifBlank { null },
-                        cover = popularCoverSelector.ifBlank { null },
-                        nextPage = it,
-                    )
-                },
-                // Search reuses the popular list layout; pagination can differ.
-                search = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
-                    list = popularListSelector,
-                    title = popularTitleSelector.ifBlank { null },
-                    cover = popularCoverSelector.ifBlank { null },
-                    nextPage = searchNextPageSelector.ifBlank { null },
-                ),
-                details = eu.kanade.tachiyomi.source.custom.DetailSelectors(
-                    title = detailsTitleSelector,
-                    description = detailsDescriptionSelector.ifBlank { null },
-                    cover = detailsCoverSelector.ifBlank { null },
-                    author = detailsAuthorSelector.ifBlank { null },
-                    genre = detailsGenreSelector.ifBlank { null },
-                    status = detailsStatusSelector.ifBlank { null },
-                ),
-                chapters = eu.kanade.tachiyomi.source.custom.ChapterSelectors(
-                    list = chaptersListSelector,
-                    link = chapterLinkSelector.ifBlank { null },
-                    name = chapterNameSelector.ifBlank { null },
-                    date = chapterDateSelector.ifBlank { null },
-                    nextPage = chapterNextPageSelector.ifBlank { null },
-                    indexLinkSelector = chapterIndexLinkSelector.ifBlank { null },
-                    urlPattern = chapterUrlPattern.ifBlank { null },
-                    countSelector = chapterCountSelector.ifBlank { null },
-                    firstNumber = chapterFirstNumber.toIntOrNull(),
-                    lastNumber = chapterLastNumber.toIntOrNull(),
-                ),
-                content = eu.kanade.tachiyomi.source.custom.ContentSelectors(
-                    primary = contentPrimarySelector,
-                    fallbacks = contentFallbacksSelector.split(",")
-                        .map { it.trim() }.filter { it.isNotEmpty() }.ifEmpty { null },
-                ),
-            ),
-            useCloudflare = useCloudflare,
+            dateFormat = dateFormat.ifBlank { null },
+            headers = parseHeaders(headersText),
+            testSearchQuery = testSearchQuery.ifBlank { null },
+            sampleNovelUrl = sampleNovelUrl.ifBlank { null },
+            selectors = selectors,
             reverseChapters = reverseChapters,
             postSearch = postSearch,
             basedOnSourceId = basedOnSourceId,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.PlayArrow
@@ -873,7 +872,8 @@ class CustomSourceEditorScreen(
                     popularPagination = c?.selectors?.popular?.nextPage != null || c?.popularPagedUrl != null,
                     latestPagination = c?.selectors?.latest?.nextPage != null || c?.latestPagedUrl != null,
                     searchPagination = c?.selectors?.search?.nextPage != null || c?.searchPagedUrl != null,
-                    chapterListPagination = c?.selectors?.chapters?.nextPage != null,
+                    chapterListPagination = c?.selectors?.chapters?.nextPage != null ||
+                        c?.selectors?.chapters?.pagedUrlPattern != null,
                     chapterListSeparatePage = c?.selectors?.chapters?.indexLinkSelector != null,
                     chapterGenerateFromPattern = c?.selectors?.chapters?.urlPattern != null,
                 ),
@@ -1066,46 +1066,10 @@ class CustomSourceEditorScreen(
                 OutlinedTextField(
                     value = language,
                     onValueChange = { language = it },
-                    label = { Text("Language code (e.g. en, ja, zh)") },
+                    label = { Text(stringResource(TDMR.strings.custom_source_language_label)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
-
-                // Show info card when based on extension
-                if (selectedBasedOnSourceId != null) {
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Card(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                Icons.Outlined.Extension,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Column {
-                                Text(
-                                    text = stringResource(TDMR.strings.custom_source_base_on_extension),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                )
-                                Text(
-                                    text = stringResource(TDMR.strings.custom_source_base_on_extension_desc),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
-                                )
-                            }
-                        }
-                    }
-                }
 
                 Spacer(modifier = Modifier.height(8.dp))
 
@@ -1126,7 +1090,7 @@ class CustomSourceEditorScreen(
                                 Injekt.get<SourceManager>().get(id)?.let { source ->
                                     "${source.name} (${source.lang})"
                                 }
-                            } ?: "Not based on another source",
+                            } ?: stringResource(TDMR.strings.custom_source_not_based),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -1363,11 +1327,6 @@ class CustomSourceEditorScreen(
                         text = stringResource(TDMR.strings.custom_source_css_selectors),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                    )
-                    Text(
-                        text = stringResource(TDMR.strings.custom_source_css_selectors_help),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Spacer(modifier = Modifier.height(8.dp))
 
@@ -1859,6 +1818,7 @@ class CustomSourceEditorScreen(
                                 basedOnSourceId = selectedBasedOnSourceId,
                                 isNovel = isNovel,
                                 language = language,
+                                features = features,
                             )
 
                             val result = if (sourceId != null) {
@@ -2002,30 +1962,45 @@ class CustomSourceEditorScreen(
         basedOnSourceId: Long? = null,
         isNovel: Boolean = true,
         language: String = "en",
+        features: eu.kanade.tachiyomi.ui.customsource.SourceFeatures,
     ): CustomSourceConfig {
+        // Gate every field by its section/mode toggle so unchecking a box actually clears the saved
+        // data (otherwise a disabled section's stale URL/selector lingers and the box re-appears
+        // ticked on the next edit). The shared list/title/cover inputs feed whichever listing is on.
+        val cardTitle = popularTitleSelector.ifBlank { null }
+        val cardCover = popularCoverSelector.ifBlank { null }
+        val generate = features.chapterGenerateFromPattern
         val selectors = eu.kanade.tachiyomi.source.custom.SourceSelectors(
             popular = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
-                list = popularListSelector,
-                title = popularTitleSelector.ifBlank { null },
-                cover = popularCoverSelector.ifBlank { null },
-                nextPage = popularNextPageSelector.ifBlank { null },
+                list = if (features.hasPopular) popularListSelector else "",
+                title = if (features.hasPopular) cardTitle else null,
+                cover = if (features.hasPopular) cardCover else null,
+                nextPage = if (features.hasPopular && features.popularPagination) {
+                    popularNextPageSelector.ifBlank { null }
+                } else {
+                    null
+                },
             ),
-            // Separate latest pagination only; latest reuses the popular card layout + URL.
-            latest = latestNextPageSelector.ifBlank { null }?.let {
+            latest = if (features.hasLatest) {
                 eu.kanade.tachiyomi.source.custom.MangaListSelectors(
                     list = popularListSelector,
-                    title = popularTitleSelector.ifBlank { null },
-                    cover = popularCoverSelector.ifBlank { null },
-                    nextPage = it,
+                    title = cardTitle,
+                    cover = cardCover,
+                    nextPage = if (features.latestPagination) latestNextPageSelector.ifBlank { null } else null,
                 )
+            } else {
+                null
             },
-            // Search reuses the popular list layout; pagination can differ.
-            search = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
-                list = popularListSelector,
-                title = popularTitleSelector.ifBlank { null },
-                cover = popularCoverSelector.ifBlank { null },
-                nextPage = searchNextPageSelector.ifBlank { null },
-            ),
+            search = if (features.hasSearch) {
+                eu.kanade.tachiyomi.source.custom.MangaListSelectors(
+                    list = popularListSelector,
+                    title = cardTitle,
+                    cover = cardCover,
+                    nextPage = if (features.searchPagination) searchNextPageSelector.ifBlank { null } else null,
+                )
+            } else {
+                null
+            },
             details = eu.kanade.tachiyomi.source.custom.DetailSelectors(
                 title = detailsTitleSelector,
                 description = detailsDescriptionSelector.ifBlank { null },
@@ -2037,26 +2012,43 @@ class CustomSourceEditorScreen(
             ),
             chapters = eu.kanade.tachiyomi.source.custom.ChapterSelectors(
                 list = chaptersListSelector,
-                link = chapterLinkSelector.ifBlank { null },
-                name = chapterNameSelector.ifBlank { null },
-                date = chapterDateSelector.ifBlank { null },
-                nextPage = chapterNextPageSelector.ifBlank { null },
-                indexLinkSelector = chapterIndexLinkSelector.ifBlank { null },
-                urlPattern = chapterUrlPattern.ifBlank { null },
-                countSelector = chapterCountSelector.ifBlank { null },
-                firstNumber = chapterFirstNumber.toIntOrNull(),
-                lastNumber = chapterLastNumber.toIntOrNull(),
-                nameTemplate = chapterNameTemplate.ifBlank { null },
+                link = if (generate) null else chapterLinkSelector.ifBlank { null },
+                name = if (generate) null else chapterNameSelector.ifBlank { null },
+                date = if (generate) null else chapterDateSelector.ifBlank { null },
+                nextPage = if (!generate && features.chapterListPagination) {
+                    chapterNextPageSelector.ifBlank { null }
+                } else {
+                    null
+                },
+                // No dedicated input; preserve the wizard-derived numbered-pagination template only
+                // while chapter-list pagination stays enabled.
+                pagedUrlPattern = if (!generate && features.chapterListPagination) {
+                    existing?.selectors?.chapters?.pagedUrlPattern
+                } else {
+                    null
+                },
+                indexLinkSelector = if (!generate && features.chapterListSeparatePage) {
+                    chapterIndexLinkSelector.ifBlank { null }
+                } else {
+                    null
+                },
+                urlPattern = if (generate) chapterUrlPattern.ifBlank { null } else null,
+                countSelector = if (generate) chapterCountSelector.ifBlank { null } else null,
+                firstNumber = if (generate) chapterFirstNumber.toIntOrNull() else null,
+                lastNumber = if (generate) chapterLastNumber.toIntOrNull() else null,
+                nameTemplate = if (generate) chapterNameTemplate.ifBlank { null } else null,
             ),
             content = eu.kanade.tachiyomi.source.custom.ContentSelectors(
                 primary = contentPrimarySelector,
                 fallbacks = splitSelectorList(contentFallbacksSelector),
                 removeSelectors = splitSelectorList(contentRemoveSelectors),
+                // No UI toggle for this; preserve whatever an imported config set instead of
+                // resetting to the default on every edit.
+                removeBoilerplate = existing?.selectors?.content?.removeBoilerplate ?: true,
             ),
         )
 
-        // Start from the existing config so fields without a dedicated input (the per-section paged
-        // URLs derived by the wizard) survive a round-trip edit instead of being silently dropped.
+        // Start from the existing config so fields without a dedicated input survive a round-trip.
         val base = existing ?: CustomSourceConfig(
             name = name,
             baseUrl = baseUrl.trimEnd('/'),
@@ -2069,9 +2061,14 @@ class CustomSourceEditorScreen(
             baseUrl = baseUrl.trimEnd('/'),
             language = language,
             id = existingId,
-            popularUrl = popularUrl,
-            latestUrl = latestUrl.ifBlank { null },
-            searchUrl = searchUrl,
+            popularUrl = if (features.hasPopular) popularUrl else "",
+            latestUrl = if (features.hasLatest) latestUrl.ifBlank { null } else null,
+            searchUrl = if (features.hasSearch) searchUrl else "",
+            // Per-section paged URLs are wizard-derived (no field here); keep them only while the
+            // matching section + pagination toggle are both on.
+            popularPagedUrl = if (features.hasPopular && features.popularPagination) base.popularPagedUrl else null,
+            latestPagedUrl = if (features.hasLatest && features.latestPagination) base.latestPagedUrl else null,
+            searchPagedUrl = if (features.hasSearch && features.searchPagination) base.searchPagedUrl else null,
             statusMapping = parseStatusMapping(statusMappingText),
             dateFormat = dateFormat.ifBlank { null },
             headers = parseHeaders(headersText),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/CreateCustomSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/CreateCustomSourceScreen.kt
@@ -63,10 +63,7 @@ private fun FeatureToggle(
     }
 }
 
-/**
- * Pre-wizard setup page: enter the site URL and choose which sections/pagination the source has,
- * so the WebView wizard only walks the user through the steps that apply.
- */
+/** Pre-wizard page: enter the site URL and choose sections/pagination so the wizard shows only needed steps. */
 class WizardSetupScreen(
     private val initialUrl: String = "",
 ) : Screen {
@@ -182,8 +179,7 @@ class WizardSetupScreen(
                         features.chapterListPagination,
                     ) { features = features.copy(chapterListPagination = it) }
                 }
-                // Content pagination (a single chapter split across pages) is rarely useful for
-                // novels — set it in the manual editor when actually needed.
+                // Content pagination (one chapter split across pages) is set in the manual editor.
 
                 if (!features.hasPopular && !features.hasLatest) {
                     Text(
@@ -210,9 +206,7 @@ class WizardSetupScreen(
     }
 }
 
-/**
- * Voyager screen wrapper for the Element Selector
- */
+/** Voyager wrapper for the element selector wizard. */
 class ElementSelectorVoyagerScreen(
     private val initialUrl: String,
     private val initialSourceName: String = "",
@@ -226,7 +220,6 @@ class ElementSelectorVoyagerScreen(
         val screenModel = rememberScreenModel { ElementSelectorScreenModel(initialUrl, initialSourceName) }
         val state by screenModel.state.collectAsState()
 
-        // Handle success
         LaunchedEffect(state.savedSuccessfully) {
             if (state.savedSuccessfully) {
                 Toast.makeText(
@@ -238,7 +231,6 @@ class ElementSelectorVoyagerScreen(
             }
         }
 
-        // Handle error
         LaunchedEffect(state.error) {
             state.error?.let { error ->
                 Toast.makeText(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/CreateCustomSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/CreateCustomSourceScreen.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.ui.customsource
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,22 +8,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Code
-import androidx.compose.material.icons.filled.Launch
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -41,249 +35,11 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import eu.kanade.tachiyomi.jsplugin.source.JsSource
-import eu.kanade.tachiyomi.source.CatalogueSource
-import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.extension.NovelExtensionReposScreen
-import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import tachiyomi.core.common.i18n.stringResource as ctxStringResource
-
-private data class SourceTemplateOption(
-    val id: Long,
-    val name: String,
-    val baseUrl: String,
-    val type: String,
-)
-
-/**
- * Entry screen for creating a custom novel source via WebView element selection.
- */
-class CreateCustomSourceScreen : Screen {
-
-    @Composable
-    override fun Content() {
-        val navigator = LocalNavigator.currentOrThrow
-        val context = LocalContext.current
-
-        var showInstalledTemplateDialog by remember { mutableStateOf(false) }
-        val sourceManager = remember { Injekt.get<SourceManager>() }
-        val installedTemplateSources = remember {
-            sourceManager.getAll().filterIsInstance<CatalogueSource>()
-                .mapNotNull { source ->
-                    val baseUrl = when (source) {
-                        is HttpSource -> source.baseUrl
-                        is JsSource -> source.baseUrl
-                        else -> null
-                    }?.trim()
-                    if (baseUrl.isNullOrBlank() || !baseUrl.startsWith("http")) return@mapNotNull null
-                    SourceTemplateOption(
-                        id = source.id,
-                        name = source.name,
-                        baseUrl = baseUrl,
-                        type = if (source is JsSource) "JS" else "KT",
-                    )
-                }
-                .sortedBy { it.name.lowercase() }
-        }
-
-        Scaffold { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                // Header
-                Icon(
-                    Icons.Filled.Code,
-                    contentDescription = null,
-                    modifier = Modifier.height(64.dp),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = stringResource(TDMR.strings.custom_source_create_title),
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Text(
-                    text = stringResource(TDMR.strings.custom_source_create_subtitle),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                Spacer(modifier = Modifier.height(32.dp))
-
-                // Method selection cards
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    ),
-                    onClick = { navigator.push(WizardSetupScreen()) },
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Filled.Launch,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        )
-                        Spacer(modifier = Modifier.weight(0.1f))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_guided_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            )
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_guided_desc),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Alternative: Import JSON config
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    ),
-                    onClick = { showInstalledTemplateDialog = true },
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Filled.Add,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                        )
-                        Spacer(modifier = Modifier.weight(0.1f))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_template_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_template_desc),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                    ),
-                    onClick = { navigator.push(NovelExtensionReposScreen()) },
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Filled.Code,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onTertiaryContainer,
-                        )
-                        Spacer(modifier = Modifier.weight(0.1f))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_repos_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onTertiaryContainer,
-                            )
-                            Text(
-                                text = stringResource(TDMR.strings.custom_source_method_repos_desc),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f),
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(32.dp))
-
-                // Info text
-                Text(
-                    text = stringResource(TDMR.strings.custom_source_steps_intro),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-
-                listOf(
-                    stringResource(TDMR.strings.custom_source_step_1),
-                    stringResource(TDMR.strings.custom_source_step_2),
-                    stringResource(TDMR.strings.custom_source_step_3),
-                    stringResource(TDMR.strings.custom_source_step_4),
-                    stringResource(TDMR.strings.custom_source_step_5),
-                    stringResource(TDMR.strings.custom_source_step_6),
-                    stringResource(TDMR.strings.custom_source_step_7),
-                    stringResource(TDMR.strings.custom_source_step_8),
-                ).forEach { step ->
-                    Text(
-                        text = step,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-
-        if (showInstalledTemplateDialog) {
-            InstalledTemplateDialog(
-                templates = installedTemplateSources,
-                onDismiss = { showInstalledTemplateDialog = false },
-                onStart = { selected, nameOverride, urlOverride ->
-                    showInstalledTemplateDialog = false
-                    navigator.push(
-                        ElementSelectorVoyagerScreen(
-                            initialUrl = urlOverride,
-                            initialSourceName = nameOverride.ifBlank { selected.name },
-                        ),
-                    )
-                },
-            )
-        }
-    }
-}
 
 @Composable
 private fun FeatureToggle(
@@ -344,13 +100,8 @@ class WizardSetupScreen(
                     .fillMaxSize()
                     .padding(padding)
                     .padding(16.dp)
-                    .verticalScroll(androidx.compose.foundation.rememberScrollState()),
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Text(
-                    text = stringResource(TDMR.strings.custom_source_url_dialog_message),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
                 // Dynamic-site caveat: HTML parsing can't see JS-rendered content.
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -459,93 +210,6 @@ class WizardSetupScreen(
     }
 }
 
-@Composable
-private fun InstalledTemplateDialog(
-    templates: List<SourceTemplateOption>,
-    onDismiss: () -> Unit,
-    onStart: (SourceTemplateOption, String, String) -> Unit,
-) {
-    var selected by remember { mutableStateOf<SourceTemplateOption?>(null) }
-    var sourceName by remember { mutableStateOf("") }
-    var sourceUrl by remember { mutableStateOf("") }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(TDMR.strings.custom_source_choose_installed)) },
-        text = {
-            Column {
-                if (templates.isEmpty()) {
-                    Text(
-                        text = stringResource(TDMR.strings.custom_source_choose_installed_empty),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                } else {
-                    Text(
-                        text = stringResource(TDMR.strings.custom_source_choose_installed_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(220.dp)
-                            .verticalScroll(androidx.compose.foundation.rememberScrollState()),
-                    ) {
-                        templates.forEach { template ->
-                            OutlinedButton(
-                                onClick = {
-                                    selected = template
-                                    sourceName = template.name
-                                    sourceUrl = template.baseUrl
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 4.dp),
-                            ) {
-                                Text("${template.name} (${template.type})")
-                            }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                    OutlinedTextField(
-                        value = sourceName,
-                        onValueChange = { sourceName = it },
-                        label = { Text(stringResource(TDMR.strings.custom_source_source_name)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = sourceUrl,
-                        onValueChange = { sourceUrl = it },
-                        label = { Text(stringResource(TDMR.strings.custom_source_base_url)) },
-                        placeholder = { Text("https://example.com") },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    val selectedTemplate = selected ?: return@Button
-                    val normalizedUrl = if (sourceUrl.startsWith("http")) sourceUrl else "https://$sourceUrl"
-                    onStart(selectedTemplate, sourceName.trim(), normalizedUrl.trim())
-                },
-                enabled = selected != null && sourceUrl.isNotBlank(),
-            ) {
-                Text(stringResource(TDMR.strings.custom_source_use_template))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(MR.strings.action_cancel))
-            }
-        },
-    )
-}
-
 /**
  * Voyager screen wrapper for the Element Selector
  */
@@ -593,10 +257,10 @@ class ElementSelectorVoyagerScreen(
             features = features,
             onNavigateUp = { navigator.pop() },
             onSaveConfig = { config ->
-                screenModel.saveConfig(config)
+                screenModel.saveConfig(config, features)
             },
             onTestConfig = { config, section, onResult ->
-                screenModel.testConfig(config, section, onResult)
+                screenModel.testConfig(config, features, section, onResult)
             },
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -92,39 +92,33 @@ import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.components.material.Scaffold as TachiyomiScaffold
 
-/**
- * Which sections a custom source exposes. Chosen up front (URL dialog) so the wizard only walks the
- * user through the steps they actually need.
- */
+/** Which sections a source exposes; chosen up front so the wizard only shows the needed steps. */
 data class SourceFeatures(
     val hasPopular: Boolean = true,
     val hasLatest: Boolean = true,
     val hasSearch: Boolean = true,
-    // Per-section pagination — each adds its own capture step only when enabled.
+    // Per-section pagination; each adds a capture step.
     val popularPagination: Boolean = false,
     val latestPagination: Boolean = false,
     val searchPagination: Boolean = false,
-    // The chapter list spans multiple pages (adds a chapter-list pagination step).
+    // Chapter list spans multiple pages.
     val chapterListPagination: Boolean = false,
-    // The chapter list lives on a separate page linked from the details page (adds a step to tap
-    // that "all chapters / table of contents" link).
+    // Chapter list lives on a separate linked page (adds a step to tap that link).
     val chapterListSeparatePage: Boolean = false,
-    // Chapters have sequential numeric URLs (e.g. /chapter-12); generate the list from a pattern
-    // instead of scraping it (adds a "first/last chapter + total count" step).
+    // Chapters have sequential numeric URLs; generate from a pattern instead of scraping.
     val chapterGenerateFromPattern: Boolean = false,
 ) : java.io.Serializable
 
 /**
- * Element Selector Wizard Steps. The active list is derived from [SourceFeatures]; reading steps
- * (details/chapters/content) are always included. Each step optionally maps to a [SourceTestSection]
- * so its parsing can be validated in place instead of only at the end.
+ * Wizard steps; the active list is derived from [SourceFeatures] (reading steps always included).
+ * Each step optionally maps to a [SourceTestSection] for in-place validation.
  */
 enum class SelectorWizardStep(
     val titleRes: StringResource,
     val descriptionRes: StringResource,
     val detailedHelpRes: StringResource,
     val testSection: SourceTestSection? = null,
-    // Whether this step shows the (i) help button. Only steps with non-obvious, niche guidance do.
+    // Shows the (i) help button. Only steps with non-obvious guidance.
     val detailed: Boolean = true,
 ) {
     POPULAR_LIST(
@@ -251,17 +245,15 @@ data class SelectorConfig(
     var newNovelsSelector: String = "",
     var searchUrl: String = "",
     var searchKeyword: String = "",
-    // Raw page-1 search URL (with the probe word) — paired with searchPage2Url to derive {page}.
+    // Raw page-1 search URL; paired with searchPage2Url to derive {page}.
     var searchSampleUrl: String = "",
-    // Listing pagination: the page-2 URL the user navigated to. Diffed against the page-1 URL to
-    // build a correct {page} template (handles ?page= vs /page/ vs trailing-number forms).
+    // Listing page-2 URLs, diffed against page 1 to build the {page} template.
     var popularPage2Url: String = "",
     var latestPage2Url: String = "",
     var searchPage2Url: String = "",
-    // Followed-link pagination selector (fallback when the URL pattern can't be derived).
+    // Followed-link pagination selector (fallback when no URL pattern).
     var chapterListPaginationSelector: String = "",
-    // Chapter-list page 1/2 URLs. Diffed (and the novel path generalized to {novelUrl}) into a
-    // numbered-pagination template, the robust alternative to chasing a next-page button.
+    // Chapter-list page 1/2 URLs, diffed into a {novelUrl}-generalized {page} template.
     var chapterListPage1Url: String = "",
     var chapterListPage2Url: String = "",
     // Details-page selector linking to a separate chapter-list page.
@@ -1850,9 +1842,8 @@ private fun canProceedToNextStep(
 }
 
 /**
- * The wizard captures document-unique selectors (e.g. `div.list > div.card > a.title`), but the
- * source parses title/cover/link relative to each list item. Strip the list-container prefix so the
- * selector resolves inside a card; fall back to the trailing segment when there's no shared prefix.
+ * Strips the list-container prefix off a document-unique selector so it resolves inside a card
+ * (the source parses title/cover/link relative to each item). Falls back to the trailing segment.
  */
 private fun relativize(full: String, listSel: String): String {
     if (full.isBlank()) return ""
@@ -1871,9 +1862,8 @@ private fun relativize(full: String, listSel: String): String {
 }
 
 /**
- * Diffs a page-1 and page-2 URL that differ only by page number, returning the page-2 URL with the
- * differing digits replaced by {page}. Mirrors ElementSelectorScreenModel.derivePagedFromPair so the
- * wizard can preview the same template that gets saved. Null if they don't differ by a number.
+ * Diffs page-1/page-2 URLs into the page-2 URL with the differing digits replaced by {page}. Mirrors
+ * ElementSelectorScreenModel.derivePagedFromPair (preview = saved template). Null if no numeric diff.
  */
 internal fun derivePageTemplate(p1: String, p2: String): String? {
     if (p1.isBlank() || p2.isBlank() || p1 == p2) return null
@@ -1888,9 +1878,8 @@ internal fun derivePageTemplate(p1: String, p2: String): String? {
 }
 
 /**
- * Reuses the page-token discovered between popular page1/page2 and applies it to [target] (the latest
- * page-1 URL), so the user can skip navigating latest to page 2 when the site paginates identically.
- * Handles the two dominant forms: a query param (`page=2`) and a path segment (`/page/2`).
+ * Applies the popular page1/page2 page-token to [target] (latest page-1 URL), so latest needn't be
+ * navigated to page 2. Handles query-param (`page=2`) and path-segment (`/page/2`) forms.
  */
 internal fun applyPagePattern(popularP1: String, popularP2: String, target: String): String? {
     if (popularP1.isBlank() || popularP2.isBlank() || popularP1 == popularP2 || target.isBlank()) return null
@@ -1915,9 +1904,8 @@ private fun stripPositional(selector: String): String =
     selector.replace(Regex(""":nth-of-type\(\d+\)"""), "").replace(Regex(""":nth-child\(\d+\)"""), "")
 
 /**
- * Derive the repeating list-item (card) selector from the tapped elements. Prefers the common path
- * prefix; if the unique selectors share none, falls back to a common closest container (li/div/a)
- * reported by the JS, generalized so it matches every card rather than one.
+ * Derives the repeating card selector from tapped elements: common path prefix, else a shared
+ * closest container (li/div/a) reported by the JS.
  */
 private fun deriveListSelector(elements: List<SelectedElement>): String {
     val prefix = findCommonSelector(elements)
@@ -1937,9 +1925,8 @@ private fun saveSelectionsForStep(
 ) {
     when (step) {
         SelectorWizardStep.POPULAR_LIST -> {
-            // One tap = title/link only (cover skipped). Two taps = cover first, then title. List =
-            // repeating item selector (DOM-detected when available); cover/title stored RELATIVE to
-            // it so the source resolves them per item.
+            // One tap = title only; two taps = cover then title. Cover/title stored relative to the
+            // repeating item selector so the source resolves them per item.
             if (selectedElements.isNotEmpty()) {
                 val listSel = detectedListSelector?.ifBlank { null } ?: deriveListSelector(selectedElements)
                 config.trendingSelector = listSel
@@ -1973,9 +1960,8 @@ private fun saveSelectionsForStep(
             selectedElements.firstOrNull()?.let { config.chapterIndexLinkSelector = it.selector }
         }
         SelectorWizardStep.NOVEL_DETAILS -> {
-            // Fixed order: title, description, cover, then ANY number of tag/genre elements. The
-            // tag picks are merged into one comma-separated selector group; the source joins their
-            // texts so several individual tag links become a single genre string.
+            // Fixed order: title, description, cover, then any number of tags merged into one
+            // comma-separated selector group (the source joins their texts into one genre string).
             selectedElements.getOrNull(0)?.let { config.novelPageTitleSelector = it.selector }
             selectedElements.getOrNull(1)?.let { config.novelDescriptionSelector = it.selector }
             selectedElements.getOrNull(2)?.let { config.novelCoverPageSelector = it.selector }
@@ -2565,9 +2551,8 @@ internal val ELEMENT_SELECTOR_JS = """
 """
 
 /**
- * Derive a {query} search URL template from a URL the user produced by searching for [userQuery].
- * Handles both raw and percent-encoded occurrences (including '+' for spaces), regardless of which
- * query parameter or path segment the site uses. Returns the template, or null if not found.
+ * Derives a {query} template from a URL produced by searching for [userQuery]. Handles raw and
+ * percent-encoded occurrences (incl. '+' for spaces), any param/path segment. Null if not found.
  */
 internal fun deriveSearchUrl(url: String, baseUrl: String, userQuery: String): String? {
     if (userQuery.isBlank()) return null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -72,7 +71,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -126,6 +124,8 @@ enum class SelectorWizardStep(
     val descriptionRes: StringResource,
     val detailedHelpRes: StringResource,
     val testSection: SourceTestSection? = null,
+    // Whether this step shows the (i) help button. Only steps with non-obvious, niche guidance do.
+    val detailed: Boolean = true,
 ) {
     POPULAR_LIST(
         TDMR.strings.selector_step_novel_card_title,
@@ -143,6 +143,7 @@ enum class SelectorWizardStep(
         TDMR.strings.selector_step_new_novels_desc,
         TDMR.strings.selector_step_new_novels_detail,
         SourceTestSection.LATEST,
+        detailed = false,
     ),
     LATEST_PAGINATION(
         TDMR.strings.selector_step_pagination_title,
@@ -164,11 +165,13 @@ enum class SelectorWizardStep(
         TDMR.strings.selector_step_novel_details_title,
         TDMR.strings.selector_step_novel_details_desc,
         TDMR.strings.selector_step_novel_details_detail,
+        detailed = false,
     ),
     CHAPTER_INDEX_LINK(
         TDMR.strings.selector_step_chapter_index_title,
         TDMR.strings.selector_step_chapter_index_desc,
         TDMR.strings.selector_step_chapter_index_detail,
+        detailed = false,
     ),
     CHAPTER_RANGE(
         TDMR.strings.selector_step_chapter_range_title,
@@ -179,27 +182,32 @@ enum class SelectorWizardStep(
         TDMR.strings.selector_step_chapter_list_title,
         TDMR.strings.selector_step_chapter_list_desc,
         TDMR.strings.selector_step_chapter_list_detail,
+        detailed = false,
     ),
     CHAPTER_LIST_PAGINATION(
         TDMR.strings.selector_step_chapter_pagination_title,
         TDMR.strings.selector_step_chapter_pagination_desc,
         TDMR.strings.selector_step_chapter_pagination_detail,
+        detailed = false,
     ),
     CHAPTER_DATE(
         TDMR.strings.selector_step_chapter_date_title,
         TDMR.strings.selector_step_chapter_date_desc,
         TDMR.strings.selector_step_chapter_date_detail,
+        detailed = false,
     ),
     CHAPTER_CONTENT(
         TDMR.strings.selector_step_chapter_content_title,
         TDMR.strings.selector_step_chapter_content_desc,
         TDMR.strings.selector_step_chapter_content_detail,
         SourceTestSection.READING,
+        detailed = false,
     ),
     REVIEW(
         TDMR.strings.selector_review_title,
         TDMR.strings.selector_review_desc,
         TDMR.strings.selector_step_complete_detail,
+        detailed = false,
     ),
     ;
 
@@ -635,39 +643,6 @@ fun ElementSelectorScreen(
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
-
-                StepIndicatorBar(
-                    steps = steps,
-                    currentStep = currentStep,
-                    onStepClick = { screenModel.currentStepState.value = it },
-                )
-            }
-        },
-        floatingActionButton = {
-            if (!isReview) {
-                ExtendedFloatingActionButton(
-                    onClick = { if (selectionModeEnabled) disableSelectionMode() else enableSelectionMode() },
-                    containerColor = if (selectionModeEnabled) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.secondaryContainer
-                    },
-                    icon = {
-                        Icon(
-                            if (selectionModeEnabled) Icons.Filled.TouchApp else Icons.Filled.Edit,
-                            contentDescription = stringResource(TDMR.strings.selector_select_element),
-                        )
-                    },
-                    text = {
-                        Text(
-                            if (selectionModeEnabled) {
-                                stringResource(TDMR.strings.selector_selection_on)
-                            } else {
-                                stringResource(TDMR.strings.selector_select_element)
-                            },
-                        )
-                    },
-                )
             }
         },
     ) { padding ->
@@ -900,6 +875,10 @@ fun ElementSelectorScreen(
                     commitAllSelections()
                     showSourceNameDialog = true
                 },
+                selectionModeEnabled = selectionModeEnabled,
+                onToggleSelection = {
+                    if (selectionModeEnabled) disableSelectionMode() else enableSelectionMode()
+                },
             )
         }
     }
@@ -997,39 +976,6 @@ fun ElementSelectorScreen(
 }
 
 @Composable
-private fun StepIndicatorBar(
-    steps: List<SelectorWizardStep>,
-    currentStep: SelectorWizardStep,
-    onStepClick: (SelectorWizardStep) -> Unit,
-) {
-    val currentIndex = steps.indexOf(currentStep)
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(horizontal = 8.dp, vertical = 6.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        steps.forEachIndexed { index, step ->
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(4.dp)
-                    .clip(RoundedCornerShape(2.dp))
-                    .background(
-                        when {
-                            index < currentIndex -> MaterialTheme.colorScheme.primary
-                            step == currentStep -> MaterialTheme.colorScheme.tertiary
-                            else -> MaterialTheme.colorScheme.outlineVariant
-                        },
-                    )
-                    .clickable { onStepClick(step) },
-            )
-        }
-    }
-}
-
-@Composable
 private fun StepInstructionCard(
     step: SelectorWizardStep,
     selectedCount: Int,
@@ -1052,26 +998,30 @@ private fun StepInstructionCard(
     ) {
         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = if (compact) 4.dp else 8.dp)) {
             var showHelp by remember { mutableStateOf(false) }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (!compact) {
-                    Text(
-                        text = stringResource(step.descriptionRes),
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.weight(1f),
-                    )
-                } else {
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-                IconButton(onClick = { showHelp = true }, modifier = Modifier.size(28.dp)) {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = stringResource(TDMR.strings.selector_step_help),
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
+            if (!compact || step.detailed) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (!compact) {
+                        Text(
+                            text = stringResource(step.descriptionRes),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier.weight(1f),
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                    if (step.detailed) {
+                        IconButton(onClick = { showHelp = true }, modifier = Modifier.size(28.dp)) {
+                            Icon(
+                                imageVector = Icons.Outlined.Info,
+                                contentDescription = stringResource(TDMR.strings.selector_step_help),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
                 }
             }
             if (showHelp) {
@@ -1428,16 +1378,58 @@ private fun StepNavigationBar(
     onPrevious: () -> Unit,
     onNext: () -> Unit,
     onComplete: () -> Unit,
+    selectionModeEnabled: Boolean = false,
+    onToggleSelection: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 8.dp, vertical = 6.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        OutlinedButton(onClick = onPrevious, enabled = !isFirstStep) {
-            Text(stringResource(TDMR.strings.custom_selector_previous))
+        IconButton(onClick = onPrevious, enabled = !isFirstStep, modifier = Modifier.size(40.dp)) {
+            Icon(
+                Icons.AutoMirrored.Outlined.ArrowBack,
+                stringResource(TDMR.strings.custom_selector_previous),
+            )
+        }
+
+        // Select-element toggle lives between prev/next so it is reachable without the FAB. Hidden on
+        // the final review step where there is nothing to pick.
+        if (!isLastStep && onToggleSelection != null) {
+            FilledTonalButton(
+                onClick = onToggleSelection,
+                modifier = Modifier.weight(1f),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 8.dp, vertical = 6.dp),
+                colors = if (selectionModeEnabled) {
+                    ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    ButtonDefaults.filledTonalButtonColors()
+                },
+            ) {
+                Icon(
+                    if (selectionModeEnabled) Icons.Filled.TouchApp else Icons.Filled.Edit,
+                    null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    if (selectionModeEnabled) {
+                        stringResource(TDMR.strings.selector_selection_on)
+                    } else {
+                        stringResource(TDMR.strings.selector_select_element)
+                    },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        } else {
+            Spacer(Modifier.weight(1f))
         }
 
         if (isLastStep) {
@@ -1803,7 +1795,8 @@ private fun canProceedToNextStep(
     config: SelectorConfig,
 ): Boolean {
     return when (step) {
-        SelectorWizardStep.POPULAR_LIST -> selectedElements.size >= 2 // Cover + Title
+        // One tap (title) is enough; a second optional tap captures the cover for thumbnails.
+        SelectorWizardStep.POPULAR_LIST -> selectedElements.isNotEmpty()
         // Optional: by default latest reuses the popular card layout, so no taps are required —
         // only the latest page URL (captured on Next) is needed.
         SelectorWizardStep.LATEST_LIST -> true
@@ -1915,16 +1908,21 @@ private fun saveSelectionsForStep(
 ) {
     when (step) {
         SelectorWizardStep.POPULAR_LIST -> {
-            // First tap = cover image, second = title/link. List = repeating item selector (DOM-
-            // detected when available); cover/title stored RELATIVE to it so the source resolves
-            // them per item.
+            // One tap = title/link only (cover skipped). Two taps = cover first, then title. List =
+            // repeating item selector (DOM-detected when available); cover/title stored RELATIVE to
+            // it so the source resolves them per item.
             config.trendingNovels.clear()
             config.trendingNovels.addAll(selectedElements.map { it.selector })
             if (selectedElements.isNotEmpty()) {
                 val listSel = detectedListSelector?.ifBlank { null } ?: deriveListSelector(selectedElements)
                 config.trendingSelector = listSel
-                selectedElements.getOrNull(0)?.let { config.novelCoverSelector = relativize(it.selector, listSel) }
-                selectedElements.getOrNull(1)?.let { config.novelTitleSelector = relativize(it.selector, listSel) }
+                if (selectedElements.size == 1) {
+                    config.novelCoverSelector = ""
+                    config.novelTitleSelector = relativize(selectedElements[0].selector, listSel)
+                } else {
+                    config.novelCoverSelector = relativize(selectedElements[0].selector, listSel)
+                    config.novelTitleSelector = relativize(selectedElements[1].selector, listSel)
+                }
             }
         }
         SelectorWizardStep.LATEST_LIST -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -571,6 +571,10 @@ fun ElementSelectorScreen(
                             config.searchKeyword = searchProbeQuery
                             config.searchSampleUrl = newUrl // raw page-1 search URL for pagination diff
                             searchStatus = "ok:$derived"
+                        } else {
+                            // The probe word isn't in this URL yet. Notify instead of staying silent so
+                            // the user knows to run the search (and that case must match).
+                            searchStatus = "fail"
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.PlaylistAddCheck
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.AlertDialog
@@ -1050,11 +1051,39 @@ private fun StepInstructionCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
     ) {
         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = if (compact) 4.dp else 8.dp)) {
-            if (!compact) {
-                Text(
-                    text = stringResource(step.descriptionRes),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontWeight = FontWeight.Medium,
+            var showHelp by remember { mutableStateOf(false) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (!compact) {
+                    Text(
+                        text = stringResource(step.descriptionRes),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.weight(1f),
+                    )
+                } else {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+                IconButton(onClick = { showHelp = true }, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = stringResource(TDMR.strings.selector_step_help),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+            }
+            if (showHelp) {
+                AlertDialog(
+                    onDismissRequest = { showHelp = false },
+                    title = { Text(stringResource(step.titleRes)) },
+                    text = { Text(stringResource(step.detailedHelpRes)) },
+                    confirmButton = {
+                        TextButton(onClick = { showHelp = false }) {
+                            Text(stringResource(MR.strings.action_ok))
+                        }
+                    },
                 )
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -1820,25 +1820,6 @@ private fun relativize(full: String, listSel: String): String {
 }
 
 /**
- * From the first and last chapter URLs, derive a numeric pattern ({n} at the chapter number) plus
- * both numbers. Uses the LAST digit run as the chapter number (robust to a novel id earlier in the
- * path). Returns (relativePattern, firstNumber, lastNumber) or null.
- */
-private fun deriveNumericPattern(url1: String, url2: String, baseUrl: String): Triple<String, Int, Int>? {
-    if (url1.isBlank() || url2.isBlank()) return null
-    val rx = Regex("""\d+""")
-    val m1 = rx.findAll(url1).lastOrNull() ?: return null
-    val m2 = rx.findAll(url2).lastOrNull() ?: return null
-    val n1 = m1.value.toIntOrNull() ?: return null
-    val n2 = m2.value.toIntOrNull() ?: return null
-    if (n1 == n2) return null
-    val patternAbs = url1.substring(0, m1.range.first) + "{n}" + url1.substring(m1.range.last + 1)
-    val base = baseUrl.trimEnd('/')
-    val pattern = if (patternAbs.startsWith(base)) patternAbs.removePrefix(base) else patternAbs
-    return Triple(pattern, n1, n2)
-}
-
-/**
  * Diffs a page-1 and page-2 URL that differ only by page number, returning the page-2 URL with the
  * differing digits replaced by {page}. Mirrors ElementSelectorScreenModel.derivePagedFromPair so the
  * wizard can preview the same template that gets saved. Null if they don't differ by a number.
@@ -1929,7 +1910,11 @@ private fun saveSelectionsForStep(
             }
         }
         SelectorWizardStep.CHAPTER_LIST_PAGINATION -> {
-            selectedElements.firstOrNull()?.let { config.chapterListPaginationSelector = it.selector }
+            // Strip positional bits (:nth-of-type) so the "next page" selector keeps matching on
+            // page 2+ where the element's index differs from page 1.
+            selectedElements.firstOrNull()?.let {
+                config.chapterListPaginationSelector = stripPositional(it.selector)
+            }
         }
         SelectorWizardStep.CHAPTER_INDEX_LINK -> {
             // On the details page; stored as a document selector (resolved against the details doc).
@@ -1967,7 +1952,12 @@ private fun saveSelectionsForStep(
             // element holding the total chapter count (overrides the last number).
             val first = selectedElements.getOrNull(0)?.href.orEmpty()
             val last = selectedElements.getOrNull(1)?.href.orEmpty()
-            deriveNumericPattern(first, last, config.baseUrl)?.let { (pattern, n1, n2) ->
+            eu.kanade.tachiyomi.source.custom.deriveGenericChapterPattern(
+                first,
+                last,
+                config.baseUrl,
+                config.sampleNovelUrl.ifBlank { null },
+            )?.let { (pattern, n1, n2) ->
                 config.chapterUrlPattern = pattern
                 config.chapterFirstNumber = minOf(n1, n2)
                 config.chapterLastNumber = maxOf(n1, n2)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -177,6 +177,7 @@ enum class SelectorWizardStep(
         TDMR.strings.selector_step_chapter_range_title,
         TDMR.strings.selector_step_chapter_range_desc,
         TDMR.strings.selector_step_chapter_range_detail,
+        detailed = false,
     ),
     CHAPTER_LIST(
         TDMR.strings.selector_step_chapter_list_title,
@@ -234,7 +235,6 @@ enum class SelectorWizardStep(
                 if (features.chapterListSeparatePage) add(CHAPTER_INDEX_LINK)
                 add(CHAPTER_LIST)
                 if (features.chapterListPagination) add(CHAPTER_LIST_PAGINATION)
-                add(CHAPTER_DATE)
             }
             add(CHAPTER_CONTENT)
             add(REVIEW)
@@ -248,9 +248,7 @@ data class SelectorConfig(
     var popularUrl: String = "",
     var latestUrl: String = "",
     var trendingSelector: String = "",
-    var trendingNovels: MutableList<String> = mutableListOf(),
     var newNovelsSelector: String = "",
-    var newNovels: MutableList<String> = mutableListOf(),
     var searchUrl: String = "",
     var searchKeyword: String = "",
     // Raw page-1 search URL (with the probe word) — paired with searchPage2Url to derive {page}.
@@ -260,8 +258,12 @@ data class SelectorConfig(
     var popularPage2Url: String = "",
     var latestPage2Url: String = "",
     var searchPage2Url: String = "",
-    // Followed-link pagination selector (the source follows these links itself).
+    // Followed-link pagination selector (fallback when the URL pattern can't be derived).
     var chapterListPaginationSelector: String = "",
+    // Chapter-list page 1/2 URLs. Diffed (and the novel path generalized to {novelUrl}) into a
+    // numbered-pagination template, the robust alternative to chasing a next-page button.
+    var chapterListPage1Url: String = "",
+    var chapterListPage2Url: String = "",
     // Details-page selector linking to a separate chapter-list page.
     var chapterIndexLinkSelector: String = "",
     var novelCoverSelector: String = "",
@@ -686,6 +688,8 @@ fun ElementSelectorScreen(
                         config.latestUrl.ifBlank { config.popularUrl } to currentUrl
                     SelectorWizardStep.SEARCH_PAGINATION ->
                         config.searchSampleUrl.ifBlank { config.searchUrl } to currentUrl
+                    SelectorWizardStep.CHAPTER_LIST_PAGINATION ->
+                        config.chapterListPage1Url.ifBlank { config.sampleNovelUrl } to currentUrl
                     else -> null
                 }
                 val paginationStatus = paginationPair
@@ -824,6 +828,10 @@ fun ElementSelectorScreen(
                             if (step == SelectorWizardStep.POPULAR_LIST && config.popularUrl.isBlank()) {
                                 config.popularUrl = currentUrl
                             }
+                            // Remember the chapter-list page-1 URL to diff against page 2 later.
+                            if (step == SelectorWizardStep.CHAPTER_LIST && config.chapterListPage1Url.isBlank()) {
+                                config.chapterListPage1Url = currentUrl
+                            }
                             if (selectedElements.isNotEmpty()) {
                                 val list = selectedElements.toList()
                                 detectItemSelector(list.map { it.selector }, list) { detected ->
@@ -861,6 +869,23 @@ fun ElementSelectorScreen(
                         }
                         SelectorWizardStep.SEARCH_PAGINATION -> {
                             config.searchPage2Url = currentUrl
+                            advance()
+                        }
+                        // Record the results page so search pagination can be diffed even when the
+                        // user searched manually instead of via the probe.
+                        SelectorWizardStep.SEARCH -> {
+                            if (config.searchSampleUrl.isBlank() &&
+                                currentUrl.trimEnd('/') != config.baseUrl.trimEnd('/')
+                            ) {
+                                config.searchSampleUrl = currentUrl
+                            }
+                            saveSelectionsForStep(step, selectedElements, config)
+                            advance()
+                        }
+                        // Page-2 URL of the chapter list (diffed into a {page} template).
+                        SelectorWizardStep.CHAPTER_LIST_PAGINATION -> {
+                            config.chapterListPage2Url = currentUrl
+                            saveSelectionsForStep(step, selectedElements, config)
                             advance()
                         }
                         SelectorWizardStep.NOVEL_DETAILS -> {
@@ -1157,7 +1182,7 @@ private fun LiveTestDialog(
         text = {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 if (obj == null) {
-                    Text("No result", style = MaterialTheme.typography.bodySmall)
+                    Text(stringResource(TDMR.strings.selector_no_result), style = MaterialTheme.typography.bodySmall)
                 } else {
                     val ok = obj.optBoolean("ok", false)
                     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -1850,7 +1875,7 @@ private fun relativize(full: String, listSel: String): String {
  * differing digits replaced by {page}. Mirrors ElementSelectorScreenModel.derivePagedFromPair so the
  * wizard can preview the same template that gets saved. Null if they don't differ by a number.
  */
-private fun derivePageTemplate(p1: String, p2: String): String? {
+internal fun derivePageTemplate(p1: String, p2: String): String? {
     if (p1.isBlank() || p2.isBlank() || p1 == p2) return null
     val maxLen = minOf(p1.length, p2.length)
     var pre = 0
@@ -1867,7 +1892,7 @@ private fun derivePageTemplate(p1: String, p2: String): String? {
  * page-1 URL), so the user can skip navigating latest to page 2 when the site paginates identically.
  * Handles the two dominant forms: a query param (`page=2`) and a path segment (`/page/2`).
  */
-private fun applyPagePattern(popularP1: String, popularP2: String, target: String): String? {
+internal fun applyPagePattern(popularP1: String, popularP2: String, target: String): String? {
     if (popularP1.isBlank() || popularP2.isBlank() || popularP1 == popularP2 || target.isBlank()) return null
     val maxLen = minOf(popularP1.length, popularP2.length)
     var pre = 0
@@ -1915,8 +1940,6 @@ private fun saveSelectionsForStep(
             // One tap = title/link only (cover skipped). Two taps = cover first, then title. List =
             // repeating item selector (DOM-detected when available); cover/title stored RELATIVE to
             // it so the source resolves them per item.
-            config.trendingNovels.clear()
-            config.trendingNovels.addAll(selectedElements.map { it.selector })
             if (selectedElements.isNotEmpty()) {
                 val listSel = detectedListSelector?.ifBlank { null } ?: deriveListSelector(selectedElements)
                 config.trendingSelector = listSel
@@ -1930,8 +1953,6 @@ private fun saveSelectionsForStep(
             }
         }
         SelectorWizardStep.LATEST_LIST -> {
-            config.newNovels.clear()
-            config.newNovels.addAll(selectedElements.map { it.selector })
             if (selectedElements.isNotEmpty()) {
                 config.newNovelsSelector = detectedListSelector?.ifBlank { null }
                     ?: deriveListSelector(selectedElements)
@@ -2294,22 +2315,6 @@ internal val ELEMENT_SELECTOR_JS = """
         highlightedElements = [];
     };
 
-    // Test a selector and return count of matching elements
-    window.testSelector = function(selector) {
-        try {
-            const elements = document.querySelectorAll(selector);
-            // Also highlight found elements
-            elements.forEach(el => {
-                el.classList.add('element-selector-highlight');
-                highlightedElements.push(el);
-            });
-            return elements.length;
-        } catch (e) {
-            console.error('Invalid selector:', selector);
-            return 0;
-        }
-    };
-
     // Auto-detect the main chapter text block: pick the element with the highest
     // text density (most characters that are not inside links/nav).
     window.autoDetectContent = function() {
@@ -2564,7 +2569,7 @@ internal val ELEMENT_SELECTOR_JS = """
  * Handles both raw and percent-encoded occurrences (including '+' for spaces), regardless of which
  * query parameter or path segment the site uses. Returns the template, or null if not found.
  */
-private fun deriveSearchUrl(url: String, baseUrl: String, userQuery: String): String? {
+internal fun deriveSearchUrl(url: String, baseUrl: String, userQuery: String): String? {
     if (userQuery.isBlank()) return null
 
     val baseHost = runCatching { java.net.URI(baseUrl.trimEnd('/')).host }.getOrNull()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreenModel.kt
@@ -74,9 +74,8 @@ class ElementSelectorScreenModel(
         val cardCover = selectorConfig.novelCoverSelector.ifBlank { null }
         val generate = features.chapterGenerateFromPattern
 
-        // Page 1 = the verbatim URL the user browsed. Page 2+ template = page1/page2 diff (handles
-        // ?page= vs /page/ alike). Each is gated by its section + pagination toggle so the saved
-        // config matches the boxes the user actually ticked (and round-trips to the editor).
+        // Page 1 = verbatim browsed URL; page 2+ = page1/page2 diff. Each gated by its section +
+        // pagination toggle so the saved config matches the ticked boxes and round-trips.
         val popularUrl = if (features.hasPopular) {
             selectorConfig.popularUrl.trim().ifBlank { baseUrl }.trimEnd('/')
         } else {
@@ -206,10 +205,7 @@ class ElementSelectorScreenModel(
         )
     }
 
-    /**
-     * Diffs two URLs that differ only by page number, returning the page-2 URL with the differing
-     * digits replaced by {page}. Works regardless of param vs path form. Null if they don't differ.
-     */
+    /** Diffs two URLs into the page-2 URL with the differing digits replaced by {page}. */
     private fun derivePagedFromPair(p1: String, p2: String): String? {
         if (p2.isBlank() || p1 == p2) return null
         val maxLen = minOf(p1.length, p2.length)
@@ -224,10 +220,8 @@ class ElementSelectorScreenModel(
     }
 
     /**
-     * Diffs the chapter-list page 1/2 URLs into a numbered template and generalizes the
-     * novel-specific path to {novelUrl}, so one pattern works for every novel (not just the sampled
-     * one). e.g. ("/series/abc/", "/series/abc/?page=2") -> "{novelUrl}/?page={page}". Null if the
-     * two URLs don't differ by a number.
+     * Diffs the chapter-list page 1/2 URLs into a numbered template, generalizing the novel path to
+     * {novelUrl}. e.g. ("/series/abc/", "/series/abc/?page=2") -> "{novelUrl}/?page={page}".
      */
     private fun deriveChapterListPagePattern(
         page1: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreenModel.kt
@@ -16,8 +16,6 @@ import eu.kanade.tachiyomi.source.custom.SourceTestResult
 import eu.kanade.tachiyomi.source.custom.SourceTestSection
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -30,8 +28,6 @@ class ElementSelectorScreenModel(
     private val initialSourceName: String = "",
     private val customSourceManager: CustomSourceManager = Injekt.get(),
 ) : StateScreenModel<ElementSelectorScreenModel.State>(State()) {
-
-    private val json = Json { prettyPrint = true }
 
     // ---- Wizard UI state, held here (not in the composable) so it survives Activity recreation
     // on rotation — the same reason the rest of the app keeps screen state in ScreenModels. The
@@ -47,107 +43,80 @@ class ElementSelectorScreenModel(
     val detectedListState = mutableStateMapOf<SelectorWizardStep, String>()
 
     data class State(
-        val isLoading: Boolean = false,
-        val sourceName: String = "",
-        val baseUrl: String = "",
-        val config: SelectorConfig = SelectorConfig(),
         val savedSuccessfully: Boolean = false,
         val error: String? = null,
-        // Preview data for confirmation UI
-        val previewData: StepPreviewData? = null,
     )
 
-    init {
-        mutableState.update {
-            it.copy(
-                sourceName = initialSourceName,
-                baseUrl = initialUrl,
-            )
-        }
-    }
-
-    fun updateSourceName(name: String) {
-        mutableState.update { it.copy(sourceName = name) }
-    }
-
-    fun updatePreviewData(preview: StepPreviewData) {
-        mutableState.update { it.copy(previewData = preview) }
-    }
-
-    fun clearPreview() {
-        mutableState.update { it.copy(previewData = null) }
-    }
-
-    fun saveConfig(config: SelectorConfig) {
+    fun saveConfig(config: SelectorConfig, features: SourceFeatures) {
         screenModelScope.launch {
-            mutableState.update { it.copy(isLoading = true) }
-
             try {
-                // Convert SelectorConfig to CustomSourceConfig
-                val sourceConfig = convertToCustomSourceConfig(config)
-
-                // Save via CustomSourceManager
-                val result = customSourceManager.createSource(sourceConfig)
-
-                result.fold(
-                    onSuccess = {
-                        mutableState.update {
-                            it.copy(
-                                isLoading = false,
-                                savedSuccessfully = true,
-                                config = config,
-                            )
-                        }
-                    },
-                    onFailure = { e ->
-                        mutableState.update {
-                            it.copy(
-                                isLoading = false,
-                                error = e.message,
-                            )
-                        }
-                    },
+                val sourceConfig = convertToCustomSourceConfig(config, features)
+                customSourceManager.createSource(sourceConfig).fold(
+                    onSuccess = { mutableState.update { it.copy(savedSuccessfully = true) } },
+                    onFailure = { e -> mutableState.update { it.copy(error = e.message) } },
                 )
             } catch (e: Exception) {
-                mutableState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = e.message,
-                    )
-                }
+                mutableState.update { it.copy(error = e.message) }
             }
         }
     }
 
-    private fun convertToCustomSourceConfig(selectorConfig: SelectorConfig): CustomSourceConfig {
+    private fun convertToCustomSourceConfig(
+        selectorConfig: SelectorConfig,
+        features: SourceFeatures,
+    ): CustomSourceConfig {
         val baseUrl = selectorConfig.baseUrl.trimEnd('/')
 
-        // Popular and search reuse the popular card layout. When popular was toggled off (latest-only
-        // setup), fall back to the latest list selector so those sections still resolve items instead
-        // of throwing "List selector is empty".
-        val primaryListSelector = selectorConfig.trendingSelector.ifBlank { selectorConfig.newNovelsSelector }
+        // The shared card selectors feed whichever listing(s) the user enabled. Popular falls back to
+        // the latest list selector for a latest-only setup.
+        val cardList = selectorConfig.trendingSelector.ifBlank { selectorConfig.newNovelsSelector }
+        val cardTitle = selectorConfig.novelTitleSelector.ifBlank { null }
+        val cardCover = selectorConfig.novelCoverSelector.ifBlank { null }
+        val generate = features.chapterGenerateFromPattern
 
         // Page 1 = the verbatim URL the user browsed. Page 2+ template = page1/page2 diff (handles
-        // ?page= vs /page/ alike). The source uses page1 for page 1 and the template afterwards, so
-        // the first page keeps or omits the page token exactly as the site does.
-        val popularUrl = selectorConfig.popularUrl.trim().ifBlank { baseUrl }.trimEnd('/')
-        val popularPagedUrl = derivePagedFromPair(popularUrl, selectorConfig.popularPage2Url.trim())
+        // ?page= vs /page/ alike). Each is gated by its section + pagination toggle so the saved
+        // config matches the boxes the user actually ticked (and round-trips to the editor).
+        val popularUrl = if (features.hasPopular) {
+            selectorConfig.popularUrl.trim().ifBlank { baseUrl }.trimEnd('/')
+        } else {
+            ""
+        }
+        val popularPagedUrl = if (features.hasPopular && features.popularPagination) {
+            derivePagedFromPair(popularUrl, selectorConfig.popularPage2Url.trim())
+        } else {
+            null
+        }
 
-        val hasLatest = selectorConfig.newNovelsSelector.isNotEmpty() ||
-            selectorConfig.latestPage2Url.isNotBlank()
-        val latestPage1 = selectorConfig.latestUrl.ifBlank { selectorConfig.popularUrl }.trim().trimEnd('/')
-        val latestUrl = if (hasLatest) latestPage1.ifBlank { popularUrl } else null
-        val latestPagedUrl = if (hasLatest) {
-            derivePagedFromPair(
-                latestPage1,
-                selectorConfig.latestPage2Url.trim(),
+        val latestUrl = if (features.hasLatest) {
+            selectorConfig.latestUrl.ifBlank { selectorConfig.popularUrl }.trim().trimEnd('/').ifBlank { baseUrl }
+        } else {
+            null
+        }
+        val latestPagedUrl = if (features.hasLatest && features.latestPagination) {
+            derivePagedFromPair(latestUrl.orEmpty(), selectorConfig.latestPage2Url.trim())
+        } else {
+            null
+        }
+
+        // Numbered chapter-list pagination template (preferred over the next-button selector).
+        val chapterPagedPattern = if (!generate && features.chapterListPagination) {
+            deriveChapterListPagePattern(
+                selectorConfig.chapterListPage1Url.ifBlank { selectorConfig.sampleNovelUrl },
+                selectorConfig.chapterListPage2Url,
+                baseUrl,
+                selectorConfig.sampleNovelUrl,
             )
         } else {
             null
         }
 
-        val searchUrl = selectorConfig.searchUrl.ifBlank { "$baseUrl/?s={query}" }
-        val searchPagedUrl = run {
+        val searchUrl = if (features.hasSearch) {
+            selectorConfig.searchUrl.ifBlank { "$baseUrl/?s={query}" }
+        } else {
+            ""
+        }
+        val searchPagedUrl = if (features.hasSearch && features.searchPagination) {
             val p1 = selectorConfig.searchSampleUrl.trim()
             val p2 = selectorConfig.searchPage2Url.trim()
             if (p1.isNotBlank() && p2.isNotBlank()) {
@@ -155,6 +124,8 @@ class ElementSelectorScreenModel(
             } else {
                 null
             }
+        } else {
+            null
         }
 
         return CustomSourceConfig(
@@ -171,30 +142,34 @@ class ElementSelectorScreenModel(
             latestPagedUrl = latestPagedUrl,
             searchPagedUrl = searchPagedUrl,
             sampleNovelUrl = selectorConfig.sampleNovelUrl.ifBlank { null },
-            testSearchQuery = selectorConfig.searchKeyword.ifBlank { null },
+            testSearchQuery = if (features.hasSearch) selectorConfig.searchKeyword.ifBlank { null } else null,
             selectors = SourceSelectors(
                 popular = MangaListSelectors(
-                    list = primaryListSelector,
-                    link = selectorConfig.novelTitleSelector.ifBlank { null },
-                    title = selectorConfig.novelTitleSelector.ifBlank { null },
-                    cover = selectorConfig.novelCoverSelector.ifBlank { null },
+                    list = if (features.hasPopular) cardList else "",
+                    link = if (features.hasPopular) cardTitle else null,
+                    title = if (features.hasPopular) cardTitle else null,
+                    cover = if (features.hasPopular) cardCover else null,
                 ),
-                // Separate latest selectors when the latest list layout was captured; otherwise
-                // latest falls back to popular at parse time.
-                latest = selectorConfig.newNovelsSelector.ifBlank { null }?.let {
+                latest = if (features.hasLatest) {
                     MangaListSelectors(
-                        list = it,
-                        link = selectorConfig.novelTitleSelector.ifBlank { null },
-                        title = selectorConfig.novelTitleSelector.ifBlank { null },
-                        cover = selectorConfig.novelCoverSelector.ifBlank { null },
+                        list = selectorConfig.newNovelsSelector.ifBlank { cardList },
+                        link = cardTitle,
+                        title = cardTitle,
+                        cover = cardCover,
                     )
+                } else {
+                    null
                 },
-                search = MangaListSelectors(
-                    list = primaryListSelector, // Usually same as popular
-                    link = selectorConfig.novelTitleSelector.ifBlank { null },
-                    title = selectorConfig.novelTitleSelector.ifBlank { null },
-                    cover = selectorConfig.novelCoverSelector.ifBlank { null },
-                ),
+                search = if (features.hasSearch) {
+                    MangaListSelectors(
+                        list = cardList,
+                        link = cardTitle,
+                        title = cardTitle,
+                        cover = cardCover,
+                    )
+                } else {
+                    null
+                },
                 details = DetailSelectors(
                     title = selectorConfig.novelPageTitleSelector,
                     description = selectorConfig.novelDescriptionSelector,
@@ -203,15 +178,24 @@ class ElementSelectorScreenModel(
                 ),
                 chapters = ChapterSelectors(
                     list = selectorConfig.chapterListSelector,
-                    link = selectorConfig.chapterLinkSelector.ifBlank { null },
-                    name = selectorConfig.chapterLinkSelector.ifBlank { null },
-                    date = selectorConfig.chapterDateSelector.ifBlank { null },
-                    nextPage = selectorConfig.chapterListPaginationSelector.ifBlank { null },
-                    indexLinkSelector = selectorConfig.chapterIndexLinkSelector.ifBlank { null },
-                    urlPattern = selectorConfig.chapterUrlPattern.ifBlank { null },
-                    countSelector = selectorConfig.chapterCountSelector.ifBlank { null },
-                    firstNumber = selectorConfig.chapterFirstNumber,
-                    lastNumber = selectorConfig.chapterLastNumber,
+                    link = if (generate) null else selectorConfig.chapterLinkSelector.ifBlank { null },
+                    name = if (generate) null else selectorConfig.chapterLinkSelector.ifBlank { null },
+                    date = if (generate) null else selectorConfig.chapterDateSelector.ifBlank { null },
+                    nextPage = if (!generate && features.chapterListPagination) {
+                        selectorConfig.chapterListPaginationSelector.ifBlank { null }
+                    } else {
+                        null
+                    },
+                    pagedUrlPattern = chapterPagedPattern,
+                    indexLinkSelector = if (!generate && features.chapterListSeparatePage) {
+                        selectorConfig.chapterIndexLinkSelector.ifBlank { null }
+                    } else {
+                        null
+                    },
+                    urlPattern = if (generate) selectorConfig.chapterUrlPattern.ifBlank { null } else null,
+                    countSelector = if (generate) selectorConfig.chapterCountSelector.ifBlank { null } else null,
+                    firstNumber = if (generate) selectorConfig.chapterFirstNumber else null,
+                    lastNumber = if (generate) selectorConfig.chapterLastNumber else null,
                 ),
                 content = ContentSelectors(
                     primary = selectorConfig.chapterContentSelector,
@@ -239,6 +223,33 @@ class ElementSelectorScreenModel(
         return p2.substring(0, pre) + templated + p2.substring(p2.length - suf)
     }
 
+    /**
+     * Diffs the chapter-list page 1/2 URLs into a numbered template and generalizes the
+     * novel-specific path to {novelUrl}, so one pattern works for every novel (not just the sampled
+     * one). e.g. ("/series/abc/", "/series/abc/?page=2") -> "{novelUrl}/?page={page}". Null if the
+     * two URLs don't differ by a number.
+     */
+    private fun deriveChapterListPagePattern(
+        page1: String,
+        page2: String,
+        baseUrl: String,
+        novelUrl: String,
+    ): String? {
+        val p1 = page1.trim()
+        val p2 = page2.trim()
+        if (p1.isBlank() || p2.isBlank()) return null
+        val templated = derivePagedFromPair(p1, p2) ?: return null
+        val base = baseUrl.trimEnd('/')
+        var rel = if (templated.startsWith(base)) templated.removePrefix(base) else templated
+        val novelRel = novelUrl.trim()
+            .let { if (it.startsWith(base)) it.removePrefix(base) else it }
+            .trimEnd('/')
+        if (novelRel.isNotBlank() && rel.startsWith(novelRel)) {
+            rel = "{novelUrl}" + rel.removePrefix(novelRel)
+        }
+        return rel.ifBlank { null }
+    }
+
     private fun insertQueryPlaceholder(url: String, query: String): String? {
         if (query.isBlank()) return null
         val enc = java.net.URLEncoder.encode(query, "UTF-8")
@@ -252,11 +263,12 @@ class ElementSelectorScreenModel(
 
     fun testConfig(
         selectorConfig: SelectorConfig,
+        features: SourceFeatures,
         section: SourceTestSection = SourceTestSection.ALL,
         onResult: (SourceTestResult) -> Unit,
     ) {
         screenModelScope.launch {
-            val result = customSourceManager.testSource(convertToCustomSourceConfig(selectorConfig), section)
+            val result = customSourceManager.testSource(convertToCustomSourceConfig(selectorConfig, features), section)
             onResult(result)
         }
     }
@@ -264,23 +276,4 @@ class ElementSelectorScreenModel(
     fun clearError() {
         mutableState.update { it.copy(error = null) }
     }
-
-    fun exportConfigAsJson(config: SelectorConfig): String {
-        return json.encodeToString(convertToCustomSourceConfig(config))
-    }
 }
-
-data class StepPreviewData(
-    val stepName: String,
-    val detectedTitle: String? = null,
-    val detectedUrl: String? = null,
-    val detectedImageUrl: String? = null,
-    val detectedDescription: String? = null,
-    val detectedChaptersTotal: Int? = null,
-    val detectedChapterFirstUrl: String? = null,
-    val detectedChapterLastUrl: String? = null,
-    val sampleContentStart: String? = null,
-    val sampleContentEnd: String? = null,
-    val searchResultsCount: Int? = null,
-    val sampleSearchResults: List<String>? = null,
-)

--- a/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
@@ -329,6 +329,70 @@ class CustomNovelSourceTest {
         )
     }
 
+    @Test
+    fun `derive generic chapter pattern uses last digit run and generalizes novel url`() {
+        // Two chapter URLs of the same novel; novel id "abc" must become the {novelUrl} placeholder
+        // so the pattern is portable to other novels.
+        val result = deriveGenericChapterPattern(
+            "https://example.com/novel/abc/chapter-1",
+            "https://example.com/novel/abc/chapter-450",
+            "https://example.com",
+            "https://example.com/novel/abc",
+        )
+        assertEquals(Triple("{novelUrl}/chapter-{n}", 1, 450), result)
+    }
+
+    @Test
+    fun `derive generic chapter pattern without novel url stays relative`() {
+        val result = deriveGenericChapterPattern(
+            "https://example.com/novel/abc/chapter-1",
+            "https://example.com/novel/abc/chapter-2",
+            "https://example.com",
+            null,
+        )
+        assertEquals(Triple("/novel/abc/chapter-{n}", 1, 2), result)
+    }
+
+    @Test
+    fun `derive generic chapter pattern returns null when no numeric difference`() {
+        assertEquals(
+            null,
+            deriveGenericChapterPattern(
+                "https://example.com/novel/abc/intro",
+                "https://example.com/novel/abc/intro",
+                "https://example.com",
+                "https://example.com/novel/abc",
+            ),
+        )
+    }
+
+    @Test
+    fun `apply novel url to pattern substitutes current novel path`() {
+        assertEquals(
+            "/series/xyz/chapter-{n}",
+            applyNovelUrlToPattern("{novelUrl}/chapter-{n}", "/series/xyz"),
+        )
+        // No placeholder = unchanged (legacy patterns).
+        assertEquals(
+            "/novel/abc/chapter-{n}",
+            applyNovelUrlToPattern("/novel/abc/chapter-{n}", "/series/xyz"),
+        )
+    }
+
+    @Test
+    fun `generated chapter entries build numbered urls and names`() {
+        val entries = generatedChapterEntries("/series/xyz/chapter-{n}", 1, 3, null)
+        assertEquals(3, entries.size)
+        assertEquals("/series/xyz/chapter-1", entries.first().url)
+        assertEquals("Chapter 1", entries.first().name)
+        assertEquals("Chapter 3", entries.last().name)
+
+        val custom = generatedChapterEntries("/c/{n}", 5, 5, "Ep {n}")
+        assertEquals(1, custom.size)
+        assertEquals("Ep 5", custom.first().name)
+        assertEquals(5f, custom.first().number)
+    }
+
     // Helper function that mirrors buildAbsoluteUrl logic for testing
     private fun buildAbsoluteUrlForTest(url: String?, baseUrl: String): String {
         val trimmedUrl = url?.trim().orEmpty()

--- a/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
@@ -393,6 +393,26 @@ class CustomNovelSourceTest {
         assertEquals(5f, custom.first().number)
     }
 
+    @Test
+    fun `parse status uses custom mapping before english fallback`() {
+        // Non-English label resolved via the user mapping.
+        assertEquals(
+            SManga.COMPLETED,
+            parseCustomSourceStatus("完结", mapOf("完结" to "completed")),
+        )
+        // Mapping is case-insensitive and substring-based.
+        assertEquals(
+            SManga.ONGOING,
+            parseCustomSourceStatus("En cours de publication", mapOf("en cours" to "ongoing")),
+        )
+        // Built-in English keywords still work without a mapping.
+        assertEquals(SManga.ONGOING, parseCustomSourceStatus("Ongoing"))
+        assertEquals(SManga.COMPLETED, parseCustomSourceStatus("Completed"))
+        // Unknown text and blank are UNKNOWN.
+        assertEquals(SManga.UNKNOWN, parseCustomSourceStatus("???", mapOf("done" to "completed")))
+        assertEquals(SManga.UNKNOWN, parseCustomSourceStatus(null))
+    }
+
     // Helper function that mirrors buildAbsoluteUrl logic for testing
     private fun buildAbsoluteUrlForTest(url: String?, baseUrl: String): String {
         val trimmedUrl = url?.trim().orEmpty()

--- a/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomSourceManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomSourceManagerTest.kt
@@ -1,12 +1,144 @@
 package eu.kanade.tachiyomi.source.custom
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
 
 class CustomSourceManagerTest {
+
+    private fun config(
+        name: String = "Example",
+        baseUrl: String = "https://example.com",
+        id: Long? = 1L,
+        popularUrl: String = "https://example.com/popular/{page}",
+        latestUrl: String? = null,
+        searchUrl: String = "https://example.com/?s={query}",
+        popularList: String = ".novel-item",
+        latestList: String? = null,
+        searchList: String? = null,
+        detailsTitle: String = "h1.title",
+        chaptersList: String = ".chapter-list li",
+        chaptersPattern: String? = null,
+        contentPrimary: String = ".chapter-content",
+        basedOnSourceId: Long? = null,
+    ) = CustomSourceConfig(
+        name = name,
+        baseUrl = baseUrl,
+        id = id,
+        popularUrl = popularUrl,
+        latestUrl = latestUrl,
+        searchUrl = searchUrl,
+        basedOnSourceId = basedOnSourceId,
+        selectors = SourceSelectors(
+            popular = MangaListSelectors(list = popularList),
+            latest = latestList?.let { MangaListSelectors(list = it) },
+            search = searchList?.let { MangaListSelectors(list = it) },
+            details = DetailSelectors(title = detailsTitle),
+            chapters = ChapterSelectors(list = chaptersList, urlPattern = chaptersPattern),
+            content = ContentSelectors(primary = contentPrimary),
+        ),
+    )
+
+    @Test
+    fun `valid full config has no errors`() {
+        assertTrue(customSourceValidationErrors(config()).isEmpty())
+    }
+
+    @Test
+    fun `latest-only config does not require popular or search url`() {
+        // Popular and search blank, only latest set: previously this wrongly failed with
+        // "Popular URL is required" / "Search URL is required".
+        val errors = customSourceValidationErrors(
+            config(
+                popularUrl = "",
+                searchUrl = "",
+                latestUrl = "https://example.com/latest/{page}",
+                latestList = ".novel-item",
+            ),
+        )
+        assertTrue(errors.isEmpty(), "Unexpected errors: $errors")
+    }
+
+    @Test
+    fun `config with no listing url fails`() {
+        val errors = customSourceValidationErrors(config(popularUrl = "", searchUrl = "", latestUrl = null))
+        assertTrue(errors.any { it.contains("listing URL") })
+    }
+
+    @Test
+    fun `chapter url pattern satisfies chapter requirement without list selector`() {
+        val errors = customSourceValidationErrors(
+            config(chaptersList = "", chaptersPattern = "{novelUrl}/chapter-{n}"),
+        )
+        assertTrue(errors.isEmpty(), "Unexpected errors: $errors")
+    }
+
+    @Test
+    fun `missing chapter list and pattern fails`() {
+        val errors = customSourceValidationErrors(config(chaptersList = "", chaptersPattern = null))
+        assertTrue(errors.any { it.contains("chapter") })
+    }
+
+    @Test
+    fun `extension-based config skips selector requirements`() {
+        val errors = customSourceValidationErrors(
+            config(
+                popularUrl = "",
+                searchUrl = "",
+                popularList = "",
+                detailsTitle = "",
+                chaptersList = "",
+                contentPrimary = "",
+                basedOnSourceId = 999L,
+            ),
+        )
+        assertTrue(errors.isEmpty(), "Unexpected errors: $errors")
+    }
+
+    @Test
+    fun `duplicate name and base url are detected against existing`() {
+        val existing = listOf(config(name = "Dup", baseUrl = "https://dup.com", id = 1L))
+        val incoming = config(name = "Dup", baseUrl = "https://dup.com", id = 2L)
+        val errors = customSourceValidationErrors(incoming, existing)
+        assertTrue(errors.any { it.contains("name already exists") })
+        assertTrue(errors.any { it.contains("base URL already exists") })
+    }
+
+    @Test
+    fun `same id is not treated as duplicate of itself`() {
+        val existing = listOf(config(name = "Self", baseUrl = "https://self.com", id = 7L))
+        val incoming = config(name = "Self", baseUrl = "https://self.com", id = 7L)
+        assertFalse(customSourceValidationErrors(incoming, existing).any { it.contains("already exists") })
+    }
+
+    private val json = kotlinx.serialization.json.Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `blank template passes validation`() {
+        assertTrue(customSourceValidationErrors(customSourceBlankTemplate()).isEmpty())
+    }
+
+    @Test
+    fun `blank template json round-trips`() {
+        val encoded = json.encodeToString(
+            CustomSourceConfig.serializer(),
+            customSourceBlankTemplate(),
+        )
+        val decoded = json.decodeFromString(CustomSourceConfig.serializer(), encoded)
+        assertEquals(customSourceBlankTemplate(), decoded)
+        // Removed fields must not appear in the exported template.
+        assertFalse(encoded.contains("useCloudflare"))
+        assertFalse(encoded.contains("sourceType"))
+        assertFalse(encoded.contains("chapterAjax"))
+        assertFalse(encoded.contains("novelId"))
+    }
 
     @Test
     fun `stable id is derived from name and base url`() {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/customsource/SelectorUrlAlgorithmsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/customsource/SelectorUrlAlgorithmsTest.kt
@@ -1,0 +1,84 @@
+package eu.kanade.tachiyomi.ui.customsource
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SelectorUrlAlgorithmsTest {
+
+    @Test
+    fun `derivePageTemplate handles query param form`() {
+        assertEquals(
+            "https://site.com/list?page={page}",
+            derivePageTemplate("https://site.com/list?page=1", "https://site.com/list?page=2"),
+        )
+    }
+
+    @Test
+    fun `derivePageTemplate handles path segment form`() {
+        assertEquals(
+            "https://site.com/page/{page}",
+            derivePageTemplate("https://site.com/page/1", "https://site.com/page/2"),
+        )
+    }
+
+    @Test
+    fun `derivePageTemplate returns null when urls are identical or non-numeric`() {
+        assertNull(derivePageTemplate("https://site.com/list", "https://site.com/list"))
+        assertNull(derivePageTemplate("https://site.com/a", "https://site.com/b"))
+        assertNull(derivePageTemplate("", "https://site.com/page/2"))
+    }
+
+    @Test
+    fun `applyPagePattern reuses query token when page-1 had no page param`() {
+        // The inserted token must contain the full "page=2" for the query form to trigger; this
+        // happens when page 1 has no param and page 2 adds one.
+        assertEquals(
+            "https://site.com/latest?page=2",
+            applyPagePattern("https://site.com/list", "https://site.com/list?page=2", "https://site.com/latest"),
+        )
+    }
+
+    @Test
+    fun `applyPagePattern reuses path token on the latest url`() {
+        assertEquals(
+            "https://site.com/latest/2",
+            applyPagePattern("https://site.com/list/1", "https://site.com/list/2", "https://site.com/latest"),
+        )
+    }
+
+    @Test
+    fun `applyPagePattern appends with ampersand when target already has a query`() {
+        assertEquals(
+            "https://site.com/latest?lang=en&page=2",
+            applyPagePattern(
+                "https://site.com/list",
+                "https://site.com/list?page=2",
+                "https://site.com/latest?lang=en",
+            ),
+        )
+    }
+
+    @Test
+    fun `deriveSearchUrl replaces raw query occurrence with placeholder`() {
+        assertEquals(
+            "https://site.com/?s={query}",
+            deriveSearchUrl("https://site.com/?s=sword", "https://site.com", "sword"),
+        )
+    }
+
+    @Test
+    fun `deriveSearchUrl matches percent-encoded multi-word query`() {
+        assertEquals(
+            "https://site.com/search/{query}",
+            deriveSearchUrl("https://site.com/search/sword%20art", "https://site.com", "sword art"),
+        )
+    }
+
+    @Test
+    fun `deriveSearchUrl returns null when host differs or query absent`() {
+        assertNull(deriveSearchUrl("https://other.com/?s=sword", "https://site.com", "sword"))
+        assertNull(deriveSearchUrl("https://site.com/?s=other", "https://site.com", "sword"))
+        assertNull(deriveSearchUrl("https://site.com/?s=sword", "https://site.com", ""))
+    }
+}

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -706,8 +706,8 @@
     <string name="selector_step_trending_desc">Navigate to the trending/popular novels section</string>
     <string name="selector_step_trending_detail">Find the section showing popular or trending novels on the homepage</string>
     <string name="selector_step_novel_card_title">Popular list</string>
-    <string name="selector_step_novel_card_desc">On the popular/trending page, tap a novel\'s COVER, then its TITLE link (in that order).</string>
-    <string name="selector_step_novel_card_detail">These two selectors drive how novels show in the popular, latest and search lists. Tap the title text inside the link; you can switch to its parent &lt;a&gt; in the next dialog.</string>
+    <string name="selector_step_novel_card_desc">On the popular/trending page, tap a novel\'s TITLE link. To also grab thumbnails, tap the COVER first, then the title.</string>
+    <string name="selector_step_novel_card_detail">If the title tap only catches the inner text, switch to its parent &lt;a&gt; in the next dialog so links resolve. The cover is optional: skip it and the lists just show no thumbnails.</string>
     <string name="selector_step_trending_novels_title">Trending Novels</string>
     <string name="selector_step_trending_novels_desc">Select 3 novel items: Click on TITLE element of each novel</string>
     <string name="selector_step_trending_novels_detail">Click on the title text of 3 different trending novels.</string>
@@ -718,8 +718,8 @@
     <string name="selector_step_new_novels_desc">Navigate to the latest/updates page, then continue. Only tap cover+title if its layout differs from popular.</string>
     <string name="selector_step_new_novels_detail">Latest reuses the popular card selectors by default — you just need to land on the latest page so its URL is captured.</string>
     <string name="selector_step_search_title">Search (optional)</string>
-    <string name="selector_step_search_desc">Tap \"Set up search\", type any word, then search for it on the site — the address is captured automatically.</string>
-    <string name="selector_step_search_detail">Use a word you know has results. The captured address becomes the search template; the test then parses the results currently shown.</string>
+    <string name="selector_step_search_desc">Tap \"Set up search\", type a word, then run it on the site. The address is captured automatically. Many sites match case-sensitively, so type the word exactly.</string>
+    <string name="selector_step_search_detail">Your word is swapped for {query} in the captured address to build the search template. Pick a word that returns results, and mind capitalization since some sites treat \"Sword\" and \"sword\" differently.</string>
     <string name="selector_step_search_url_title">Search URL Pattern</string>
     <string name="selector_step_search_url_desc">Identify where the search keyword appears in the URL</string>
     <string name="selector_step_search_url_detail">Look for your search term in the URL. Common patterns: ?s=keyword, ?q=keyword, /search/keyword</string>
@@ -743,7 +743,7 @@
     <string name="selector_step_chapter_pagination_detail">For chapter lists that span multiple pages.</string>
     <string name="selector_step_chapter_range_title">Chapter range</string>
     <string name="selector_step_chapter_range_desc">Tap the FIRST chapter, then the LAST chapter. Optionally tap an element showing the total chapter count.</string>
-    <string name="selector_step_chapter_range_detail">The chapter URLs are read as a numbered pattern (e.g. /chapter-12); the whole list is generated from the range, with no page scraping.</string>
+    <string name="selector_step_chapter_range_detail">Chapter URLs are read as a numbered pattern (e.g. /chapter-12) and the whole list is generated from the range. Tap the true first and last chapters even if they sit on different pages of the list (navigate there first); order and gaps between them don\'t matter, only the two numbers.</string>
     <string name="selector_step_chapter_date_title">Chapter date (optional)</string>
     <string name="selector_step_chapter_date_desc">Tap a chapter\'s upload date, or continue to skip.</string>
     <string name="selector_step_chapter_date_detail">Captures the per-chapter date selector. Skip if the list shows no dates.</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -282,8 +282,6 @@
     <string name="selector_selection_on">Selection ON</string>
     <string name="selector_select_element">Select Element</string>
     <string name="selector_tap_to_select">Tap an element to select it</string>
-    <string name="selector_elements_selected">%d element(s) selected</string>
-    <string name="selector_clear_selections">Clear selections</string>
     <string name="selector_selected_elements">Selected Elements</string>
     <string name="selector_selected_text">Selected Text:</string>
     <string name="selector_select_parent">Select Parent Element:</string>
@@ -296,6 +294,7 @@
     <string name="selector_setup_search">Set up search</string>
     <string name="selector_auto_detect">Auto-detect</string>
     <string name="selector_step_help">Step help</string>
+    <string name="selector_no_result">No result</string>
     <string name="selector_search_captured">Search captured: %s</string>
     <string name="selector_pagination_detected">Detected page pattern: %s</string>
     <string name="selector_reuse_popular_pagination">Same as popular</string>
@@ -317,7 +316,6 @@
     <string name="selector_feature_popular">Popular / trending list</string>
     <string name="selector_feature_latest">Latest updates list</string>
     <string name="selector_feature_search">Search</string>
-    <string name="selector_feature_pagination">Pagination (more pages)</string>
     <string name="selector_feature_popular_pagination">Popular has multiple pages</string>
     <string name="selector_feature_latest_pagination">Latest has multiple pages</string>
     <string name="selector_feature_search_pagination">Search has multiple pages</string>
@@ -610,6 +608,8 @@
     <string name="custom_source_basic_info">Basic Information</string>
     <string name="custom_source_source_name_required">Source Name *</string>
     <string name="custom_source_base_url_required">Base URL *</string>
+    <string name="custom_source_language_label">Language code (e.g. en, ja, zh)</string>
+    <string name="custom_source_not_based">Not based on another source</string>
     <string name="custom_source_options">Source Options</string>
     <string name="custom_source_reverse_chapters">Reverse Chapter Order</string>
     <string name="custom_source_reverse_chapters_desc">Enable if chapters are listed newest first</string>
@@ -620,7 +620,6 @@
     <string name="custom_source_manga_requires_base">Manga sources must be based on an installed extension. Pick a base source.</string>
     <string name="custom_source_base_on_extension">Base on Extension</string>
     <string name="custom_source_base_on_extension_desc">Create a custom source that delegates to an installed extension with a different name/URL</string>
-    <string name="custom_source_pick_extension">Pick Extension Source</string>
     <string name="custom_source_pick_extension_hint">Select an installed novel extension to base your custom source on. You can override the name and base URL.</string>
     <string name="custom_source_no_extensions">No novel extensions installed. Install extensions from the Extensions tab first.</string>
     <string name="custom_source_url_patterns">URL Patterns</string>
@@ -631,7 +630,6 @@
     <string name="custom_source_search_url">Search URL *</string>
     <string name="custom_source_search_url_hint">{baseUrl}/search?q={query}&amp;page={page}</string>
     <string name="custom_source_css_selectors">CSS Selectors</string>
-    <string name="custom_source_css_selectors_help">Use browser DevTools to find CSS selectors</string>
     <string name="custom_source_novel_list">Novel List (Popular/Latest)</string>
     <string name="custom_source_list_item_selector">List Item Selector *</string>
     <string name="custom_source_list_item_hint">.novel-item, .book-card</string>
@@ -705,39 +703,24 @@
     <string name="custom_source_export_subject">Custom Source: %s</string>
 
     <!-- Custom Source - WebView Element Selector Wizard -->
-    <string name="selector_step_trending_title">Trending Section</string>
-    <string name="selector_step_trending_desc">Navigate to the trending/popular novels section</string>
-    <string name="selector_step_trending_detail">Find the section showing popular or trending novels on the homepage</string>
     <string name="selector_step_novel_card_title">Popular list</string>
     <string name="selector_step_novel_card_desc">On the popular/trending page, tap a novel\'s TITLE link. To also grab thumbnails, tap the COVER first, then the title.</string>
     <string name="selector_step_novel_card_detail">If the title tap only catches the inner text, switch to its parent &lt;a&gt; in the next dialog so links resolve. The cover is optional: skip it and the lists just show no thumbnails.</string>
-    <string name="selector_step_trending_novels_title">Trending Novels</string>
-    <string name="selector_step_trending_novels_desc">Select 3 novel items: Click on TITLE element of each novel</string>
-    <string name="selector_step_trending_novels_detail">Click on the title text of 3 different trending novels.</string>
-    <string name="selector_step_new_section_title">New Novels Section</string>
-    <string name="selector_step_new_section_desc">Navigate to the new/latest novels section</string>
-    <string name="selector_step_new_section_detail">Find the section showing recently updated novels</string>
     <string name="selector_step_new_novels_title">Latest list</string>
     <string name="selector_step_new_novels_desc">Navigate to the latest/updates page, then continue. Only tap cover+title if its layout differs from popular.</string>
     <string name="selector_step_new_novels_detail">Latest reuses the popular card selectors by default — you just need to land on the latest page so its URL is captured.</string>
     <string name="selector_step_search_title">Search (optional)</string>
-    <string name="selector_step_search_desc">Tap \"Set up search\", type a word, then run it on the site. The address is captured automatically. Many sites match case-sensitively, so type the word exactly.</string>
+    <string name="selector_step_search_desc">Tap \"Set up search\", type a word, then run it on the site.</string>
     <string name="selector_step_search_detail">Your word is swapped for {query} in the captured address to build the search template. Pick a word that returns results, and mind capitalization since some sites treat \"Sword\" and \"sword\" differently.</string>
-    <string name="selector_step_search_url_title">Search URL Pattern</string>
-    <string name="selector_step_search_url_desc">Identify where the search keyword appears in the URL</string>
-    <string name="selector_step_search_url_detail">Look for your search term in the URL. Common patterns: ?s=keyword, ?q=keyword, /search/keyword</string>
     <string name="selector_step_pagination_title">Go to page 2</string>
     <string name="selector_step_pagination_desc">Open page 2 of this list (via the site\'s pagination), then continue.</string>
     <string name="selector_step_pagination_detail">The page-2 address is compared with page 1 to learn the page pattern — works for ?page= and /page/ styles alike. Continue without going to page 2 to leave it single-page.</string>
-    <string name="selector_step_novel_page_title">Novel Details Page</string>
-    <string name="selector_step_novel_page_desc">Click on a novel to open its details page</string>
-    <string name="selector_step_novel_page_detail">Navigate to any novel\'s main page</string>
     <string name="selector_step_novel_details_title">Novel Details</string>
     <string name="selector_step_novel_details_desc">Select in order: 1) Title, 2) Description/Summary, 3) Cover image, then 4+) any number of Tag/Genre elements (optional, merged together)</string>
-    <string name="selector_step_novel_details_detail">Select each element that shows novel information on the details page</string>
+    <string name="selector_step_novel_details_detail">Tags are merged into one genre string; pick as many as you want.</string>
     <string name="selector_step_chapter_list_title">Chapter List</string>
     <string name="selector_step_chapter_list_desc">Select chapter items: Click on the TITLE/LINK of chapters</string>
-    <string name="selector_step_chapter_list_detail">Select at least one chapter item (more improves accuracy)</string>
+    <string name="selector_step_chapter_list_detail">One chapter is enough; more improves selector accuracy.</string>
     <string name="selector_step_chapter_index_title">Chapter list link</string>
     <string name="selector_step_chapter_index_desc">On the novel page, tap the link that opens the full chapter list / table of contents.</string>
     <string name="selector_step_chapter_index_detail">Use this when chapters live on a separate page. The source follows this link to read them.</string>
@@ -745,50 +728,24 @@
     <string name="selector_step_chapter_pagination_desc">Tap the \'next page\' link of the chapter list, or continue to skip.</string>
     <string name="selector_step_chapter_pagination_detail">For chapter lists that span multiple pages.</string>
     <string name="selector_step_chapter_range_title">Chapter range</string>
-    <string name="selector_step_chapter_range_desc">Tap the FIRST chapter, then any other chapter (this learns the URL pattern). Then tap the element showing the total chapter count so each novel loads its own length.</string>
-    <string name="selector_step_chapter_range_detail">The two chapter taps only locate the number in the URL (e.g. /chapter-12); the start is the lower of the two and they can be on different pages of a paged or newest-first list. The END comes from the count element, read fresh on every novel\'s page, so each novel loads the right number of chapters. Without a count element the list is capped at the highest number you tapped, which only fits the novel you sampled.</string>
+    <string name="selector_step_chapter_range_desc">Tap two chapters (any two), then the element showing the total chapter count.</string>
+    <string name="selector_step_chapter_range_detail">The two taps learn the numbered URL; the count element sets each novel\'s length.</string>
     <string name="selector_step_chapter_date_title">Chapter date (optional)</string>
     <string name="selector_step_chapter_date_desc">Tap a chapter\'s upload date, or continue to skip.</string>
     <string name="selector_step_chapter_date_detail">Captures the per-chapter date selector. Skip if the list shows no dates.</string>
-    <string name="selector_step_chapter_page_title">Chapter Page</string>
-    <string name="selector_step_chapter_page_desc">Open a chapter to identify the content element</string>
-    <string name="selector_step_chapter_page_detail">Click on any chapter to open its reading page</string>
     <string name="selector_step_chapter_content_title">Chapter Content</string>
     <string name="selector_step_chapter_content_desc">Select the main text container element</string>
-    <string name="selector_step_chapter_content_detail">Click on the element containing the actual chapter text/content</string>
-    <string name="selector_step_complete_title">Complete</string>
-    <string name="selector_step_complete_desc">Review and save your custom source configuration</string>
+    <string name="selector_step_chapter_content_detail">Pick the text container; boilerplate (ads, nav) is stripped automatically.</string>
     <string name="selector_step_complete_detail">Verify your selections and save</string>
 
     <!-- Custom Source UI -->
     <string name="custom_source_create_title">Create Custom Source</string>
-    <string name="custom_source_create_subtitle">Build your own novel source by selecting elements from a website</string>
-    <string name="custom_source_method_guided_title">Guided WebView Selector</string>
-    <string name="custom_source_method_guided_desc">Navigate to a novel website and select elements step-by-step</string>
-    <string name="custom_source_method_template_title">Start From an Installed Source</string>
-    <string name="custom_source_method_template_desc">Pick an installed KT/JS source to prefill the URL and name, then build with the selector</string>
-    <string name="custom_source_method_repos_title">Manage Saved Repositories</string>
-    <string name="custom_source_method_repos_desc">Open Kotlin/JS repo management before building a source</string>
-    <string name="custom_source_steps_intro">The guided selector will walk you through:</string>
-    <string name="custom_source_step_1">1. Selecting trending/popular novels section</string>
-    <string name="custom_source_step_2">2. Selecting new/latest novels section</string>
-    <string name="custom_source_step_3">3. Setting up search functionality</string>
-    <string name="custom_source_step_4">4. Identifying pagination patterns</string>
-    <string name="custom_source_step_5">5. Selecting novel card elements (cover, title)</string>
-    <string name="custom_source_step_6">6. Selecting novel details (description, tags)</string>
-    <string name="custom_source_step_7">7. Selecting chapter list elements</string>
-    <string name="custom_source_step_8">8. Selecting chapter content area</string>
     <string name="custom_source_url_dialog_title">Enter Website URL</string>
-    <string name="custom_source_url_dialog_message">Enter the URL of the novel website you want to create a source for:</string>
     <string name="custom_source_url_label">Website URL</string>
     <string name="custom_source_start_wizard">Start Setup</string>
-    <string name="custom_source_choose_installed">Choose Installed Source</string>
-    <string name="custom_source_choose_installed_desc">Select an installed source, then optionally override name and URL.</string>
-    <string name="custom_source_choose_installed_empty">No installed KT/JS catalogue sources with HTTP base URLs were found.</string>
     <string name="custom_source_source_name">Source name</string>
     <string name="custom_source_base_url">Base URL</string>
     <string name="custom_source_pick_from_site">Pick from website</string>
-    <string name="custom_source_use_template">Continue</string>
     <string name="custom_source_import_dialog_title">Import source</string>
     <string name="custom_source_import_paste_label">Paste source JSON</string>
     <string name="custom_source_import_from_file">From file</string>
@@ -808,7 +765,6 @@
     <string name="custom_sources_use_webview_selector">Use WebView Element Selector</string>
     <string name="custom_sources_use_webview_selector_summary">Guided setup to select elements visually</string>
     <string name="custom_sources_open_webview_wizard">Open WebView Setup</string>
-    <string name="custom_selector_skip">Skip</string>
     <string name="custom_selector_previous">Previous</string>
     <string name="custom_selector_next_step">Next Step</string>
     <string name="custom_selector_save_source">Save Source</string>
@@ -816,7 +772,6 @@
     <string name="custom_selector_css_selector">CSS Selector</string>
     <string name="custom_selector_save_custom_source">Save Custom Source</string>
     <string name="custom_selector_source_name_required">Source Name *</string>
-    <string name="custom_selector_select_parent_format">Select Parent &lt;%1$s&gt;</string>
     <!-- Translation UI strings -->
     <string name="action_retranslate">Retranslate</string>
     <string name="action_delete_translation">Delete translation</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -295,6 +295,7 @@
     <string name="selector_base_url_format">Base URL: %s</string>
     <string name="selector_setup_search">Set up search</string>
     <string name="selector_auto_detect">Auto-detect</string>
+    <string name="selector_step_help">Step help</string>
     <string name="selector_search_captured">Search captured: %s</string>
     <string name="selector_pagination_detected">Detected page pattern: %s</string>
     <string name="selector_reuse_popular_pagination">Same as popular</string>
@@ -661,6 +662,24 @@
     <string name="custom_source_chapter_content">Chapter Content</string>
     <string name="custom_source_content_selector">Content Selector *</string>
     <string name="custom_source_content_selector_hint">.chapter-content, #content</string>
+    <string name="custom_source_artist_selector">Artist Selector</string>
+    <string name="custom_source_status_selector">Status Selector</string>
+    <string name="custom_source_status_mapping">Status Mapping (word=ongoing, word=completed)</string>
+    <string name="custom_source_status_mapping_desc">Optional. Map this site\'s status words to ongoing/completed/hiatus/cancelled.</string>
+    <string name="custom_source_chapter_name_template">Chapter Name Template</string>
+    <string name="custom_source_chapter_name_template_desc">Use {n} for the chapter number.</string>
+    <string name="custom_source_chapter_url_pattern_desc">Use {n} for the chapter number, and {novelUrl} for the novel path so the pattern works across novels.</string>
+    <string name="custom_source_remove_selectors">Elements to Remove</string>
+    <string name="custom_source_remove_selectors_desc">Comma-separated selectors stripped from the content before display.</string>
+    <string name="custom_source_advanced">Advanced</string>
+    <string name="custom_source_date_format">Chapter Date Format</string>
+    <string name="custom_source_date_format_desc">Optional. Java SimpleDateFormat pattern, e.g. MMM d, yyyy. Needed for worded dates.</string>
+    <string name="custom_source_headers">Custom Headers</string>
+    <string name="custom_source_headers_desc">One per line, e.g. Referer: https://example.com</string>
+    <string name="custom_source_test_search_query">Test Search Query</string>
+    <string name="custom_source_test_search_query_desc">Optional. Query used when testing this source.</string>
+    <string name="custom_source_sample_novel_url">Sample Novel URL</string>
+    <string name="custom_source_sample_novel_url_desc">Optional. A novel details-page URL. Lets the reading test open a known novel without using a listing.</string>
     <string name="custom_source_save">Save Source</string>
 
     <!-- Custom Source - Import/Export -->

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -610,8 +610,6 @@
     <string name="custom_source_source_name_required">Source Name *</string>
     <string name="custom_source_base_url_required">Base URL *</string>
     <string name="custom_source_options">Source Options</string>
-    <string name="custom_source_use_cloudflare">Use Cloudflare Bypass</string>
-    <string name="custom_source_use_cloudflare_desc">Enable for sites protected by Cloudflare</string>
     <string name="custom_source_reverse_chapters">Reverse Chapter Order</string>
     <string name="custom_source_reverse_chapters_desc">Enable if chapters are listed newest first</string>
     <string name="custom_source_post_search">Use POST for Search</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -648,8 +648,11 @@
     <string name="custom_source_chapter_index_selector">Chapter list link selector (separate page)</string>
     <string name="custom_source_chapter_url_pattern">Chapter URL pattern (use {n})</string>
     <string name="custom_source_chapter_count_selector">Chapter count selector (total)</string>
+    <string name="custom_source_chapter_count_selector_desc">Read on each novel\'s page to set its length. Preferred, so the source works for every novel.</string>
     <string name="custom_source_chapter_first_number">First chapter number</string>
+    <string name="custom_source_chapter_first_number_desc">Numbering start, usually 1 (sometimes 0).</string>
     <string name="custom_source_chapter_last_number">Last chapter number</string>
+    <string name="custom_source_chapter_last_number_desc">Fallback only. A fixed value applies to every novel, so it fits single-novel sources.</string>
     <string name="custom_source_content_fallbacks">Content fallback selectors (comma-separated)</string>
     <string name="custom_source_novel_details">Novel Details</string>
     <string name="custom_source_title_selector_required">Title Selector *</string>
@@ -742,8 +745,8 @@
     <string name="selector_step_chapter_pagination_desc">Tap the \'next page\' link of the chapter list, or continue to skip.</string>
     <string name="selector_step_chapter_pagination_detail">For chapter lists that span multiple pages.</string>
     <string name="selector_step_chapter_range_title">Chapter range</string>
-    <string name="selector_step_chapter_range_desc">Tap the FIRST chapter, then the LAST chapter. Optionally tap an element showing the total chapter count.</string>
-    <string name="selector_step_chapter_range_detail">Chapter URLs are read as a numbered pattern (e.g. /chapter-12) and the whole list is generated from the range. Tap the true first and last chapters even if they sit on different pages of the list (navigate there first); order and gaps between them don\'t matter, only the two numbers.</string>
+    <string name="selector_step_chapter_range_desc">Tap the FIRST chapter, then any other chapter (this learns the URL pattern). Then tap the element showing the total chapter count so each novel loads its own length.</string>
+    <string name="selector_step_chapter_range_detail">The two chapter taps only locate the number in the URL (e.g. /chapter-12); the start is the lower of the two and they can be on different pages of a paged or newest-first list. The END comes from the count element, read fresh on every novel\'s page, so each novel loads the right number of chapters. Without a count element the list is capped at the highest number you tapped, which only fits the novel you sampled.</string>
     <string name="selector_step_chapter_date_title">Chapter date (optional)</string>
     <string name="selector_step_chapter_date_desc">Tap a chapter\'s upload date, or continue to skip.</string>
     <string name="selector_step_chapter_date_detail">Captures the per-chapter date selector. Skip if the list shows no dates.</string>


### PR DESCRIPTION
Chapters
- Chapter-list pagination: derive a numbered {novelUrl}?page={page} template from page1/page2 diff, preferred over a next-button.
- Generated chapter mode: added {novelUrl} placeholder.
- Per-novel chapter count, configurable first/last number and name template.


Editor
- Added fields previously exclusive to json.
UI:
- made webview more compact, added help notes

added more tests.