### PR TITLE
perf(library): optimize bulk data clearing and chapter removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - jsplugins should surface fetch errors [@mrissaoussama](https://github.com/mrissaoussama) [#293](https://github.com/tsundoku-otaku/tsundoku/pull/293)
+- Optimize bulk data clearing and chapter removal [@mrissaoussama](https://github.com/mrissaoussama) [#313](https://github.com/tsundoku-otaku/tsundoku/pull/313)
 - Merged df37d81 from Mihon [@mrissaoussama](https://github.com/mrissaoussama) [#281](https://github.com/tsundoku-otaku/tsundoku/pull/281)
 - Merged a2f3ec9 from Mihon [@Rojikku](https://github.com/Rojikku) [#251](https://github.com/tsundoku-otaku/tsundoku/pull/251)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId = "app.tsundoku"
 
-        versionCode = 20
+        versionCode = 21
         versionName = "0.2.0"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/DeleteLibraryMangaDialog.kt
@@ -37,18 +37,6 @@ fun DeleteLibraryMangaDialog(
     var clearDescriptions by remember { mutableStateOf(false) }
     var clearTags by remember { mutableStateOf(false) }
 
-    // Keep destructive clear options disabled when removing from library.
-    // They are redundant because removing from library already clears associated data.
-    fun onRemoveFromLibraryChanged(checked: Boolean) {
-        removeFromLibrary = checked
-        if (checked) {
-            clearChaptersFromDb = false
-            clearCovers = false
-            clearDescriptions = false
-            clearTags = false
-        }
-    }
-
     data class CheckboxItem(
         val label: StringResource,
         val checked: Boolean,
@@ -67,33 +55,15 @@ fun DeleteLibraryMangaDialog(
         clearTags,
     ) {
         buildList {
-            add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary, { onRemoveFromLibraryChanged(it) }))
+            add(CheckboxItem(MR.strings.manga_from_library, removeFromLibrary, { removeFromLibrary = it }))
             if (!containsLocalManga) {
                 add(CheckboxItem(MR.strings.downloaded_chapters, deleteDownloads, { deleteDownloads = it }))
             }
-            add(
-                CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb || removeFromLibrary, {
-                    clearChaptersFromDb =
-                        it
-                }, enabled = !removeFromLibrary),
-            )
+            add(CheckboxItem(TDMR.strings.chapters_from_database, clearChaptersFromDb, { clearChaptersFromDb = it }))
             add(CheckboxItem(TDMR.strings.translated_chapters, deleteTranslations, { deleteTranslations = it }))
-            add(
-                CheckboxItem(TDMR.strings.action_clear_covers, clearCovers || removeFromLibrary, {
-                    clearCovers = it
-                }, enabled = !removeFromLibrary),
-            )
-            add(
-                CheckboxItem(TDMR.strings.action_clear_descriptions, clearDescriptions || removeFromLibrary, {
-                    clearDescriptions =
-                        it
-                }, enabled = !removeFromLibrary),
-            )
-            add(
-                CheckboxItem(TDMR.strings.action_clear_tags, clearTags || removeFromLibrary, {
-                    clearTags = it
-                }, enabled = !removeFromLibrary),
-            )
+            add(CheckboxItem(TDMR.strings.action_clear_covers, clearCovers, { clearCovers = it }))
+            add(CheckboxItem(TDMR.strings.action_clear_descriptions, clearDescriptions, { clearDescriptions = it }))
+            add(CheckboxItem(TDMR.strings.action_clear_tags, clearTags, { clearTags = it }))
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -171,7 +171,7 @@ object SettingsAdvancedScreen : SearchableSettings {
             ),
             Preference.PreferenceItem.SliderPreference(
                 value = libraryPageSize,
-                valueRange = 50..1000 step 50,
+                valueRange = 50..10000 step 500,
                 steps = 18,
                 title = stringResource(TDMR.strings.pref_experimental_library_page_size),
                 subtitle = stringResource(TDMR.strings.pref_experimental_library_page_size_summary, libraryPageSize),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryClearJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryClearJob.kt
@@ -9,7 +9,6 @@ import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.util.system.cancelNotification
@@ -18,14 +17,16 @@ import eu.kanade.tachiyomi.util.system.notify
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
-import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.RemoveChapters
-import tachiyomi.domain.manga.interactor.GetManga
-import tachiyomi.domain.manga.model.MangaUpdate
+import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -35,54 +36,59 @@ import java.io.File
 class LibraryClearJob(private val context: Context, workerParams: WorkerParameters) :
     CoroutineWorker(context, workerParams) {
 
-    private val getManga: GetManga = Injekt.get()
-    private val updateManga: UpdateManga = Injekt.get()
     private val coverCache: CoverCache = Injekt.get()
-    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get()
     private val removeChapters: RemoveChapters = Injekt.get()
+    private val mangaRepository: MangaRepository = Injekt.get()
+    private val getLibraryManga: GetLibraryManga = Injekt.get()
+
+    private val progressBuilder by lazy {
+        context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
+            setSmallIcon(android.R.drawable.ic_menu_delete)
+            setOngoing(true)
+            setOnlyAlertOnce(true)
+        }
+    }
+    private var lastNotificationTime = 0L
 
     override suspend fun doWork(): Result {
         val mangaIds = loadMangaIds() ?: return Result.failure()
-        val operation = inputData.getString(KEY_OPERATION) ?: return Result.failure()
+        val operations = inputData.getString(KEY_OPERATIONS)
+            ?.split(",")
+            ?.filter { it.isNotEmpty() }
+            ?.takeIf { it.isNotEmpty() }
+            ?: return Result.failure()
 
         setForegroundSafely()
 
         return withIOContext {
             try {
-                when (operation) {
-                    OP_CLEAR_COVERS -> clearCovers(mangaIds)
-                    OP_CLEAR_DESCRIPTIONS -> clearDescriptions(mangaIds)
-                    OP_CLEAR_TAGS -> clearTags(mangaIds)
-                    OP_CLEAR_CHAPTERS -> clearChapters(mangaIds)
-                    else -> return@withIOContext Result.failure()
+                val combineDescTags = OP_CLEAR_DESCRIPTIONS in operations && OP_CLEAR_TAGS in operations
+                operations.forEach { operation ->
+                    when (operation) {
+                        OP_CLEAR_COVERS -> clearCovers(mangaIds)
+                        OP_CLEAR_DESCRIPTIONS -> if (!combineDescTags) clearDescriptions(mangaIds)
+                        OP_CLEAR_TAGS -> if (combineDescTags) clearDescriptionsAndTags(mangaIds) else clearTags(mangaIds)
+                        OP_CLEAR_CHAPTERS -> clearChapters(mangaIds)
+                    }
                 }
+                showComplete(context.stringResource(TDMR.strings.library_clear_cleared_generic, mangaIds.size))
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                logcat(LogPriority.ERROR, e) { "Library clear job failed: $operation" }
+                logcat(LogPriority.ERROR, e) { "Library clear job failed: $operations" }
                 Result.failure()
             } finally {
                 context.cancelNotification(Notifications.ID_LIBRARY_CLEAR_PROGRESS)
+                getLibraryManga.notifyChanged()
             }
         }
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        val operation = inputData.getString(KEY_OPERATION) ?: "Clear"
-        val title = when (operation) {
-            OP_CLEAR_COVERS -> context.stringResource(TDMR.strings.library_clear_clearing_covers)
-            OP_CLEAR_DESCRIPTIONS -> context.stringResource(TDMR.strings.library_clear_clearing_descriptions)
-            OP_CLEAR_TAGS -> context.stringResource(TDMR.strings.library_clear_clearing_tags)
-            OP_CLEAR_CHAPTERS -> context.stringResource(TDMR.strings.library_clear_clearing_chapters)
-            else -> context.stringResource(TDMR.strings.library_clear_clearing)
-        }
-        val notification = context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
-            setSmallIcon(android.R.drawable.ic_menu_delete)
-            setContentTitle(title)
-            setOngoing(true)
-            setOnlyAlertOnce(true)
-            setProgress(0, 0, true)
-        }.build()
+        val notification = progressBuilder
+            .setContentTitle(context.stringResource(TDMR.strings.library_clear_clearing))
+            .setProgress(0, 0, true)
+            .build()
         return ForegroundInfo(
             Notifications.ID_LIBRARY_CLEAR_PROGRESS,
             notification,
@@ -95,57 +101,59 @@ class LibraryClearJob(private val context: Context, workerParams: WorkerParamete
     }
 
     private suspend fun clearCovers(mangaIds: LongArray) {
-        val total = mangaIds.size
-        mangaIds.forEachIndexed { index, id ->
-            val manga = getManga.await(id) ?: return@forEachIndexed
-            if (!manga.isLocal()) {
-                coverCache.deleteFromCache(manga, true)
+        val title = context.stringResource(TDMR.strings.library_clear_clearing_covers)
+        runChunked(mangaIds, title) { chunk ->
+            val mangas = mangaRepository.getMangasByIds(chunk)
+            coroutineScope {
+                mangas.filterNot { it.isLocal() }
+                    .map { manga -> async { coverCache.deleteFromCache(manga, true) } }
+                    .awaitAll()
             }
-            updateManga.await(
-                MangaUpdate(
-                    id = id,
-                    thumbnailUrl = "",
-                    coverLastModified = System.currentTimeMillis(),
-                ),
-            )
-            updateProgress(index + 1, total, context.stringResource(TDMR.strings.library_clear_clearing_covers))
+            mangaRepository.clearCoversForMangaIds(chunk, System.currentTimeMillis())
         }
-        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_covers, total))
     }
 
     private suspend fun clearDescriptions(mangaIds: LongArray) {
-        val updates = mangaIds.map { MangaUpdate(id = it, description = "") }
-        updateManga.awaitAll(updates)
-        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_descriptions, mangaIds.size))
+        val title = context.stringResource(TDMR.strings.library_clear_clearing_descriptions)
+        runChunked(mangaIds, title) { chunk -> mangaRepository.clearDescriptionsForMangaIds(chunk) }
     }
 
     private suspend fun clearTags(mangaIds: LongArray) {
-        val updates = mangaIds.map { MangaUpdate(id = it, genre = emptyList()) }
-        updateManga.awaitAll(updates)
-        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_tags, mangaIds.size))
+        val title = context.stringResource(TDMR.strings.library_clear_clearing_tags)
+        runChunked(mangaIds, title) { chunk -> mangaRepository.clearGenresForMangaIds(chunk) }
+    }
+
+    private suspend fun clearDescriptionsAndTags(mangaIds: LongArray) {
+        val title = context.stringResource(TDMR.strings.library_clear_clearing)
+        runChunked(mangaIds, title) { chunk -> mangaRepository.clearDescriptionsAndGenresForMangaIds(chunk) }
     }
 
     private suspend fun clearChapters(mangaIds: LongArray) {
-        val total = mangaIds.size
-        mangaIds.forEachIndexed { index, id ->
-            val chapters = getChaptersByMangaId.await(id)
-            if (chapters.isNotEmpty()) {
-                removeChapters.await(chapters)
-            }
-            updateProgress(index + 1, total, context.stringResource(TDMR.strings.library_clear_clearing_chapters))
+        val title = context.stringResource(TDMR.strings.library_clear_clearing_chapters)
+        runChunked(mangaIds, title) { chunk ->
+            removeChapters.awaitByMangaIds(chunk)
         }
-        showComplete(context.stringResource(TDMR.strings.library_clear_cleared_chapters, total))
     }
 
-    private fun updateProgress(current: Int, total: Int, title: String) {
-        val notification = context.notificationBuilder(Notifications.CHANNEL_LIBRARY_CLEAR) {
-            setSmallIcon(android.R.drawable.ic_menu_delete)
-            setContentTitle(title)
-            setContentText("$current / $total")
-            setProgress(total, current, false)
-            setOngoing(true)
-            setOnlyAlertOnce(true)
-        }.build()
+    private suspend fun runChunked(mangaIds: LongArray, title: String, block: suspend (List<Long>) -> Unit) {
+        val total = mangaIds.size
+        var processed = 0
+        mangaIds.toList().chunked(CHUNK_SIZE).forEach { chunk ->
+            block(chunk)
+            processed += chunk.size
+            updateProgress(processed, total, title, force = processed >= total)
+        }
+    }
+
+    private fun updateProgress(current: Int, total: Int, title: String, force: Boolean) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastNotificationTime < NOTIFICATION_THROTTLE_MS) return
+        lastNotificationTime = now
+        val notification = progressBuilder
+            .setContentTitle(title)
+            .setContentText("$current / $total")
+            .setProgress(total, current, false)
+            .build()
         context.notify(Notifications.ID_LIBRARY_CLEAR_PROGRESS, notification)
     }
 
@@ -178,15 +186,19 @@ class LibraryClearJob(private val context: Context, workerParams: WorkerParamete
         private const val TAG = "LibraryClearJob"
         private const val KEY_MANGA_IDS = "manga_ids"
         private const val KEY_IDS_FILE = "ids_file"
-        private const val KEY_OPERATION = "operation"
+        private const val KEY_OPERATIONS = "operations"
         private const val MAX_DIRECT_IDS = 500
+        private const val CHUNK_SIZE = 200
+        private const val NOTIFICATION_THROTTLE_MS = 400L
         const val OP_CLEAR_COVERS = "clear_covers"
         const val OP_CLEAR_DESCRIPTIONS = "clear_descriptions"
         const val OP_CLEAR_TAGS = "clear_tags"
         const val OP_CLEAR_CHAPTERS = "clear_chapters"
 
-        fun start(context: Context, mangaIds: List<Long>, operation: String) {
-            val inputDataBuilder = workDataOf(KEY_OPERATION to operation).let {
+        fun start(context: Context, mangaIds: List<Long>, operations: List<String>) {
+            if (operations.isEmpty() || mangaIds.isEmpty()) return
+
+            val inputDataBuilder = workDataOf(KEY_OPERATIONS to operations.joinToString(",")).let {
                 androidx.work.Data.Builder().putAll(it)
             }
 
@@ -203,8 +215,8 @@ class LibraryClearJob(private val context: Context, workerParams: WorkerParamete
                 .setInputData(inputDataBuilder.build())
                 .build()
             context.workManager.enqueueUniqueWork(
-                "${TAG}_$operation",
-                ExistingWorkPolicy.REPLACE,
+                TAG,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
                 workRequest,
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -67,7 +67,6 @@ import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.chapter.interactor.GetBookmarkedChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
-import tachiyomi.domain.chapter.interactor.RemoveChapters
 import tachiyomi.domain.chapter.interactor.SearchChapterNames
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.history.interactor.GetNextChapters
@@ -102,7 +101,6 @@ class LibraryScreenModel(
     private val getTracksPerManga: GetTracksPerManga = Injekt.get(),
     private val getNextChapters: GetNextChapters = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
-    private val removeChapters: RemoveChapters = Injekt.get(),
     private val getBookmarkedChaptersByMangaId: GetBookmarkedChaptersByMangaId = Injekt.get(),
     private val setReadStatus: SetReadStatus = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
@@ -1036,11 +1034,6 @@ class LibraryScreenModel(
                 }
             }
 
-            if (clearChaptersFromDb) {
-                val mangaIds = mangas.map { it.id }
-                removeChapters.awaitByMangaIds(mangaIds)
-            }
-
             if (deleteTranslations) {
                 mangas.forEach { manga ->
                     val chapters = getChaptersByMangaId.await(manga.id)
@@ -1048,29 +1041,17 @@ class LibraryScreenModel(
                 }
             }
 
-            // Delegate clear operations to LibraryClearJob (runs as background WorkManager job)
-            if (!deleteFromLibrary) {
-                val mangaIds = mangas.map { it.id }
-                val context = Injekt.get<android.app.Application>()
-                if (clearCovers) {
-                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_COVERS)
-                }
-                if (clearDescriptions) {
-                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
-                }
-                if (clearTags) {
-                    LibraryClearJob.start(context, mangaIds, LibraryClearJob.OP_CLEAR_TAGS)
-                }
+            val clearOperations = buildList {
+                if (clearChaptersFromDb) add(LibraryClearJob.OP_CLEAR_CHAPTERS)
+                if (clearCovers) add(LibraryClearJob.OP_CLEAR_COVERS)
+                if (clearDescriptions) add(LibraryClearJob.OP_CLEAR_DESCRIPTIONS)
+                if (clearTags) add(LibraryClearJob.OP_CLEAR_TAGS)
+            }
+            if (clearOperations.isNotEmpty()) {
+                LibraryClearJob.start(Injekt.get<android.app.Application>(), mangas.map { it.id }, clearOperations)
             }
 
-            // Refresh library UI after modifications
-            @Suppress("ktlint:standard:max-line-length")
-            if (!deleteFromLibrary &&
-                (
-                    deleteChapters || clearChaptersFromDb || deleteTranslations || clearCovers || clearDescriptions ||
-                        clearTags
-                    )
-            ) {
+            if (!deleteFromLibrary && (deleteChapters || deleteTranslations)) {
                 getLibraryManga.notifyChanged()
             }
         }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -81,7 +81,11 @@ class ChapterRepositoryImpl(
 
     override suspend fun removeChaptersWithIds(chapterIds: List<Long>) {
         try {
-            database.chaptersQueries.removeChaptersWithIds(chapterIds)
+            database.transaction {
+                chapterIds.chunked(SQLITE_VARIABLE_LIMIT).forEach { chunk ->
+                    database.chaptersQueries.removeChaptersWithIds(chunk)
+                }
+            }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
         }
@@ -89,7 +93,14 @@ class ChapterRepositoryImpl(
 
     override suspend fun removeChaptersByMangaIds(mangaIds: List<Long>) {
         try {
-            database.chaptersQueries.removeChaptersByMangaIds(mangaIds)
+            database.transaction {
+                mangaIds.chunked(SQLITE_VARIABLE_LIMIT).forEach { chunk ->
+                    database.mangasQueries.setIsSyncingForIds(1, chunk)
+                    database.chaptersQueries.removeChaptersByMangaIds(chunk)
+                    database.mangasQueries.resetChapterAggregatesForIds(chunk)
+                    database.mangasQueries.setIsSyncingForIds(0, chunk)
+                }
+            }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
         }
@@ -182,4 +193,8 @@ class ChapterRepositoryImpl(
         version = version,
         memo = memo,
     )
+
+    companion object {
+        private const val SQLITE_VARIABLE_LIMIT = 900
+    }
 }

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -100,6 +100,77 @@ class MangaRepositoryImpl(
         }.awaitAsOne()
     }
 
+    override suspend fun getMangasByIds(ids: List<Long>): List<Manga> {
+        if (ids.isEmpty()) return emptyList()
+        return ids.chunked(SQLITE_VARIABLE_LIMIT).flatMap { chunk ->
+            database.mangasQueries.getMangasByIds(chunk) {
+                    id,
+                    source,
+                    url,
+                    artist,
+                    author,
+                    description,
+                    genre,
+                    title,
+                    alternative_titles,
+                    status,
+                    thumbnail_url,
+                    favorite,
+                    last_update,
+                    next_update,
+                    initialized,
+                    viewer,
+                    chapter_flags,
+                    cover_last_modified,
+                    date_added,
+                    update_strategy,
+                    calculate_interval,
+                    last_modified_at,
+                    favorite_modified_at,
+                    version,
+                    is_syncing,
+                    notes,
+                    is_novel,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                ->
+                MangaMapper.mapManga(id, source, url, artist, author, description, genre, title, alternative_titles, status, thumbnail_url, favorite, last_update, next_update, initialized, viewer, chapter_flags, cover_last_modified, date_added, update_strategy, calculate_interval, last_modified_at, favorite_modified_at, version, is_syncing, notes, is_novel)
+            }.awaitAsList()
+        }
+    }
+
+    override suspend fun clearDescriptionsForMangaIds(ids: List<Long>) {
+        clearFieldsForMangaIds(ids) { database.mangasQueries.clearDescriptionsForIds(it) }
+    }
+
+    override suspend fun clearGenresForMangaIds(ids: List<Long>) {
+        clearFieldsForMangaIds(ids) { database.mangasQueries.clearGenresForIds(it) }
+    }
+
+    override suspend fun clearDescriptionsAndGenresForMangaIds(ids: List<Long>) {
+        clearFieldsForMangaIds(ids) { database.mangasQueries.clearDescriptionsAndGenresForIds(it) }
+    }
+
+    override suspend fun clearCoversForMangaIds(ids: List<Long>, coverLastModified: Long) {
+        clearFieldsForMangaIds(ids) { database.mangasQueries.clearThumbnailsForIds(coverLastModified, it) }
+    }
+
+    private suspend fun clearFieldsForMangaIds(ids: List<Long>, statement: suspend (List<Long>) -> Unit) {
+        if (ids.isEmpty()) return
+        try {
+            database.transaction {
+                ids.chunked(SQLITE_VARIABLE_LIMIT).forEach { statement(it) }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
+
     override suspend fun getMangaByIdAsFlow(id: Long): Flow<Manga> {
         return database.mangasQueries.getMangaById(id) {
                 id,
@@ -2003,5 +2074,9 @@ class MangaRepositoryImpl(
         // Aggregates live directly on the mangas table, no separate cache exists.
         // Always report valid to avoid unnecessary recomputation on startup.
         return 0L to 0L
+    }
+
+    companion object {
+        private const val SQLITE_VARIABLE_LIMIT = 900
     }
 }

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -200,6 +200,7 @@ END;
 CREATE TRIGGER manga_agg_chapter_delete
 AFTER DELETE ON chapters
 WHEN (SELECT favorite FROM mangas WHERE _id = old.manga_id) = 1
+AND (SELECT is_syncing FROM mangas WHERE _id = old.manga_id) = 0
 BEGIN
     UPDATE mangas SET
         total_count = coalesce((

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -84,6 +84,31 @@ SELECT memo
 FROM mangas
 WHERE _id = :id;
 
+getMangasByIds:
+SELECT *
+FROM mangas
+WHERE _id IN :ids;
+
+clearDescriptionsForIds:
+UPDATE mangas SET description = '' WHERE _id IN :ids;
+
+clearGenresForIds:
+UPDATE mangas SET genre = '' WHERE _id IN :ids;
+
+clearDescriptionsAndGenresForIds:
+UPDATE mangas SET description = '', genre = '' WHERE _id IN :ids;
+
+clearThumbnailsForIds:
+UPDATE mangas SET thumbnail_url = '', cover_last_modified = :coverLastModified WHERE _id IN :ids;
+
+setIsSyncingForIds:
+UPDATE mangas SET is_syncing = :value WHERE _id IN :ids;
+
+resetChapterAggregatesForIds:
+UPDATE mangas
+SET total_count = 0, read_count = 0, bookmark_count = 0, latest_upload = 0, chapter_fetched_at = 0
+WHERE _id IN :ids;
+
 -- TODO: this should ideally never really have more than 1 result
 getMangaByUrlAndSource:
 SELECT *

--- a/data/src/main/sqldelight/tachiyomi/migrations/29.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/29.sqm
@@ -1,0 +1,41 @@
+-- Skip the per-row chapter-delete aggregate trigger while is_syncing is set.
+DROP TRIGGER IF EXISTS manga_agg_chapter_delete;
+
+CREATE TRIGGER manga_agg_chapter_delete
+AFTER DELETE ON chapters
+WHEN (SELECT favorite FROM mangas WHERE _id = old.manga_id) = 1
+AND (SELECT is_syncing FROM mangas WHERE _id = old.manga_id) = 0
+BEGIN
+    UPDATE mangas SET
+        total_count = coalesce((
+            SELECT count(*) FROM chapters
+            LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+                AND chapters.scanlator = excluded_scanlators.scanlator
+            WHERE chapters.manga_id = old.manga_id AND excluded_scanlators.scanlator IS NULL
+        ), 0),
+        read_count = coalesce((
+            SELECT sum(read) FROM chapters
+            LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+                AND chapters.scanlator = excluded_scanlators.scanlator
+            WHERE chapters.manga_id = old.manga_id AND excluded_scanlators.scanlator IS NULL
+        ), 0),
+        bookmark_count = coalesce((
+            SELECT sum(bookmark) FROM chapters
+            LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+                AND chapters.scanlator = excluded_scanlators.scanlator
+            WHERE chapters.manga_id = old.manga_id AND excluded_scanlators.scanlator IS NULL
+        ), 0),
+        latest_upload = coalesce((
+            SELECT max(date_upload) FROM chapters
+            LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+                AND chapters.scanlator = excluded_scanlators.scanlator
+            WHERE chapters.manga_id = old.manga_id AND excluded_scanlators.scanlator IS NULL
+        ), 0),
+        chapter_fetched_at = coalesce((
+            SELECT max(date_fetch) FROM chapters
+            LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+                AND chapters.scanlator = excluded_scanlators.scanlator
+            WHERE chapters.manga_id = old.manga_id AND excluded_scanlators.scanlator IS NULL
+        ), 0)
+    WHERE _id = old.manga_id;
+END;

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -25,10 +25,20 @@ interface MangaRepository {
 
     suspend fun getMangaById(id: Long): Manga
 
+    suspend fun getMangasByIds(ids: List<Long>): List<Manga>
+
     suspend fun getMangaByIdAsFlow(id: Long): Flow<Manga>
 
     /** Raw [Manga.memo] JSON for a manga, used for per-field custom metadata overrides. */
     suspend fun getMemo(mangaId: Long): JsonObject
+
+    suspend fun clearDescriptionsForMangaIds(ids: List<Long>)
+
+    suspend fun clearGenresForMangaIds(ids: List<Long>)
+
+    suspend fun clearDescriptionsAndGenresForMangaIds(ids: List<Long>)
+
+    suspend fun clearCoversForMangaIds(ids: List<Long>, coverLastModified: Long)
 
     suspend fun getMangaByUrlAndSourceId(url: String, sourceId: Long): Manga?
 

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -841,6 +841,7 @@
     <string name="library_clear_cleared_descriptions">Cleared descriptions for %d entries</string>
     <string name="library_clear_cleared_tags">Cleared tags for %d entries</string>
     <string name="library_clear_cleared_chapters">Cleared chapters for %d entries</string>
+    <string name="library_clear_cleared_generic">Cleared data for %d entries</string>
     <!-- Database maintenance notifications -->
     <string name="channel_db_maintenance">Database Maintenance</string>
     <string name="db_maintenance_title">Database maintenance</string>


### PR DESCRIPTION
Rework library maintenance to use bulk SQL and serialized background work so clearing data is faster.

- Add fused repository methods to clear descriptions, genres and covers in chunked UPDATE statements that stay under SQLite's variable limit.
- Skip the per-row manga_agg_chapter_delete trigger during bulk chapter removal via an is_syncing guard, then reset manga aggregates in one statement (migration 29).
- LibraryClearJob now handles multiple operation types per run, serialized with APPEND_OR_REPLACE, with throttled progress notifications.
- decouple the clear-data checkboxes from remove-from-library in the delete dialog.

