### PR TITLE
fix(customsource): stop leaking base-URL rewrite onto shared extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Download ahead download states should no longer get stale values [@mrissaoussama](https://github.com/mrissaoussama) [#289](https://github.com/tsundoku-otaku/tsundoku/pull/289)
 - Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
 - Fix library setting loading and tags [@mrissaoussama](https://github.com/mrissaoussama) [#291](https://github.com/tsundoku-otaku/tsundoku/pull/291)
+- Customesource leaking baseUrl with shared extension [@mrissaoussama](https://github.com/mrissaoussama) [#298](https://github.com/tsundoku-otaku/tsundoku/pull/298)
 - Fetch json parse failrues (jsplugin) [@mrissaoussama](https://github.com/mrissaoussama) [#295](https://github.com/tsundoku-otaku/tsundoku/pull/295)
 - Fix a rare translation queue exception [@mrissaoussama](https://github.com/mrissaoussama) [#286](https://github.com/tsundoku-otaku/tsundoku/pull/286)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -282,13 +282,22 @@ private fun patchHttpSourceForCustomBaseUrl(source: HttpSource, customBaseUrl: S
     val targetBaseUrl = customBaseUrl.trimEnd('/')
     if (targetBaseUrl.isBlank() || sourceBaseUrl == targetBaseUrl) return source
 
-    val rewrittenClient = createBaseUrlRewriteClient(source.client, sourceBaseUrl, targetBaseUrl)
-    trySetFieldRecursively(source, "client", rewrittenClient)
-    // DO NOT change source.baseUrl - keep it as original so the interceptor can match requests
-    // The interceptor is configured to rewrite sourceBaseUrl -> targetBaseUrl
-    // If we change baseUrl here, HttpSource will build requests with the new URL, and the
-    // interceptor won't match because it's looking for the old sourceBaseUrl
-    return source
+    // Patch a fresh instance, not the shared SourceManager singleton: mutating its client
+    // leaks the rewrite interceptor onto the original source's own requests.
+    val target = source.freshCopyOrNull() ?: source
+    val rewrittenClient = createBaseUrlRewriteClient(target.client, sourceBaseUrl, targetBaseUrl)
+    trySetFieldRecursively(target, "client", rewrittenClient)
+    // Keep baseUrl original so the interceptor still matches outgoing requests.
+    return target
+}
+
+// Null for SourceFactory-built sources with no no-arg constructor; caller falls back to shared.
+private fun HttpSource.freshCopyOrNull(): HttpSource? = try {
+    javaClass.getDeclaredConstructor()
+        .apply { isAccessible = true }
+        .newInstance() as? HttpSource
+} catch (_: Throwable) {
+    null
 }
 
 internal fun customSourceStorageFileCandidates(


### PR DESCRIPTION
patchHttpSourceForCustomBaseUrl mutated the shared extension singleton from SourceManager, installing the host-rewrite interceptor on the original source's client. After a custom source based on an extension was opened, the original extension's own requests were redirected to the custom base URL too (interceptor never cleaned).
