### PR TITLE
fix(epub): gate fragment slicing to shared-file TOC entries

### DIFF
--- a/app/src/test/java/mihon/core/archive/EpubReaderFragmentTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderFragmentTest.kt
@@ -1,0 +1,134 @@
+package mihon.core.archive
+
+import mihon.core.archive.EpubReader.EpubChapter
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubReaderFragmentTest {
+
+    private fun doc(html: String) = Jsoup.parse(html, "", Parser.xmlParser())
+
+    private fun toc(vararg hrefs: String) =
+        hrefs.mapIndexed { index, href -> EpubChapter(title = "T$index", href = href, order = index) }
+
+    // Fragment gate: whole file for a lone entry, slice only when a file is shared.
+
+    @Test
+    fun `single toc entry per file must not slice`() {
+        val entries = toc(
+            "Text/section-0004.html#auto_bookmark_toc_top",
+            "Text/section-0005.html#auto_bookmark_toc_top",
+        )
+        assertEquals(1, EpubReader.tocEntryCountForPath(entries, "Text/section-0005.html"))
+    }
+
+    @Test
+    fun `several toc entries in one file are counted as shared`() {
+        val entries = toc(
+            "Text/chapter.xhtml#part1",
+            "Text/chapter.xhtml#part2",
+            "Text/chapter.xhtml#part3",
+        )
+        assertEquals(3, EpubReader.tocEntryCountForPath(entries, "Text/chapter.xhtml"))
+    }
+
+    @Test
+    fun `count ignores fragments and surrounding whitespace`() {
+        val entries = toc(" a.xhtml#x ", "a.xhtml", "b.xhtml#y")
+        assertEquals(2, EpubReader.tocEntryCountForPath(entries, "a.xhtml"))
+        assertEquals(1, EpubReader.tocEntryCountForPath(entries, "b.xhtml"))
+        assertEquals(0, EpubReader.tocEntryCountForPath(entries, "missing.xhtml"))
+    }
+
+    @Test
+    fun `count decodes percent-encoded hrefs before matching the decoded entry path`() {
+        val entries = toc(
+            "Text/Chapter%201.xhtml#a",
+            "Text/Chapter%201.xhtml#b",
+        )
+        assertEquals(2, EpubReader.tocEntryCountForPath(entries, "Text/Chapter 1.xhtml"))
+    }
+
+    // Fragment materialization.
+
+    @Test
+    fun `anchor on a leading paragraph slices only that paragraph`() {
+        val document = doc(
+            """
+            <html><body>
+              <p id="top"><b>Chapter 1</b></p>
+              <p>First body paragraph.</p>
+              <p>Second body paragraph.</p>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val html = EpubReader.extractFragmentHtml(document, "top")
+
+        assertTrue(html!!.contains("Chapter 1"))
+        assertTrue(!html.contains("First body paragraph"))
+    }
+
+    @Test
+    fun `heading anchor gathers following siblings until the next same-level heading`() {
+        val document = doc(
+            """
+            <html><body>
+              <h2 id="c1">Chapter 1</h2>
+              <p>Intro for one.</p>
+              <h3 id="s1">Sub</h3>
+              <p>Sub body.</p>
+              <h2 id="c2">Chapter 2</h2>
+              <p>Intro for two.</p>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val html = EpubReader.extractFragmentHtml(document, "c1")!!
+
+        assertTrue(html.contains("Chapter 1"))
+        assertTrue(html.contains("Intro for one."))
+        assertTrue(html.contains("Sub body."))
+        assertTrue(!html.contains("Chapter 2"))
+        assertTrue(!html.contains("Intro for two."))
+    }
+
+    @Test
+    fun `anchor resolves through the name attribute`() {
+        val document = doc(
+            """
+            <html><body>
+              <p name="mark">Body reached through a name attribute, comfortably past the eighty character floor.</p>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val html = EpubReader.extractFragmentHtml(document, "mark")!!
+        assertTrue(html.contains("name attribute"))
+    }
+
+    @Test
+    fun `url-encoded fragment matches a decoded id`() {
+        val document = doc(
+            """
+            <html><body>
+              <h2 id="Chapter 1">Chapter 1</h2>
+              <p>Body.</p>
+            </body></html>
+            """.trimIndent(),
+        )
+
+        val html = EpubReader.extractFragmentHtml(document, "Chapter%201")!!
+        assertTrue(html.contains("Chapter 1"))
+    }
+
+    @Test
+    fun `unknown fragment returns null`() {
+        val document = doc("<html><body><p>Only paragraph.</p></body></html>")
+        assertNull(EpubReader.extractFragmentHtml(document, "nope"))
+    }
+}

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -272,7 +272,11 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
      * Returns the table of contents (chapters) from the EPUB.
      * Tries EPUB 3 NAV first, then falls back to EPUB 2 NCX.
      */
-    fun getTableOfContents(): List<EpubChapter> {
+    private val cachedTableOfContents: List<EpubChapter> by lazy { computeTableOfContents() }
+
+    fun getTableOfContents(): List<EpubChapter> = cachedTableOfContents
+
+    private fun computeTableOfContents(): List<EpubChapter> {
         val ref = getPackageHref()
         val doc = getPackageDocument(ref)
         val opfBasePath = getParentDirectory(ref)
@@ -402,6 +406,10 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             else -> resolveZipPath(packageBasePath, pathPart)
         }
 
+        // Slice by fragment only when several TOC entries share this file; a lone entry's anchor is a
+        // chapter-top marker and must yield the whole file.
+        val effectiveFragment = fragment?.takeIf { tocEntriesForPath(entryPath) > 1 }
+
         return getInputStream(entryPath)?.use { inputStream ->
             val document = Jsoup.parse(inputStream, null, "", Parser.xmlParser())
 
@@ -517,7 +525,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             // Remove title to prevent bleeding into text viewers.
             document.getElementsByTag("title").remove()
 
-            val fragmentHtml = fragment?.let { extractFragmentHtml(document, it) }.orEmpty()
+            val fragmentHtml = effectiveFragment?.let { extractFragmentHtml(document, it) }.orEmpty()
             when {
                 fragmentHtml.isNotBlank() -> fragmentHtml
                 bodyOnly -> document.body().html().ifBlank { document.outerHtml() }
@@ -708,6 +716,93 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 .take(80)
             return if (extension != null) "$squashed.$extension" else squashed
         }
+
+        /** Counts TOC entries whose target file (href minus fragment) equals [entryPath]. */
+        fun tocEntryCountForPath(toc: List<EpubChapter>, entryPath: String): Int =
+            toc.count { urlDecode(it.href.substringBefore("#").trim()) == entryPath }
+
+        /** Returns the HTML anchored at [fragment], or null when it resolves to no slice-able element. */
+        fun extractFragmentHtml(document: Document, fragment: String): String? {
+            val candidates = buildList {
+                val primary = fragment.substringAfterLast("#").trim().removePrefix("#")
+                if (primary.isNotBlank()) {
+                    add(primary)
+                    val decoded = runCatching { URLDecoder.decode(primary, "UTF-8") }.getOrDefault("")
+                    if (decoded.isNotBlank() && decoded != primary) {
+                        add(decoded)
+                    }
+                }
+            }.distinct()
+
+            for (candidate in candidates) {
+                val elementById = document.getElementById(candidate)
+                if (elementById != null) {
+                    val materialized = materializeFragmentElement(elementById)
+                    if (materialized.isNotBlank()) return materialized
+                }
+
+                val escaped = candidate
+                    .replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                val elementByName = document.selectFirst("*[id=\"$escaped\"], *[name=\"$escaped\"]")
+                if (elementByName != null) {
+                    val materialized = materializeFragmentElement(elementByName)
+                    if (materialized.isNotBlank()) return materialized
+                }
+            }
+
+            return null
+        }
+
+        private fun materializeFragmentElement(element: Element): String {
+            findHeadingElement(element)?.let { heading ->
+                return extractHeadingSectionHtml(heading)
+            }
+
+            if (isMeaningfulFragmentElement(element)) {
+                return element.outerHtml()
+            }
+
+            return ""
+        }
+
+        private fun findHeadingElement(element: Element): Element? {
+            return if (isHeadingTag(element.tagName())) {
+                element
+            } else {
+                element.parents().firstOrNull { isHeadingTag(it.tagName()) }
+            }
+        }
+
+        private fun extractHeadingSectionHtml(heading: Element): String {
+            val headingLevel = heading.tagName().removePrefix("h").toIntOrNull() ?: return heading.outerHtml()
+            val section = Element("div")
+
+            var node: Node? = heading
+            while (node != null) {
+                if (node !== heading && node is Element && isHeadingTag(node.tagName())) {
+                    val siblingHeadingLevel = node.tagName().removePrefix("h").toIntOrNull() ?: Int.MAX_VALUE
+                    if (siblingHeadingLevel <= headingLevel) break
+                }
+
+                section.appendChild(node.clone())
+                node = node.nextSibling()
+            }
+
+            return section.html().ifBlank { heading.outerHtml() }
+        }
+
+        private fun isMeaningfulFragmentElement(element: Element): Boolean {
+            val text = element.text().trim()
+            if (text.length >= 80) return true
+
+            return element.select("p, div, section, article, table, ul, ol, blockquote, pre, figure, img, svg")
+                .isNotEmpty()
+        }
+
+        private fun isHeadingTag(tagName: String): Boolean {
+            return tagName.length == 2 && tagName[0] == 'h' && tagName[1] in '1'..'6'
+        }
     }
 
     private fun inlineAssetAsDataUri(assetPath: String): String? {
@@ -735,84 +830,6 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
     }
 
-    private fun extractFragmentHtml(document: Document, fragment: String): String? {
-        val candidates = buildList {
-            val primary = fragment.substringAfterLast("#").trim().removePrefix("#")
-            if (primary.isNotBlank()) {
-                add(primary)
-                val decoded = runCatching { URLDecoder.decode(primary, "UTF-8") }.getOrDefault("")
-                if (decoded.isNotBlank() && decoded != primary) {
-                    add(decoded)
-                }
-            }
-        }.distinct()
-
-        for (candidate in candidates) {
-            val elementById = document.getElementById(candidate)
-            if (elementById != null) {
-                val materialized = materializeFragmentElement(elementById)
-                if (materialized.isNotBlank()) return materialized
-            }
-
-            val escaped = candidate
-                .replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-            val elementByName = document.selectFirst("*[id=\"$escaped\"], *[name=\"$escaped\"]")
-            if (elementByName != null) {
-                val materialized = materializeFragmentElement(elementByName)
-                if (materialized.isNotBlank()) return materialized
-            }
-        }
-
-        return null
-    }
-
-    private fun materializeFragmentElement(element: Element): String {
-        findHeadingElement(element)?.let { heading ->
-            return extractHeadingSectionHtml(heading)
-        }
-
-        if (isMeaningfulFragmentElement(element)) {
-            return element.outerHtml()
-        }
-
-        return ""
-    }
-
-    private fun findHeadingElement(element: Element): Element? {
-        return if (isHeadingTag(element.tagName())) {
-            element
-        } else {
-            element.parents().firstOrNull { isHeadingTag(it.tagName()) }
-        }
-    }
-
-    private fun extractHeadingSectionHtml(heading: Element): String {
-        val headingLevel = heading.tagName().removePrefix("h").toIntOrNull() ?: return heading.outerHtml()
-        val section = Element("div")
-
-        var node: Node? = heading
-        while (node != null) {
-            if (node !== heading && node is Element && isHeadingTag(node.tagName())) {
-                val siblingHeadingLevel = node.tagName().removePrefix("h").toIntOrNull() ?: Int.MAX_VALUE
-                if (siblingHeadingLevel <= headingLevel) break
-            }
-
-            section.appendChild(node.clone())
-            node = node.nextSibling()
-        }
-
-        return section.html().ifBlank { heading.outerHtml() }
-    }
-
-    private fun isMeaningfulFragmentElement(element: Element): Boolean {
-        val text = element.text().trim()
-        if (text.length >= 80) return true
-
-        return element.select("p, div, section, article, table, ul, ol, blockquote, pre, figure, img, svg").isNotEmpty()
-    }
-
-    private fun isHeadingTag(tagName: String): Boolean {
-        return tagName.length == 2 && tagName[0] == 'h' && tagName[1] in '1'..'6'
-    }
+    private fun tocEntriesForPath(entryPath: String): Int =
+        tocEntryCountForPath(getTableOfContents(), entryPath)
 }


### PR DESCRIPTION
A lone TOC entry with 1 href carries a chapter-top anchor was sliced at that anchor, truncating the chapter to its title. Only slice when several entries share the file (real sub-sections); otherwise return the whole file.

Also decode percent-encoded hrefs before matching the decoded entry path in the count, and memoize getTableOfContents to avoid reparsing the NAV/NCX per chapter open. 
follow up fix of #315 

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
