### PR TITLE
Fix compatibility with older backups [remove later]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Some great improvements to custom sources, including {novelUrl} [@mrissaoussama](https://github.com/mrissaoussama) [#296](https://github.com/tsundoku-otaku/tsundoku/pull/296)
 - Improve performance on library export notifications [@mrissaoussama](https://github.com/mrissaoussama) [#285](https://github.com/tsundoku-otaku/tsundoku/pull/285)
 - Edit manga now has an artist field [@mrissaoussama](https://github.com/mrissaoussama) [#278](https://github.com/tsundoku-otaku/tsundoku/pull/278)
+- Compatibility with previous backups [@mrissaoussama](https://github.com/mrissaoussama) [#306](https://github.com/tsundoku-otaku/tsundoku/pull/306)
 - URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)
 - Mass import improvements and resume counting [@mrissaoussama](https://github.com/mrissaoussama) [#288](https://github.com/tsundoku-otaku/tsundoku/pull/288)
 - Append clipboard added in edit quotes [@Rojikku](https://github.com/Rojikku) [#301](https://github.com/tsundoku-otaku/tsundoku/pull/301)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
@@ -40,6 +40,7 @@ class BackupDecoder(
             }
 
             val backupBytes = payloadSource.use { readWithSizeLimit(it, MAX_BACKUP_BYTES) }
+                .let { BackupProtoMigration.migrateLegacyIsNovel(it) }
             try {
                 parser.decodeFromByteArray(Backup.serializer(), backupBytes)
             } catch (_: SerializationException) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
@@ -3,11 +3,8 @@ package eu.kanade.tachiyomi.data.backup
 import java.io.ByteArrayOutputStream
 
 /**
- * Older fork backups stored isNovel as a boolean at ProtoNumber 112. That number now holds memo,
- * a length-delimited ByteArray, and isNovel moved to 8000. Boolean (wire type 0, varint) and
- * ByteArray (wire type 2, length-delimited) are distinguishable on the wire, so any varint found at
- * field 112 inside a BackupManga is a legacy isNovel and is rewritten to field 8000 before decoding.
- * A current backup has no varint at 112 (it is memo bytes, or absent), so it passes through unchanged.
+This is a temporary migration fix to keep compatibility with old backup files that use isNovel proto number 112 before it was moved to 8000
+ TODO: Remove this class after a few releases.
  */
 internal object BackupProtoMigration {
     private const val BACKUP_MANGA_FIELD = 1

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
@@ -1,0 +1,170 @@
+package eu.kanade.tachiyomi.data.backup
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * Older fork backups stored isNovel as a boolean at ProtoNumber 112. That number now holds memo,
+ * a length-delimited ByteArray, and isNovel moved to 8000. Boolean (wire type 0, varint) and
+ * ByteArray (wire type 2, length-delimited) are distinguishable on the wire, so any varint found at
+ * field 112 inside a BackupManga is a legacy isNovel and is rewritten to field 8000 before decoding.
+ * A current backup has no varint at 112 (it is memo bytes, or absent), so it passes through unchanged.
+ */
+internal object BackupProtoMigration {
+    private const val BACKUP_MANGA_FIELD = 1
+    private const val LEGACY_IS_NOVEL_FIELD = 112
+    private const val IS_NOVEL_FIELD = 8000
+
+    private const val WIRE_VARINT = 0
+    private const val WIRE_I64 = 1
+    private const val WIRE_LEN = 2
+    private const val WIRE_I32 = 5
+
+    fun migrateLegacyIsNovel(input: ByteArray): ByteArray {
+        return try {
+            if (!hasLegacyIsNovel(input)) return input
+            val reader = Reader(input)
+            val out = ByteArrayOutputStream(input.size + 16)
+            var changed = false
+            while (reader.hasRemaining()) {
+                val tag = reader.readVarint()
+                val field = (tag ushr 3).toInt()
+                val wire = (tag and 0x7).toInt()
+                if (field == BACKUP_MANGA_FIELD && wire == WIRE_LEN) {
+                    val body = reader.readLengthDelimited()
+                    val migrated = migrateManga(body)
+                    if (migrated !== body) changed = true
+                    writeTag(out, BACKUP_MANGA_FIELD, WIRE_LEN)
+                    writeVarint(out, migrated.size.toLong())
+                    out.write(migrated)
+                } else {
+                    writeVarint(out, tag)
+                    copyPayload(reader, out, wire)
+                }
+            }
+            if (changed) out.toByteArray() else input
+        } catch (_: Exception) {
+            input
+        }
+    }
+
+    private fun hasLegacyIsNovel(buf: ByteArray): Boolean {
+        val reader = Reader(buf)
+        while (reader.hasRemaining()) {
+            val tag = reader.readVarint()
+            val field = (tag ushr 3).toInt()
+            val wire = (tag and 0x7).toInt()
+            if (field == BACKUP_MANGA_FIELD && wire == WIRE_LEN) {
+                val len = reader.readVarint().toInt()
+                val end = reader.pos + len
+                if (mangaHasLegacyIsNovel(buf, reader.pos, end)) return true
+                reader.pos = end
+            } else {
+                skipPayload(reader, wire)
+            }
+        }
+        return false
+    }
+
+    private fun mangaHasLegacyIsNovel(buf: ByteArray, start: Int, end: Int): Boolean {
+        val reader = Reader(buf)
+        reader.pos = start
+        while (reader.pos < end) {
+            val tag = reader.readVarint()
+            val field = (tag ushr 3).toInt()
+            val wire = (tag and 0x7).toInt()
+            if (field == LEGACY_IS_NOVEL_FIELD && wire == WIRE_VARINT) return true
+            skipPayload(reader, wire)
+        }
+        return false
+    }
+
+    private fun skipPayload(reader: Reader, wire: Int) {
+        when (wire) {
+            WIRE_VARINT -> reader.readVarint()
+            WIRE_I64 -> reader.skip(8)
+            WIRE_LEN -> reader.skip(reader.readVarint().toInt())
+            WIRE_I32 -> reader.skip(4)
+            else -> throw IllegalStateException("Unsupported wire type $wire")
+        }
+    }
+
+    private fun migrateManga(body: ByteArray): ByteArray {
+        val reader = Reader(body)
+        val out = ByteArrayOutputStream(body.size + 2)
+        var changed = false
+        while (reader.hasRemaining()) {
+            val tag = reader.readVarint()
+            val field = (tag ushr 3).toInt()
+            val wire = (tag and 0x7).toInt()
+            if (field == LEGACY_IS_NOVEL_FIELD && wire == WIRE_VARINT) {
+                writeTag(out, IS_NOVEL_FIELD, WIRE_VARINT)
+                writeVarint(out, reader.readVarint())
+                changed = true
+            } else {
+                writeVarint(out, tag)
+                copyPayload(reader, out, wire)
+            }
+        }
+        return if (changed) out.toByteArray() else body
+    }
+
+    private fun copyPayload(reader: Reader, out: ByteArrayOutputStream, wire: Int) {
+        when (wire) {
+            WIRE_VARINT -> writeVarint(out, reader.readVarint())
+            WIRE_I64 -> out.write(reader.readBytes(8))
+            WIRE_LEN -> {
+                val body = reader.readLengthDelimited()
+                writeVarint(out, body.size.toLong())
+                out.write(body)
+            }
+            WIRE_I32 -> out.write(reader.readBytes(4))
+            else -> throw IllegalStateException("Unsupported wire type $wire")
+        }
+    }
+
+    private fun writeTag(out: ByteArrayOutputStream, field: Int, wire: Int) =
+        writeVarint(out, (field.toLong() shl 3) or wire.toLong())
+
+    private fun writeVarint(out: ByteArrayOutputStream, value: Long) {
+        var v = value
+        while (true) {
+            val b = (v and 0x7F).toInt()
+            v = v ushr 7
+            if (v != 0L) {
+                out.write(b or 0x80)
+            } else {
+                out.write(b)
+                return
+            }
+        }
+    }
+
+    private class Reader(private val buf: ByteArray) {
+        var pos = 0
+
+        fun hasRemaining() = pos < buf.size
+
+        fun readVarint(): Long {
+            var result = 0L
+            var shift = 0
+            while (true) {
+                val b = buf[pos++].toInt() and 0xFF
+                result = result or ((b and 0x7F).toLong() shl shift)
+                if (b and 0x80 == 0) return result
+                shift += 7
+            }
+        }
+
+        fun readBytes(n: Int): ByteArray {
+            val slice = buf.copyOfRange(pos, pos + n)
+            pos += n
+            return slice
+        }
+
+        fun readLengthDelimited(): ByteArray = readBytes(readVarint().toInt())
+
+        fun skip(n: Int) {
+            pos += n
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -47,7 +47,6 @@ class BackupManga(
     @ProtoNumber(111) var initialized: Boolean = false,
     @ProtoNumber(112) var memo: ByteArray = JsonObjectEmptyBytes,
     // Fork fields use a reserved 8000+ ProtoNumber block so they never collide with new upstream fields.
-    // isNovel was historically at 112 (now memo); BackupProtoMigration remaps legacy 112 varints to 8000.
     @ProtoNumber(8000) var isNovel: Boolean = false,
 ) {
     fun getMangaImpl(): Manga {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -47,6 +47,7 @@ class BackupManga(
     @ProtoNumber(111) var initialized: Boolean = false,
     @ProtoNumber(112) var memo: ByteArray = JsonObjectEmptyBytes,
     // Fork fields use a reserved 8000+ ProtoNumber block so they never collide with new upstream fields.
+    // isNovel was historically at 112 (now memo); BackupProtoMigration remaps legacy 112 varints to 8000.
     @ProtoNumber(8000) var isNovel: Boolean = false,
 ) {
     fun getMangaImpl(): Manga {

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigrationTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigrationTest.kt
@@ -1,0 +1,64 @@
+package eu.kanade.tachiyomi.data.backup
+
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BackupProtoMigrationTest {
+
+    @Serializable
+    private class LegacyBackup(
+        @ProtoNumber(1) val backupManga: List<LegacyBackupManga>,
+    )
+
+    @Serializable
+    private class LegacyBackupManga(
+        @ProtoNumber(1) val source: Long,
+        @ProtoNumber(2) val url: String,
+        @ProtoNumber(3) val title: String = "",
+        @ProtoNumber(112) val isNovel: Boolean = false,
+    )
+
+    @Test
+    fun `legacy isNovel at 112 is remapped to 8000 and decodes`() {
+        val legacy = LegacyBackup(
+            listOf(
+                LegacyBackupManga(source = 7, url = "/novel", title = "T", isNovel = true),
+                LegacyBackupManga(source = 8, url = "/manga", title = "M", isNovel = false),
+            ),
+        )
+        val bytes = ProtoBuf.encodeToByteArray(LegacyBackup.serializer(), legacy)
+
+        val migrated = BackupProtoMigration.migrateLegacyIsNovel(bytes)
+        val backup = ProtoBuf.decodeFromByteArray(Backup.serializer(), migrated)
+
+        assertEquals(2, backup.backupManga.size)
+        assertTrue(backup.backupManga[0].isNovel)
+        assertEquals(7L, backup.backupManga[0].source)
+        assertEquals("/novel", backup.backupManga[0].url)
+        assertEquals("T", backup.backupManga[0].title)
+        assertFalse(backup.backupManga[1].isNovel)
+        assertEquals("M", backup.backupManga[1].title)
+    }
+
+    @Test
+    fun `current backup with isNovel at 8000 is unchanged`() {
+        val backup = Backup(
+            backupManga = listOf(
+                BackupManga(source = 1, url = "/x", title = "X", isNovel = true),
+            ),
+        )
+        val bytes = ProtoBuf.encodeToByteArray(Backup.serializer(), backup)
+
+        val migrated = BackupProtoMigration.migrateLegacyIsNovel(bytes)
+
+        assertEquals(bytes.toList(), migrated.toList())
+        assertTrue(ProtoBuf.decodeFromByteArray(Backup.serializer(), migrated).backupManga[0].isNovel)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigrationTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigrationTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-
+/*
+TODO: Remove this test after a few releases, when the migration is no longer needed.
+ */
 class BackupProtoMigrationTest {
 
     @Serializable


### PR DESCRIPTION
Added support for older backup versions that used 112 as a protonumber for isNovel before it was used for `memo`

Revert after a few months/next stable release or something