### PR TITLE
fix(download): strip invisible chars from filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)
 - Download ahead download states should no longer get stale values [@mrissaoussama](https://github.com/mrissaoussama) [#289](https://github.com/tsundoku-otaku/tsundoku/pull/289)
 - Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
+- Remove invisible characters from filenames to prevent dl index issues [@mrissaoussama](https://github.com/mrissaoussama) [#307](https://github.com/tsundoku-otaku/tsundoku/pull/307)
 - Fix library setting loading and tags [@mrissaoussama](https://github.com/mrissaoussama) [#291](https://github.com/tsundoku-otaku/tsundoku/pull/291)
 - Quick migrate should now duplicate check properly [@mrissaoussama](https://github.com/mrissaoussama) [#300](https://github.com/tsundoku-otaku/tsundoku/pull/300)
 - Customesource leaking baseUrl with shared extension [@mrissaoussama](https://github.com/mrissaoussama) [#298](https://github.com/tsundoku-otaku/tsundoku/pull/298)

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/storage/DiskUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/storage/DiskUtil.kt
@@ -141,7 +141,9 @@ object DiskUtil {
         maxBytes: Int = MAX_FILE_NAME_BYTES,
         disallowNonAscii: Boolean = false,
     ): String {
-        val name = origName.trim('.', ' ')
+        val name = origName
+            .filterNot { it in ZERO_WIDTH_CHARS }
+            .trim { it == '.' || it.isWhitespace() || Character.isSpaceChar(it) }
         if (name.isEmpty()) {
             return "(invalid)"
         }
@@ -196,6 +198,11 @@ object DiskUtil {
             else -> true
         }
     }
+
+    // Stripped because some SAF providers drop them on create, desyncing the computed name from the
+    // on-disk name so the download cache misses after a reindex.
+    private val ZERO_WIDTH_CHARS =
+        setOf(0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF).mapTo(mutableSetOf()) { it.toChar() }
 
     const val NOMEDIA_FILE = ".nomedia"
 


### PR DESCRIPTION
prevents rare case where title has invisible chars in the title, causing dl index to miss