### PR TITLE
fix(translation): drop trailing "null" from Google scraper output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - CatalogueSource novel/manga sources [@mrissaoussama](https://github.com/mrissaoussama) [#309](https://github.com/tsundoku-otaku/tsundoku/pull/309)
 - Download ahead download states should no longer get stale values [@mrissaoussama](https://github.com/mrissaoussama) [#289](https://github.com/tsundoku-otaku/tsundoku/pull/289)
 - Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
+- Prevent google translate returning literal null [@mrissaoussama](https://github.com/mrissaoussama) [#312](https://github.com/tsundoku-otaku/tsundoku/pull/312)
 - Remove invisible characters from filenames to prevent dl index issues [@mrissaoussama](https://github.com/mrissaoussama) [#307](https://github.com/tsundoku-otaku/tsundoku/pull/307)
 - Fix library setting loading and tags [@mrissaoussama](https://github.com/mrissaoussama) [#291](https://github.com/tsundoku-otaku/tsundoku/pull/291)
 - Quick migrate should now duplicate check properly [@mrissaoussama](https://github.com/mrissaoussama) [#300](https://github.com/tsundoku-otaku/tsundoku/pull/300)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GoogleTranslateScraperEngine.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.network.POST
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.FormBody
@@ -207,10 +208,10 @@ class GoogleTranslateScraperEngine : TranslationEngine {
             val sentenceArray = sentence.jsonArray
             if (sentenceArray.isEmpty()) continue
             val translatedPart = try {
-                sentenceArray[0].jsonPrimitive.content
+                sentenceArray[0].jsonPrimitive.contentOrNull
             } catch (_: Exception) {
-                continue
-            }
+                null
+            } ?: continue
             result.append(translatedPart)
         }
 


### PR DESCRIPTION
fix google scraper returning literal null in translated content