### PR TITLE
Append Clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Edit manga now has an artist field [@mrissaoussama](https://github.com/mrissaoussama) [#278](https://github.com/tsundoku-otaku/tsundoku/pull/278)
 - URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)
 - Mass import improvements and resume counting [@mrissaoussama](https://github.com/mrissaoussama) [#288](https://github.com/tsundoku-otaku/tsundoku/pull/288)
+- Append clipboard added in edit quotes [@Rojikku](https://github.com/Rojikku) [#301](https://github.com/tsundoku-otaku/tsundoku/pull/301)
 - Prevent duplicate custom sources [@mrissaoussama](https://github.com/mrissaoussama) [#294](https://github.com/tsundoku-otaku/tsundoku/pull/294)
 
 ### Fixed

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.Reorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -211,6 +212,8 @@ fun QuotesSheet(
 
     // Show edit dialog when a quote is being edited
     if (editingQuote.value != null) {
+        val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
+
         AlertDialog(
             onDismissRequest = { editingQuote.value = null },
             title = { Text(stringResource(TDMR.strings.quotes_edit_title)) },
@@ -242,8 +245,26 @@ fun QuotesSheet(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { editingQuote.value = null }) {
-                    Text(stringResource(MR.strings.action_cancel))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(
+                        onClick = {
+                            val clip = clipboardManager.getText()?.text
+                            if (!clip.isNullOrBlank()) {
+                                val current = editedContent.value
+                                editedContent.value = if (current.isBlank()) clip else "$current\n\n$clip"
+                            }
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.ContentPaste,
+                            contentDescription = stringResource(TDMR.strings.quotes_append_clipboard),
+                        )
+                    }
+                    TextButton(onClick = { editingQuote.value = null }) {
+                        Text(stringResource(MR.strings.action_cancel))
+                    }
                 }
             },
         )

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -871,6 +871,7 @@
     <string name="quotes_add_title">Add Quote</string>
     <string name="quotes_content_label">Quote content</string>
     <string name="quotes_copy">Copy</string>
+    <string name="quotes_append_clipboard">Append Clipboard</string>
     <string name="novel_chapter_loading">Loading…</string>
     <string name="novel_chapter_translating">Translating…</string>
     <string name="novel_chapter_translating_from_api">Translating from API…</string>


### PR DESCRIPTION
Append clipboard to a quote.

Should resolve a complaint about "Merging quotes". Instead of making a new quote, copy instead, then edit and append where desired. Slightly more convenient than scrolling, placing cursor, and finding paste.