### PR TITLE
Fix/epub toc subsection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - URL path resolution in JsSource [@mrissaoussama](https://github.com/mrissaoussama) [#274](https://github.com/tsundoku-otaku/tsundoku/pull/274)
 - ALt title import when tracking, case insensitive dupe check [@mrissaoussama](https://github.com/mrissaoussama) [#305](https://github.com/tsundoku-otaku/tsundoku/pull/305)
 - Mass import improvements and resume counting [@mrissaoussama](https://github.com/mrissaoussama) [#288](https://github.com/tsundoku-otaku/tsundoku/pull/288)
+- EPUBC ToC Subsection Fix [@mrissaoussama](https://github.com/mrissaoussama) [#315](https://github.com/tsundoku-otaku/tsundoku/pull/315)
 - Append clipboard added in edit quotes [@Rojikku](https://github.com/Rojikku) [#301](https://github.com/tsundoku-otaku/tsundoku/pull/301)
 - Prevent duplicate custom sources [@mrissaoussama](https://github.com/mrissaoussama) [#294](https://github.com/tsundoku-otaku/tsundoku/pull/294)
 - Added novel extension repos entry into browse settings [@mrissaoussama](https://github.com/mrissaoussama) [#304](https://github.com/tsundoku-otaku/tsundoku/pull/304)

--- a/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
@@ -1,0 +1,137 @@
+package mihon.core.archive
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EpubReaderNormalizeTocTest {
+
+    private fun chapter(title: String, order: Int, depth: Int = 0) =
+        EpubReader.EpubChapter(title = title, href = "s$order.xhtml", order = order, depth = depth)
+
+    private fun normalizeFlat(vararg titles: String): List<String> =
+        EpubReader.normalizeTableOfContents(
+            titles.mapIndexed { index, title -> chapter(title, index) },
+        ).map { it.title }
+
+    private fun normalize(vararg entries: Pair<String, Int>): List<String> =
+        EpubReader.normalizeTableOfContents(
+            entries.mapIndexed { index, (title, depth) -> chapter(title, index, depth) },
+        ).map { it.title }
+
+    // ── Flat TOC (heuristic fallback) ───────────────────────────────
+
+    @Test
+    fun `descriptive chapter titles are left untouched`() {
+        // Regression: "Chapter N: Title" used to match the subsection regex and get prefixed with the
+        // previous front-matter entry (e.g. "Table of Contents Page - Chapter 1: ...").
+        val result = normalizeFlat(
+            "Table of Contents Page",
+            "Chapter 1: Operating Behind the Scenes",
+            "Chapter 2: True Ability",
+            "Postscript",
+        )
+
+        assertEquals(
+            listOf(
+                "Table of Contents Page",
+                "Chapter 1: Operating Behind the Scenes",
+                "Chapter 2: True Ability",
+                "Postscript",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `bare subsection labels are still prefixed with the last primary title`() {
+        val result = normalizeFlat("The Awakening", "Part 1", "Part 2")
+        assertEquals(listOf("The Awakening", "The Awakening - Part 1", "The Awakening - Part 2"), result)
+    }
+
+    @Test
+    fun `bare label with trailing punctuation still counts as a subsection`() {
+        val result = normalizeFlat("Prologue", "Chapter 3.", "Chapter 4:")
+        assertEquals(listOf("Prologue", "Prologue - Chapter 3.", "Prologue - Chapter 4:"), result)
+    }
+
+    @Test
+    fun `roman numeral subsection labels are recognized`() {
+        val result = normalizeFlat("The Return", "Act IV")
+        assertEquals(listOf("The Return", "The Return - Act IV"), result)
+    }
+
+    @Test
+    fun `subsection at the start with no primary is left as-is`() {
+        val result = normalizeFlat("Part 1", "The Real Start")
+        assertEquals(listOf("Part 1", "The Real Start"), result)
+    }
+
+    @Test
+    fun `blank titles fall back to a positional chapter name`() {
+        val result = normalizeFlat("Intro", "   ")
+        assertEquals(listOf("Intro", "Chapter 2"), result)
+    }
+
+    @Test
+    fun `empty toc returns empty`() {
+        assertEquals(emptyList<String>(), EpubReader.normalizeTableOfContents(emptyList()))
+    }
+
+    // ── Nested TOC (structural, locale-agnostic) ────────────────────
+
+    @Test
+    fun `nested entries are prefixed with their parent title`() {
+        val result = normalize(
+            "Part One" to 0,
+            "Chapter 1" to 1,
+            "Chapter 2" to 1,
+            "Part Two" to 0,
+            "Chapter 3" to 1,
+        )
+
+        assertEquals(
+            listOf(
+                "Part One",
+                "Part One - Chapter 1",
+                "Part One - Chapter 2",
+                "Part Two",
+                "Part Two - Chapter 3",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `structural nesting works for non-english titles`() {
+        // No keyword list involved, so German/Japanese labels normalize just like English ones.
+        val result = normalize(
+            "Erster Teil" to 0,
+            "Kapitel 1" to 1,
+            "第1章" to 1,
+        )
+
+        assertEquals(listOf("Erster Teil", "Erster Teil - Kapitel 1", "Erster Teil - 第1章"), result)
+    }
+
+    @Test
+    fun `deep nesting joins the full ancestor chain`() {
+        val result = normalize(
+            "Book I" to 0,
+            "Part A" to 1,
+            "Chapter 1" to 2,
+        )
+
+        assertEquals(listOf("Book I", "Book I - Part A", "Book I - Part A - Chapter 1"), result)
+    }
+
+    @Test
+    fun `descriptive titles under a parent keep the parent prefix instead of heuristic mangling`() {
+        // A nested TOC forces the structural path even though a sibling looks like a heuristic subsection.
+        val result = normalize(
+            "Volume 1" to 0,
+            "Chapter 1: The Beginning" to 1,
+        )
+
+        assertEquals(listOf("Volume 1", "Volume 1 - Chapter 1: The Beginning"), result)
+    }
+}

--- a/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
@@ -18,7 +18,7 @@ class EpubReaderNormalizeTocTest {
             entries.mapIndexed { index, (title, depth) -> chapter(title, index, depth) },
         ).map { it.title }
 
-    // ── Flat TOC (heuristic fallback) ───────────────────────────────
+    // Flat TOC (heuristic fallback)
 
     @Test
     fun `descriptive chapter titles are left untouched`() {
@@ -77,7 +77,7 @@ class EpubReaderNormalizeTocTest {
         assertEquals(emptyList<String>(), EpubReader.normalizeTableOfContents(emptyList()))
     }
 
-    // ── Nested TOC (structural, locale-agnostic) ────────────────────
+    // Nested TOC (structural, locale-agnostic)
 
     @Test
     fun `nested entries are prefixed with their parent title`() {

--- a/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
@@ -1,0 +1,153 @@
+package mihon.core.archive
+
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EpubReaderTocParseTest {
+
+    // resolvePath mirrors resolveZipPath with an empty base dir: identity for these flat fixtures.
+    private val identityResolve: (String) -> String = { it }
+
+    private fun ncx(xml: String) =
+        Jsoup.parse(xml, "", Parser.xmlParser()).selectFirst("navMap")!!
+
+    private fun navList(xml: String) =
+        Jsoup.parse(xml, "", Parser.xmlParser())
+            .selectFirst("nav")!!
+            .selectFirst("ol")!!
+
+    // ── EPUB 2 NCX ──────────────────────────────────────────────────
+
+    @Test
+    fun `flat ncx keeps document order and depth zero and preserves fragment hrefs`() {
+        // Mirrors the Classroom of the Elite NCX: flat navMap, each entry a distinct file with a fragment.
+        val navMap = ncx(
+            """
+            <ncx><navMap>
+              <navPoint><navLabel><text>Table of Contents Page</text></navLabel>
+                <content src="Text/section-0004.html#auto_bookmark_toc_top"/></navPoint>
+              <navPoint><navLabel><text>Chapter 1: Operating Behind the Scenes</text></navLabel>
+                <content src="Text/section-0005.html#auto_bookmark_toc_top"/></navPoint>
+            </navMap></ncx>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNcxNavMap(navMap, "toc.ncx", identityResolve)
+
+        assertEquals(2, toc.size)
+        assertEquals(listOf(0, 0), toc.map { it.depth })
+        assertEquals(listOf(0, 1), toc.map { it.order })
+        assertEquals("Text/section-0005.html#auto_bookmark_toc_top", toc[1].href)
+
+        // Full pipeline: descriptive title must survive normalization unchanged.
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(
+            listOf("Table of Contents Page", "Chapter 1: Operating Behind the Scenes"),
+            names,
+        )
+    }
+
+    @Test
+    fun `nested navPoints carry depth and normalize into parent-child labels`() {
+        val navMap = ncx(
+            """
+            <ncx><navMap>
+              <navPoint><navLabel><text>Part One</text></navLabel><content src="p1.xhtml"/>
+                <navPoint><navLabel><text>Chapter 1</text></navLabel><content src="c1.xhtml"/></navPoint>
+                <navPoint><navLabel><text>Chapter 2</text></navLabel><content src="c2.xhtml"/></navPoint>
+              </navPoint>
+              <navPoint><navLabel><text>Part Two</text></navLabel><content src="p2.xhtml"/>
+                <navPoint><navLabel><text>Chapter 3</text></navLabel><content src="c3.xhtml"/></navPoint>
+              </navPoint>
+            </navMap></ncx>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNcxNavMap(navMap, "toc.ncx", identityResolve)
+
+        assertEquals(listOf("Part One", "Chapter 1", "Chapter 2", "Part Two", "Chapter 3"), toc.map { it.title })
+        assertEquals(listOf(0, 1, 1, 0, 1), toc.map { it.depth })
+        assertEquals(listOf(0, 1, 2, 3, 4), toc.map { it.order })
+        assertEquals(listOf("p1.xhtml", "c1.xhtml", "c2.xhtml", "p2.xhtml", "c3.xhtml"), toc.map { it.href })
+
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(
+            listOf("Part One", "Part One - Chapter 1", "Part One - Chapter 2", "Part Two", "Part Two - Chapter 3"),
+            names,
+        )
+    }
+
+    @Test
+    fun `fragment-only ncx entry reuses the previous file path`() {
+        val navMap = ncx(
+            """
+            <ncx><navMap>
+              <navPoint><navLabel><text>A</text></navLabel><content src="chapter.xhtml#top"/></navPoint>
+              <navPoint><navLabel><text>B</text></navLabel><content src="#middle"/></navPoint>
+            </navMap></ncx>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNcxNavMap(navMap, "toc.ncx", identityResolve)
+
+        assertEquals("chapter.xhtml#top", toc[0].href)
+        assertEquals("chapter.xhtml#middle", toc[1].href)
+    }
+
+    // ── EPUB 3 nav ──────────────────────────────────────────────────
+
+    @Test
+    fun `nested nav ol carries depth and normalizes across locales`() {
+        val root = navList(
+            """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <nav epub:type="toc"><ol>
+                <li><a href="p1.xhtml">Erster Teil</a>
+                  <ol>
+                    <li><a href="c1.xhtml">Kapitel 1</a></li>
+                    <li><a href="c2.xhtml">Kapitel 2</a></li>
+                  </ol>
+                </li>
+                <li><a href="back.xhtml">Nachwort</a></li>
+              </ol></nav>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNavList(root, "nav.xhtml", identityResolve)
+
+        assertEquals(listOf("Erster Teil", "Kapitel 1", "Kapitel 2", "Nachwort"), toc.map { it.title })
+        assertEquals(listOf(0, 1, 1, 0), toc.map { it.depth })
+        assertEquals(listOf(0, 1, 2, 3), toc.map { it.order })
+
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(
+            listOf("Erster Teil", "Erster Teil - Kapitel 1", "Erster Teil - Kapitel 2", "Nachwort"),
+            names,
+        )
+    }
+
+    @Test
+    fun `nav parent without a link still nests its children under nothing`() {
+        // A <li> that is a bare section header (no <a>) must not crash and children keep their own depth.
+        val root = navList(
+            """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <nav epub:type="toc"><ol>
+                <li><span>Section</span>
+                  <ol><li><a href="c1.xhtml">Chapter 1</a></li></ol>
+                </li>
+              </ol></nav>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNavList(root, "nav.xhtml", identityResolve)
+
+        assertEquals(listOf("Chapter 1"), toc.map { it.title })
+        assertEquals(listOf(1), toc.map { it.depth })
+        assertEquals("c1.xhtml", toc[0].href)
+    }
+}

--- a/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
@@ -130,8 +130,7 @@ class EpubReaderTocParseTest {
     }
 
     @Test
-    fun `nav parent without a link still nests its children under nothing`() {
-        // A <li> that is a bare section header (no <a>) must not crash and children keep their own depth.
+    fun `nav heading without a link nests children under its own title`() {
         val root = navList(
             """
             <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
@@ -146,8 +145,31 @@ class EpubReaderTocParseTest {
 
         val toc = EpubReader.buildTocFromNavList(root, "nav.xhtml", identityResolve)
 
+        assertEquals(listOf("Section", "Chapter 1"), toc.map { it.title })
+        assertEquals(listOf(0, 1), toc.map { it.depth })
+        assertEquals(listOf(0, 1), toc.map { it.order })
+        assertEquals(listOf("c1.xhtml", "c1.xhtml"), toc.map { it.href })
+
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(listOf("Section", "Section - Chapter 1"), names)
+    }
+
+    @Test
+    fun `nav heading with no descendant link is skipped`() {
+        val root = navList(
+            """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <nav epub:type="toc"><ol>
+                <li><span>Empty Section</span></li>
+                <li><a href="c1.xhtml">Chapter 1</a></li>
+              </ol></nav>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNavList(root, "nav.xhtml", identityResolve)
+
         assertEquals(listOf("Chapter 1"), toc.map { it.title })
-        assertEquals(listOf(1), toc.map { it.depth })
-        assertEquals("c1.xhtml", toc[0].href)
+        assertEquals(listOf(0), toc.map { it.depth })
     }
 }

--- a/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
@@ -18,7 +18,7 @@ class EpubReaderTocParseTest {
             .selectFirst("nav")!!
             .selectFirst("ol")!!
 
-    // ── EPUB 2 NCX ──────────────────────────────────────────────────
+    // EPUB 2 NCX
 
     @Test
     fun `flat ncx keeps document order and depth zero and preserves fragment hrefs`() {
@@ -96,7 +96,7 @@ class EpubReaderTocParseTest {
         assertEquals("chapter.xhtml#middle", toc[1].href)
     }
 
-    // ── EPUB 3 nav ──────────────────────────────────────────────────
+    // EPUB 3 nav
 
     @Test
     fun `nested nav ol carries depth and normalizes across locales`() {

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -267,6 +267,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         val title: String,
         val href: String,
         val order: Int,
+        val depth: Int = 0,
     )
 
     /**
@@ -320,104 +321,41 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
      * "Chapter 1 - Part 2". This keeps preview labels and chapter list labels consistent.
      */
     fun getNormalizedTableOfContents(): List<EpubChapter> {
-        val toc = getTableOfContents()
-        if (toc.isEmpty()) return emptyList()
-
-        var latestPrimaryTitle: String? = null
-
-        return toc.mapIndexed { index, chapter ->
-            val rawTitle = chapter.title.trim()
-            val isSubsection = subsectionTitleRegex.matches(rawTitle)
-
-            val normalizedTitle = when {
-                rawTitle.isBlank() -> "Chapter ${index + 1}"
-                isSubsection && !latestPrimaryTitle.isNullOrBlank() -> "$latestPrimaryTitle - $rawTitle"
-                else -> rawTitle
-            }
-
-            if (!isSubsection && rawTitle.isNotBlank()) {
-                latestPrimaryTitle = rawTitle
-            }
-
-            chapter.copy(title = normalizedTitle)
-        }
+        return normalizeTableOfContents(getTableOfContents())
     }
 
-    private val subsectionTitleRegex =
-        Regex("(?i)^(part|section|episode|ep\\.?|act|book|volume|vol\\.?|chapter|ch\\.?)\\s*[0-9ivxlcdm]+\\b")
-
     /**
-     * Parse EPUB 3 NAV document for TOC.
+     * Parse EPUB 3 NAV document for TOC, preserving the nested <ol>/<li> hierarchy as [EpubChapter.depth].
      * NAV hrefs are relative to the NAV file location.
      * Keep hash fragments because many EPUBs map sub-sections using anchors in the same XHTML file.
      */
     private fun parseEpub3Nav(navPath: String): List<EpubChapter> {
-        val chapters = mutableListOf<EpubChapter>()
         val navBasePath = getParentDirectory(navPath)
-        var previousResolvedPath: String? = null
-        getInputStream(navPath)?.use { inputStream ->
+        return getInputStream(navPath)?.use { inputStream ->
             val doc = Jsoup.parse(inputStream, null, "", Parser.xmlParser())
-
             // EPUB 3 NAV uses <nav epub:type="toc"> or <nav id="toc">
             val navElement = doc.selectFirst("nav[*|type=toc], nav#toc, nav[epub\\:type=toc]")
-            navElement?.select("li a")?.forEachIndexed { index, element ->
-                val title = element.text().trim()
-                val href = element.attr("href").trim().urlDecoded()
-                if (title.isNotEmpty() && href.isNotEmpty()) {
-                    // Resolve path and then restore fragment (if present).
-                    val pathPart = href.substringBefore("#")
-                    val fragment = href.substringAfter("#", "")
-                    val resolvedPath = if (pathPart.isNotBlank()) {
-                        resolveZipPath(navBasePath, pathPart).also { previousResolvedPath = it }
-                    } else {
-                        // Some EPUBs use href="#fragment" to continue pointing into the prior chapter file.
-                        previousResolvedPath ?: navPath
-                    }
-                    val resolvedHref = if (fragment.isNotEmpty()) {
-                        "$resolvedPath#$fragment"
-                    } else {
-                        resolvedPath
-                    }
-                    chapters.add(EpubChapter(title, resolvedHref, index))
-                }
+            val rootList: Element? = navElement?.selectFirst("> ol") ?: navElement?.selectFirst("ol")
+            if (rootList == null) {
+                emptyList()
+            } else {
+                buildTocFromNavList(rootList, navPath) { path -> resolveZipPath(navBasePath, path) }
             }
-        }
-        return chapters
+        }.orEmpty()
     }
 
     /**
-     * Parse EPUB 2 NCX document for TOC.
+     * Parse EPUB 2 NCX document for TOC, preserving nested <navPoint> hierarchy as [EpubChapter.depth].
      * NCX src paths are resolved relative to the NCX file location.
      * Keep hash fragments because many EPUBs map sub-sections using anchors in the same XHTML file.
      */
     private fun parseEpub2Ncx(ncxPath: String): List<EpubChapter> {
-        val chapters = mutableListOf<EpubChapter>()
         val ncxBasePath = getParentDirectory(ncxPath)
-        var previousResolvedPath: String? = null
-        getInputStream(ncxPath)?.use { inputStream ->
+        return getInputStream(ncxPath)?.use { inputStream ->
             val doc = Jsoup.parse(inputStream, null, "", Parser.xmlParser())
-            doc.select("navPoint").forEachIndexed { index, navPoint ->
-                val title = navPoint.selectFirst("navLabel > text")?.text()?.trim() ?: ""
-                val href = navPoint.selectFirst("content")?.attr("src")?.trim()?.urlDecoded() ?: ""
-                if (title.isNotEmpty() && href.isNotEmpty()) {
-                    // Resolve path and then restore fragment (if present).
-                    val pathPart = href.substringBefore("#")
-                    val fragment = href.substringAfter("#", "")
-                    val resolvedPath = if (pathPart.isNotBlank()) {
-                        resolveZipPath(ncxBasePath, pathPart).also { previousResolvedPath = it }
-                    } else {
-                        previousResolvedPath ?: ncxPath
-                    }
-                    val resolvedHref = if (fragment.isNotEmpty()) {
-                        "$resolvedPath#$fragment"
-                    } else {
-                        resolvedPath
-                    }
-                    chapters.add(EpubChapter(title, resolvedHref, index))
-                }
-            }
-        }
-        return chapters
+            val navMap = doc.selectFirst("navMap") ?: doc
+            buildTocFromNcxNavMap(navMap, ncxPath) { path -> resolveZipPath(ncxBasePath, path) }
+        }.orEmpty()
     }
 
     /**
@@ -593,6 +531,162 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
     private fun buildExportImageId(imagePath: String): String = computeExportImageId(imagePath)
 
     companion object {
+        private fun urlDecode(value: String): String =
+            runCatching { URLDecoder.decode(value, "UTF-8") }.getOrDefault(value)
+
+        /**
+         * Resolves a raw TOC href to an archive path while keeping any fragment. Fragment-only hrefs
+         * (href="#anchor") reuse [previousPath] so they continue pointing into the prior chapter file.
+         * Returns the resolved href and the path to remember for the next fragment-only entry.
+         */
+        private fun resolveTocHref(
+            rawHref: String,
+            defaultPath: String,
+            previousPath: String?,
+            resolvePath: (String) -> String,
+        ): Pair<String, String> {
+            val href = urlDecode(rawHref.trim())
+            val pathPart = href.substringBefore("#")
+            val fragment = href.substringAfter("#", "")
+            val resolvedPath = if (pathPart.isNotBlank()) resolvePath(pathPart) else previousPath ?: defaultPath
+            val resolvedHref = if (fragment.isNotEmpty()) "$resolvedPath#$fragment" else resolvedPath
+            return resolvedHref to resolvedPath
+        }
+
+        /**
+         * Walks an EPUB 2 NCX <navMap> in document order, emitting one [EpubChapter] per <navPoint> and
+         * recording nesting depth from the <navPoint> tree.
+         */
+        fun buildTocFromNcxNavMap(
+            navMap: Element,
+            defaultPath: String,
+            resolvePath: (String) -> String,
+        ): List<EpubChapter> {
+            val chapters = mutableListOf<EpubChapter>()
+            var order = 0
+            var previousPath: String? = null
+
+            fun walk(navPoint: Element, depth: Int) {
+                val title = navPoint.selectFirst("> navLabel > text")?.text()?.trim().orEmpty()
+                val src = navPoint.selectFirst("> content")?.attr("src")?.trim().orEmpty()
+                if (title.isNotEmpty() && src.isNotEmpty()) {
+                    val (resolvedHref, resolvedPath) = resolveTocHref(src, defaultPath, previousPath, resolvePath)
+                    if (src.substringBefore("#").isNotBlank()) previousPath = resolvedPath
+                    chapters.add(EpubChapter(title, resolvedHref, order++, depth))
+                }
+                navPoint.children()
+                    .filter { it.normalName() == "navpoint" }
+                    .forEach { walk(it, depth + 1) }
+            }
+
+            navMap.children()
+                .filter { it.normalName() == "navpoint" }
+                .forEach { walk(it, 0) }
+            return chapters
+        }
+
+        /**
+         * Walks an EPUB 3 nav <ol> in document order, emitting one [EpubChapter] per linked <li> and
+         * recording nesting depth from the nested <ol>/<li> tree.
+         */
+        fun buildTocFromNavList(
+            rootList: Element,
+            defaultPath: String,
+            resolvePath: (String) -> String,
+        ): List<EpubChapter> {
+            val chapters = mutableListOf<EpubChapter>()
+            var order = 0
+            var previousPath: String? = null
+
+            fun walk(list: Element, depth: Int) {
+                list.children()
+                    .filter { it.normalName() == "li" }
+                    .forEach { li ->
+                        val anchor = li.selectFirst("> a") ?: li.selectFirst("> span > a")
+                        val title = anchor?.text()?.trim().orEmpty()
+                        val href = anchor?.attr("href")?.trim().orEmpty()
+                        if (title.isNotEmpty() && href.isNotEmpty()) {
+                            val (resolvedHref, resolvedPath) =
+                                resolveTocHref(href, defaultPath, previousPath, resolvePath)
+                            if (href.substringBefore("#").isNotBlank()) previousPath = resolvedPath
+                            chapters.add(EpubChapter(title, resolvedHref, order++, depth))
+                        }
+                        val childList: Element? = li.selectFirst("> ol")
+                        if (childList != null) walk(childList, depth + 1)
+                    }
+            }
+
+            walk(rootList, 0)
+            return chapters
+        }
+
+        // Fallback for flat TOCs only: matches bare subsection labels like "Part 2" or "Chapter 3." A
+        // descriptive title such as "Chapter 1: Operating Behind the Scenes" must NOT match, otherwise real
+        // chapters get prefixed with the previous entry's title. Structural nesting is preferred over this.
+        private val subsectionTitleRegex =
+            Regex(
+                "(?i)^(part|section|episode|ep\\.?|act|book|volume|vol\\.?|chapter|ch\\.?)" +
+                    "\\s*[0-9ivxlcdm]+\\s*[.:)-]?\\s*$",
+            )
+
+        /**
+         * Turns a TOC into display titles where subsections carry their parent's title
+         * ("Parent - Child"). When the TOC carries real nesting ([EpubChapter.depth]) this is done
+         * structurally and is locale-agnostic. Purely flat TOCs fall back to a keyword heuristic.
+         */
+        fun normalizeTableOfContents(toc: List<EpubChapter>): List<EpubChapter> {
+            if (toc.isEmpty()) return emptyList()
+            return if (toc.any { it.depth > 0 }) {
+                normalizeByDepth(toc)
+            } else {
+                normalizeByHeuristic(toc)
+            }
+        }
+
+        private fun normalizeByDepth(toc: List<EpubChapter>): List<EpubChapter> {
+            val ancestors = mutableListOf<String>()
+
+            return toc.mapIndexed { index, chapter ->
+                val rawTitle = chapter.title.trim()
+                val depth = chapter.depth.coerceAtLeast(0)
+
+                // Drop any ancestor titles at or below the current depth, then pad gaps in the hierarchy.
+                if (ancestors.size > depth) ancestors.subList(depth, ancestors.size).clear()
+                while (ancestors.size < depth) ancestors.add("")
+
+                val prefix = ancestors.filter { it.isNotBlank() }.joinToString(" - ")
+                val normalizedTitle = when {
+                    rawTitle.isBlank() -> "Chapter ${index + 1}"
+                    depth > 0 && prefix.isNotBlank() -> "$prefix - $rawTitle"
+                    else -> rawTitle
+                }
+
+                ancestors.add(rawTitle)
+                chapter.copy(title = normalizedTitle)
+            }
+        }
+
+        private fun normalizeByHeuristic(toc: List<EpubChapter>): List<EpubChapter> {
+            var latestPrimaryTitle: String? = null
+
+            return toc.mapIndexed { index, chapter ->
+                val rawTitle = chapter.title.trim()
+                val isSubsection = subsectionTitleRegex.matches(rawTitle)
+
+                val normalizedTitle = when {
+                    rawTitle.isBlank() -> "Chapter ${index + 1}"
+                    isSubsection && !latestPrimaryTitle.isNullOrBlank() -> "$latestPrimaryTitle - $rawTitle"
+                    else -> rawTitle
+                }
+
+                if (!isSubsection && rawTitle.isNotBlank()) {
+                    latestPrimaryTitle = rawTitle
+                }
+
+                chapter.copy(title = normalizedTitle)
+            }
+        }
+
         fun computeExportImageId(imagePath: String): String {
             val normalized = imagePath.replace('\\', '/')
             val tail = normalized.substringAfterLast('.', "")

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -15,9 +15,7 @@ import java.net.URLDecoder
  */
 class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
 
-    private fun String.urlDecoded(): String {
-        return runCatching { URLDecoder.decode(this, "UTF-8") }.getOrDefault(this)
-    }
+    private fun String.urlDecoded(): String = urlDecode(this)
 
     /**
      * Path separator used by this epub.
@@ -586,8 +584,9 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
 
         /**
-         * Walks an EPUB 3 nav <ol> in document order, emitting one [EpubChapter] per linked <li> and
-         * recording nesting depth from the nested <ol>/<li> tree.
+         * Walks an EPUB 3 nav <ol> in document order, emitting one [EpubChapter] per <li> and recording
+         * nesting depth from the nested <ol>/<li> tree. Unlinked heading <li>s reuse their first
+         * descendant link so they still carry a title into the depth hierarchy.
          */
         fun buildTocFromNavList(
             rootList: Element,
@@ -602,16 +601,20 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 list.children()
                     .filter { it.normalName() == "li" }
                     .forEach { li ->
+                        val childList: Element? = li.selectFirst("> ol")
                         val anchor = li.selectFirst("> a") ?: li.selectFirst("> span > a")
-                        val title = anchor?.text()?.trim().orEmpty()
-                        val href = anchor?.attr("href")?.trim().orEmpty()
+                        val title = (anchor?.text() ?: li.selectFirst("> span")?.text() ?: li.ownText()).trim()
+                        // Unlinked heading (<li><span>Title</span><ol>…</ol></li>): keep its text as an
+                        // ancestor prefix by pointing at its first descendant link so it stays navigable.
+                        val href = anchor?.attr("href")?.trim().orEmpty().ifEmpty {
+                            if (childList != null) li.selectFirst("a[href]")?.attr("href")?.trim().orEmpty() else ""
+                        }
                         if (title.isNotEmpty() && href.isNotEmpty()) {
                             val (resolvedHref, resolvedPath) =
                                 resolveTocHref(href, defaultPath, previousPath, resolvePath)
                             if (href.substringBefore("#").isNotBlank()) previousPath = resolvedPath
                             chapters.add(EpubChapter(title, resolvedHref, order++, depth))
                         }
-                        val childList: Element? = li.selectFirst("> ol")
                         if (childList != null) walk(childList, depth + 1)
                     }
             }


### PR DESCRIPTION
Previously, normalizeTableOfContents() used a regex to detect subsection titles and prefix them with the last parent title. This 
failed for titles that contain a colon after the chapter number
Needs testing with epubs that had this issue