### PR TITLE
feat(novel): enhance status bar with reordering and positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - Novel download queue improvements to prevent errors [@mrissaoussama](https://github.com/mrissaoussama) [#284](https://github.com/tsundoku-otaku/tsundoku/pull/284)
+- Reader status bar reordering + more [@mrissaoussama](https://github.com/mrissaoussama) [#318](https://github.com/tsundoku-otaku/tsundoku/pull/318)
 - Some great improvements to custom sources, including {novelUrl} [@mrissaoussama](https://github.com/mrissaoussama) [#296](https://github.com/tsundoku-otaku/tsundoku/pull/296)
 - Improve performance on library export notifications [@mrissaoussama](https://github.com/mrissaoussama) [#285](https://github.com/tsundoku-otaku/tsundoku/pull/285)
 - Per-field metadata overrides [@mrissaoussama](https://github.com/mrissaoussama) [#308](https://github.com/tsundoku-otaku/tsundoku/pull/308)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -36,6 +36,7 @@ object SettingsNovelReaderScreen : SearchableSettings {
             readerPref.novelSourceCssPriority,
             readerPref.novelTtsSpeed,
             readerPref.novelTtsPitch,
+            readerPref.novelStatusBarOrder,
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
@@ -54,7 +55,78 @@ object SettingsNovelReaderScreen : SearchableSettings {
             getNavigationGroup(readerPref),
             getAutoScrollGroup(readerPref),
             getContentGroup(readerPref),
+            getStatusBarGroup(readerPref, navigator),
             getTtsGroup(readerPref),
+        )
+    }
+
+    @Composable
+    private fun getStatusBarGroup(
+        readerPreferences: ReaderPreferences,
+        navigator: Navigator,
+    ): Preference.PreferenceGroup {
+        val enabled = readerPreferences.novelStatusBarEnabled.collectAsState().value
+
+        val items = buildList {
+            add(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.novelStatusBarEnabled,
+                    title = stringResource(TDMR.strings.pref_novel_status_bar),
+                ),
+            )
+            if (enabled) {
+                add(
+                    Preference.PreferenceItem.ListPreference(
+                        preference = readerPreferences.novelStatusBarPosition,
+                        entries = mapOf(
+                            "bottom" to stringResource(TDMR.strings.novel_status_bar_position_bottom),
+                            "top" to stringResource(TDMR.strings.novel_status_bar_position_top),
+                        ),
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_position),
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.ListPreference(
+                        preference = readerPreferences.novelStatusBarSize,
+                        entries = mapOf(
+                            "small" to stringResource(TDMR.strings.novel_status_bar_size_small),
+                            "medium" to stringResource(TDMR.strings.novel_status_bar_size_medium),
+                        ),
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_size),
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelStatusBarShowChapterNumber,
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_show_chapter_number),
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelStatusBarShowChapterTitle,
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_show_chapter_title),
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelStatusBarShowCharging,
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_show_charging),
+                        subtitle = stringResource(TDMR.strings.pref_novel_status_bar_show_charging_summary),
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(TDMR.strings.pref_novel_status_bar_customize),
+                        subtitle = stringResource(TDMR.strings.pref_novel_status_bar_customize_summary),
+                        onClick = { navigator.push(StatusBarElementsScreen()) },
+                    ),
+                )
+            }
+        }
+
+        return Preference.PreferenceGroup(
+            title = stringResource(TDMR.strings.pref_novel_status_bar),
+            preferenceItems = items,
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
@@ -37,7 +37,6 @@ import eu.kanade.presentation.reader.serializeStatusBarOrder
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
-import tachiyomi.core.common.preference.Preference
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
@@ -53,16 +52,33 @@ class StatusBarElementsScreen : Screen {
         val navigator = LocalNavigator.currentOrThrow
         val preferences = remember { Injekt.get<ReaderPreferences>() }
 
-        fun enabledPref(item: StatusBarItem): Preference<Boolean> = when (item) {
-            StatusBarItem.TIME -> preferences.novelStatusBarShowTime
-            StatusBarItem.CHAPTER -> preferences.novelStatusBarShowChapterNumber
-            StatusBarItem.PROGRESS -> preferences.novelStatusBarShowProgress
-            StatusBarItem.BATTERY -> preferences.novelStatusBarShowBattery
+        // Chapter visibility is the OR of two independent flags (number/title, see
+        // ReaderActivity's showChapterSegment), so this row's switch reads and writes both
+        // together rather than aliasing to just one of them.
+        fun isItemEnabled(item: StatusBarItem): Boolean = when (item) {
+            StatusBarItem.TIME -> preferences.novelStatusBarShowTime.get()
+            StatusBarItem.CHAPTER ->
+                preferences.novelStatusBarShowChapterNumber.get() ||
+                    preferences.novelStatusBarShowChapterTitle.get()
+            StatusBarItem.PROGRESS -> preferences.novelStatusBarShowProgress.get()
+            StatusBarItem.BATTERY -> preferences.novelStatusBarShowBattery.get()
+        }
+
+        fun setItemEnabled(item: StatusBarItem, enabled: Boolean) {
+            when (item) {
+                StatusBarItem.TIME -> preferences.novelStatusBarShowTime.set(enabled)
+                StatusBarItem.CHAPTER -> {
+                    preferences.novelStatusBarShowChapterNumber.set(enabled)
+                    preferences.novelStatusBarShowChapterTitle.set(enabled)
+                }
+                StatusBarItem.PROGRESS -> preferences.novelStatusBarShowProgress.set(enabled)
+                StatusBarItem.BATTERY -> preferences.novelStatusBarShowBattery.set(enabled)
+            }
         }
 
         val rows = remember {
             preferences.novelStatusBarOrder.get().deserializeStatusBarOrder()
-                .map { ElementRow(it, enabledPref(it).get()) }
+                .map { ElementRow(it, isItemEnabled(it)) }
                 .toMutableStateList()
         }
 
@@ -91,7 +107,7 @@ class StatusBarElementsScreen : Screen {
                                 rows.clear()
                                 rows.addAll(DefaultStatusBarOrder.map { ElementRow(it, true) })
                                 persistOrder()
-                                DefaultStatusBarOrder.forEach { enabledPref(it).set(true) }
+                                DefaultStatusBarOrder.forEach { setItemEnabled(it, true) }
                             },
                         ) {
                             Icon(Icons.Outlined.RestartAlt, contentDescription = null)
@@ -129,7 +145,7 @@ class StatusBarElementsScreen : Screen {
                                         val idx = rows.indexOfFirst { it.item == row.item }
                                         if (idx != -1) {
                                             rows[idx] = row.copy(enabled = checked)
-                                            enabledPref(row.item).set(checked)
+                                            setItemEnabled(row.item, checked)
                                         }
                                     },
                                 )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
@@ -89,7 +89,6 @@ class StatusBarElementsScreen : Screen {
         val lazyListState = rememberLazyListState()
         val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
             rows.add(to.index, rows.removeAt(from.index))
-            persistOrder()
         }
 
         Scaffold(
@@ -135,7 +134,7 @@ class StatusBarElementsScreen : Screen {
                                     imageVector = Icons.Outlined.DragHandle,
                                     contentDescription = null,
                                     modifier = Modifier
-                                        .draggableHandle()
+                                        .draggableHandle(onDragStopped = { persistOrder() })
                                         .padding(end = 12.dp),
                                 )
                                 Text(elementLabel(row.item), modifier = Modifier.weight(1f))

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/StatusBarElementsScreen.kt
@@ -1,0 +1,153 @@
+package eu.kanade.presentation.more.settings.screen
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.DragHandle
+import androidx.compose.material.icons.outlined.RestartAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.reader.DefaultStatusBarOrder
+import eu.kanade.presentation.reader.StatusBarItem
+import eu.kanade.presentation.reader.deserializeStatusBarOrder
+import eu.kanade.presentation.reader.serializeStatusBarOrder
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.i18n.novel.TDMR
+import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class StatusBarElementsScreen : Screen {
+
+    private data class ElementRow(val item: StatusBarItem, val enabled: Boolean)
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val preferences = remember { Injekt.get<ReaderPreferences>() }
+
+        fun enabledPref(item: StatusBarItem): Preference<Boolean> = when (item) {
+            StatusBarItem.TIME -> preferences.novelStatusBarShowTime
+            StatusBarItem.CHAPTER -> preferences.novelStatusBarShowChapterNumber
+            StatusBarItem.PROGRESS -> preferences.novelStatusBarShowProgress
+            StatusBarItem.BATTERY -> preferences.novelStatusBarShowBattery
+        }
+
+        val rows = remember {
+            preferences.novelStatusBarOrder.get().deserializeStatusBarOrder()
+                .map { ElementRow(it, enabledPref(it).get()) }
+                .toMutableStateList()
+        }
+
+        fun persistOrder() {
+            preferences.novelStatusBarOrder.set(rows.map { it.item }.serializeStatusBarOrder())
+        }
+
+        val lazyListState = rememberLazyListState()
+        val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
+            rows.add(to.index, rows.removeAt(from.index))
+            persistOrder()
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(stringResource(TDMR.strings.pref_novel_status_bar_customize)) },
+                    navigationIcon = {
+                        IconButton(onClick = navigator::pop) {
+                            Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                        }
+                    },
+                    actions = {
+                        IconButton(
+                            onClick = {
+                                rows.clear()
+                                rows.addAll(DefaultStatusBarOrder.map { ElementRow(it, true) })
+                                persistOrder()
+                                DefaultStatusBarOrder.forEach { enabledPref(it).set(true) }
+                            },
+                        ) {
+                            Icon(Icons.Outlined.RestartAlt, contentDescription = null)
+                        }
+                    },
+                )
+            },
+        ) { paddingValues ->
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = paddingValues,
+            ) {
+                items(rows, key = { it.item.id }) { row ->
+                    ReorderableItem(reorderState, key = row.item.id) { isDragging ->
+                        val elevation by animateDpAsState(if (isDragging) 8.dp else 0.dp)
+                        Surface(shadowElevation = elevation) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.DragHandle,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .draggableHandle()
+                                        .padding(end = 12.dp),
+                                )
+                                Text(elementLabel(row.item), modifier = Modifier.weight(1f))
+                                Switch(
+                                    checked = row.enabled,
+                                    onCheckedChange = { checked ->
+                                        val idx = rows.indexOfFirst { it.item == row.item }
+                                        if (idx != -1) {
+                                            rows[idx] = row.copy(enabled = checked)
+                                            enabledPref(row.item).set(checked)
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun elementLabel(item: StatusBarItem): String = stringResource(
+        when (item) {
+            StatusBarItem.TIME -> TDMR.strings.novel_status_bar_element_time
+            StatusBarItem.CHAPTER -> TDMR.strings.novel_status_bar_element_chapter
+            StatusBarItem.PROGRESS -> TDMR.strings.novel_status_bar_element_progress
+            StatusBarItem.BATTERY -> TDMR.strings.novel_status_bar_element_battery
+        },
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
@@ -57,6 +57,14 @@ import java.util.Date
 import java.util.Locale
 
 /**
+ * Rough upper-bound guess for the bar's rendered height (sized to the larger "medium"
+ * variant), used only to seed callers' state for the very first composition frame before
+ * [NovelStatusBar]'s onSizeChanged reports the real, size/font-scaling-aware height — this
+ * intentionally overestimates so that seed never under-reserves space for an overlay.
+ */
+val EstimatedStatusBarHeight = 40.dp
+
+/**
  * Full-width reading status bar that overlays the top or bottom of the novel reading view.
  *
  * Elements (time, chapter, progress, battery) are rendered left-to-right in [order], each

--- a/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
@@ -162,7 +162,7 @@ fun NovelStatusBar(
                     .fillMaxWidth()
                     .padding(end = 22.dp)
                     .align(Alignment.Center),
-                horizontalArrangement = Arrangement.SpaceEvenly,
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 order.forEach { item ->

--- a/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
@@ -7,13 +7,16 @@ import android.content.IntentFilter
 import android.os.BatteryManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Battery0Bar
 import androidx.compose.material.icons.outlined.Battery1Bar
@@ -22,6 +25,7 @@ import androidx.compose.material.icons.outlined.Battery3Bar
 import androidx.compose.material.icons.outlined.Battery4Bar
 import androidx.compose.material.icons.outlined.Battery5Bar
 import androidx.compose.material.icons.outlined.Battery6Bar
+import androidx.compose.material.icons.outlined.BatteryChargingFull
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material3.Icon
@@ -38,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
@@ -52,38 +57,50 @@ import java.util.Date
 import java.util.Locale
 
 /**
- * Full-width reading status bar that overlays the bottom of the novel reading view.
+ * Full-width reading status bar that overlays the top or bottom of the novel reading view.
  *
- * Displays time (left), chapter (center), and battery+progress (right). A small collapse
- * toggle at the far right lets the user hide the content — collapsed state shows only the
- * background strip matching the reader theme so it blends into the page.
+ * Elements (time, chapter, progress, battery) are rendered left-to-right in [order], each
+ * gated by its own show* flag. A collapse toggle is pinned to the far end. The battery
+ * element optionally reflects charging state.
  *
- * @param chapterText       Pre-formatted chapter string respecting novelChapterTitleDisplay.
- * @param progressPercent   Current scroll position, 0–100.
+ * @param chapterText       Pre-formatted chapter string respecting the display preference.
+ * @param progressPercent   Current scroll position, 0-100.
+ * @param order             Element ids in render order.
  * @param showTime          Whether to include the clock segment.
- * @param showBattery       Whether to include battery % + icon.
  * @param showChapter       Whether to include the chapter segment.
  * @param showProgress      Whether to include the progress % segment.
+ * @param showBattery       Whether to include battery % + icon.
+ * @param showCharging      When true, the battery icon reflects charging state.
  * @param backgroundColor   Reader's background color (matches current novel theme).
  * @param textColor         Reader's foreground/text color (matches current novel theme).
  * @param isCollapsed       When true, content is hidden; only the toggle icon is visible.
  * @param onToggleCollapse  Called when the user taps the collapse/expand icon.
+ * @param onHeightChanged   Reports the measured pixel height so callers can offset overlays.
  */
 @Composable
 fun NovelStatusBar(
     chapterText: String?,
     progressPercent: Int,
+    order: List<StatusBarItem>,
     showTime: Boolean,
-    showBattery: Boolean,
     showChapter: Boolean,
     showProgress: Boolean,
+    showBattery: Boolean,
+    showCharging: Boolean,
     backgroundColor: Color,
     textColor: Color,
     isCollapsed: Boolean,
     onToggleCollapse: () -> Unit,
     modifier: Modifier = Modifier,
+    size: String = "small",
+    onHeightChanged: (Int) -> Unit = {},
 ) {
-    val labelStyle = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Normal, letterSpacing = 0.sp)
+    val medium = size == "medium"
+    val fontSize = if (medium) 14.sp else 11.sp
+    val iconSize = if (medium) 18.dp else 14.dp
+    val toggleSize = if (medium) 20.dp else 16.dp
+    val verticalPadding = if (medium) 10.dp else 6.dp
+    val labelStyle = TextStyle(fontSize = fontSize, fontWeight = FontWeight.Normal, letterSpacing = 0.sp)
     val contentColor = textColor
     val dimColor = textColor.copy(alpha = 0.45f)
 
@@ -101,14 +118,22 @@ fun NovelStatusBar(
 
     // Battery — ACTION_BATTERY_CHANGED is sticky so the current level is available immediately
     var batteryPercent by remember { mutableIntStateOf(-1) }
+    var isCharging by remember { mutableStateOf(false) }
     val context = LocalContext.current
     DisposableEffect(context) {
+        fun apply(intent: Intent) {
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            if (level >= 0 && scale > 0) batteryPercent = level * 100 / scale
+            val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+            val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0)
+            isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL ||
+                plugged != 0
+        }
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(ctx: Context?, intent: Intent?) {
-                intent ?: return
-                val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
-                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-                if (level >= 0 && scale > 0) batteryPercent = level * 100 / scale
+                intent?.let(::apply)
             }
         }
         val sticky = ContextCompat.registerReceiver(
@@ -117,88 +142,82 @@ fun NovelStatusBar(
             IntentFilter(Intent.ACTION_BATTERY_CHANGED),
             ContextCompat.RECEIVER_NOT_EXPORTED,
         )
-        sticky?.let { intent ->
-            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
-            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-            if (level >= 0 && scale > 0) batteryPercent = level * 100 / scale
-        }
+        sticky?.let(::apply)
         onDispose { context.unregisterReceiver(receiver) }
     }
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
             .background(backgroundColor)
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .onSizeChanged { onHeightChanged(it.height) }
+            .padding(horizontal = 12.dp, vertical = verticalPadding),
     ) {
-        // Left: time
-        if (!isCollapsed && showTime) {
-            Text(
-                text = timeText,
-                style = labelStyle,
-                color = contentColor,
-                modifier = Modifier.align(Alignment.CenterStart),
-            )
-        }
+        // Cap chapter width so a long title ellipsizes instead of crowding fixed elements
+        val chapterMaxWidth = maxWidth * 0.55f
 
-        // Center: chapter • progress
         if (!isCollapsed) {
-            val centerText = buildString {
-                if (showChapter && chapterText != null) append(chapterText)
-                if (showChapter && chapterText != null && showProgress) append(" • ")
-                if (showProgress) append("$progressPercent%")
-            }
-            if (centerText.isNotEmpty()) {
-                Text(
-                    text = centerText,
-                    style = labelStyle,
-                    color = contentColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .padding(horizontal = 48.dp),
-                )
-            }
-        }
-
-        // Right: battery icon + % + toggle
-        Row(
-            modifier = Modifier.align(Alignment.CenterEnd),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (!isCollapsed) {
-                if (showBattery && batteryPercent >= 0) {
-                    Icon(
-                        imageVector = batteryIcon(batteryPercent),
-                        contentDescription = null,
-                        tint = contentColor,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Spacer(Modifier.width(2.dp))
-                    Text(
-                        text = "$batteryPercent%",
-                        style = labelStyle,
-                        color = contentColor,
-                    )
-                }
-                Spacer(Modifier.width(6.dp))
-            }
-
-            // Collapse/expand toggle — always visible
-            Icon(
-                imageVector = if (isCollapsed) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                contentDescription = if (isCollapsed) "Expand status bar" else "Collapse status bar",
-                tint = dimColor,
+            Row(
                 modifier = Modifier
-                    .size(16.dp)
-                    .clickable(role = Role.Button, onClick = onToggleCollapse),
-            )
+                    .fillMaxWidth()
+                    .padding(end = 22.dp)
+                    .align(Alignment.Center),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                order.forEach { item ->
+                    when (item) {
+                        StatusBarItem.TIME -> if (showTime) {
+                            Text(text = timeText, style = labelStyle, color = contentColor)
+                        }
+
+                        StatusBarItem.CHAPTER -> if (showChapter && chapterText != null) {
+                            Text(
+                                text = chapterText,
+                                style = labelStyle,
+                                color = contentColor,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.widthIn(max = chapterMaxWidth),
+                            )
+                        }
+
+                        StatusBarItem.PROGRESS -> if (showProgress) {
+                            Text(text = "$progressPercent%", style = labelStyle, color = contentColor)
+                        }
+
+                        StatusBarItem.BATTERY -> if (showBattery && batteryPercent >= 0) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = batteryIcon(batteryPercent, isCharging && showCharging),
+                                    contentDescription = null,
+                                    tint = contentColor,
+                                    modifier = Modifier.size(iconSize),
+                                )
+                                Spacer(Modifier.width(2.dp))
+                                Text(text = "$batteryPercent%", style = labelStyle, color = contentColor)
+                            }
+                        }
+                    }
+                }
+            }
         }
+
+        // Collapse/expand toggle, always visible, pinned to the right
+        Icon(
+            imageVector = if (isCollapsed) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+            contentDescription = if (isCollapsed) "Expand status bar" else "Collapse status bar",
+            tint = dimColor,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .size(toggleSize)
+                .clickable(role = Role.Button, onClick = onToggleCollapse),
+        )
     }
 }
 
-private fun batteryIcon(percent: Int): ImageVector = when {
+private fun batteryIcon(percent: Int, charging: Boolean): ImageVector = when {
+    charging -> Icons.Outlined.BatteryChargingFull
     percent <= 14 -> Icons.Outlined.Battery0Bar
     percent <= 28 -> Icons.Outlined.Battery1Bar
     percent <= 42 -> Icons.Outlined.Battery2Bar

--- a/app/src/main/java/eu/kanade/presentation/reader/StatusBarItemConfig.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/StatusBarItemConfig.kt
@@ -1,5 +1,7 @@
 package eu.kanade.presentation.reader
 
+import kotlinx.serialization.json.Json
+
 enum class StatusBarItem(val id: String) {
     TIME("time"),
     CHAPTER("chapter"),
@@ -14,11 +16,15 @@ val DefaultStatusBarOrder = listOf(
     StatusBarItem.BATTERY,
 )
 
+fun List<StatusBarItem>.serializeStatusBarOrder(): String = Json.encodeToString(map { it.id })
+
 fun String.deserializeStatusBarOrder(): List<StatusBarItem> {
-    val savedIds = split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    // Merge with DefaultStatusBarOrder so an item added in a future app update isn't
+    // silently dropped for existing users — it gets appended at the end.
+    // Falls back to defaults on malformed input, e.g. a value saved in the pre-JSON
+    // comma-separated format by an older build.
+    val savedIds = runCatching { Json.decodeFromString<List<String>>(this) }.getOrDefault(emptyList())
     val saved = savedIds.mapNotNull { id -> StatusBarItem.entries.find { it.id == id } }
     val missing = DefaultStatusBarOrder.filter { it !in saved }
     return (saved + missing).distinct()
 }
-
-fun List<StatusBarItem>.serializeStatusBarOrder(): String = joinToString(",") { it.id }

--- a/app/src/main/java/eu/kanade/presentation/reader/StatusBarItemConfig.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/StatusBarItemConfig.kt
@@ -1,0 +1,24 @@
+package eu.kanade.presentation.reader
+
+enum class StatusBarItem(val id: String) {
+    TIME("time"),
+    CHAPTER("chapter"),
+    PROGRESS("progress"),
+    BATTERY("battery"),
+}
+
+val DefaultStatusBarOrder = listOf(
+    StatusBarItem.TIME,
+    StatusBarItem.CHAPTER,
+    StatusBarItem.PROGRESS,
+    StatusBarItem.BATTERY,
+)
+
+fun String.deserializeStatusBarOrder(): List<StatusBarItem> {
+    val savedIds = split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    val saved = savedIds.mapNotNull { id -> StatusBarItem.entries.find { it.id == id } }
+    val missing = DefaultStatusBarOrder.filter { it !in saved }
+    return (saved + missing).distinct()
+}
+
+fun List<StatusBarItem>.serializeStatusBarOrder(): String = joinToString(",") { it.id }

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AppBar
@@ -155,6 +156,9 @@ fun NovelReaderAppBars(
 
     // Toolbar customization
     bottomBarItems: List<BottomBarItemState>,
+
+    // Extra bottom offset for the floating TTS overlay so it clears the status bar
+    ttsOverlayBottomPadding: Dp = 0.dp,
 ) {
     val backgroundColor = MaterialTheme.colorScheme
         .surfaceColorAtElevation(3.dp)
@@ -230,7 +234,7 @@ fun NovelReaderAppBars(
                         onStartFromViewport = onTtsStartFromViewport,
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
-                            .padding(bottom = MaterialTheme.padding.small),
+                            .padding(bottom = MaterialTheme.padding.small + ttsOverlayBottomPadding),
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -722,6 +722,16 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
         pref = screenModel.preferences.novelStatusBarEnabled,
     )
     if (statusBarEnabled) {
+        val statusBarPosition by screenModel.preferences.novelStatusBarPosition.collectAsState()
+        CheckboxItem(
+            label = stringResource(TDMR.strings.pref_novel_status_bar_at_top),
+            checked = statusBarPosition == "top",
+            onClick = {
+                screenModel.preferences.novelStatusBarPosition.set(
+                    if (statusBarPosition == "top") "bottom" else "top",
+                )
+            },
+        )
         CheckboxItem(
             label = stringResource(TDMR.strings.pref_novel_status_bar_show_time),
             pref = screenModel.preferences.novelStatusBarShowTime,
@@ -731,13 +741,31 @@ internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel
             pref = screenModel.preferences.novelStatusBarShowBattery,
         )
         CheckboxItem(
-            label = stringResource(TDMR.strings.pref_novel_status_bar_show_chapter),
-            pref = screenModel.preferences.novelStatusBarShowChapter,
+            label = stringResource(TDMR.strings.pref_novel_status_bar_show_chapter_number),
+            pref = screenModel.preferences.novelStatusBarShowChapterNumber,
+        )
+        CheckboxItem(
+            label = stringResource(TDMR.strings.pref_novel_status_bar_show_chapter_title),
+            pref = screenModel.preferences.novelStatusBarShowChapterTitle,
         )
         CheckboxItem(
             label = stringResource(TDMR.strings.pref_novel_status_bar_show_progress),
             pref = screenModel.preferences.novelStatusBarShowProgress,
         )
+        val statusBarSize by screenModel.preferences.novelStatusBarSize.collectAsState()
+        val statusBarSizeOptions = listOf(
+            stringResource(TDMR.strings.novel_status_bar_size_small) to "small",
+            stringResource(TDMR.strings.novel_status_bar_size_medium) to "medium",
+        )
+        InlineSettingsChipRow(TDMR.strings.pref_novel_status_bar_size) {
+            statusBarSizeOptions.forEach { (label, value) ->
+                FilterChip(
+                    selected = statusBarSize == value,
+                    onClick = { screenModel.preferences.novelStatusBarSize.set(value) },
+                    label = { Text(label) },
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -61,6 +61,7 @@ import com.hippo.unifile.UniFile
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.reader.DisplayRefreshHost
+import eu.kanade.presentation.reader.EstimatedStatusBarHeight
 import eu.kanade.presentation.reader.NovelStatusBar
 import eu.kanade.presentation.reader.OrientationSelectDialog
 import eu.kanade.presentation.reader.ReaderContentOverlay
@@ -363,8 +364,10 @@ class ReaderActivity : BaseActivity() {
         val novelBgColorInt by readerPreferences.novelBackgroundColor.collectAsState()
         val novelFontColorInt by readerPreferences.novelFontColor.collectAsState()
         var statusBarCollapsed by remember { mutableStateOf(false) }
-        var statusBarHeightPx by remember { mutableIntStateOf(0) }
         val density = LocalDensity.current
+        var statusBarHeightPx by remember {
+            mutableIntStateOf(with(density) { EstimatedStatusBarHeight.roundToPx() })
+        }
         val settingsScreenModel = remember {
             ReaderSettingsScreenModel(
                 readerState = viewModel.state,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
@@ -36,11 +37,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
@@ -71,6 +75,7 @@ import eu.kanade.presentation.reader.appbars.QuotesSheet
 import eu.kanade.presentation.reader.appbars.ReaderAppBars
 import eu.kanade.presentation.reader.appbars.bottomBarItemInfo
 import eu.kanade.presentation.reader.components.ChapterNavigatorType
+import eu.kanade.presentation.reader.deserializeStatusBarOrder
 import eu.kanade.presentation.reader.settings.ReaderSettingsDialog
 import eu.kanade.presentation.util.formatChapterNumber
 import eu.kanade.tachiyomi.R
@@ -346,14 +351,20 @@ class ReaderActivity : BaseActivity() {
         val novelStatusBarEnabled by readerPreferences.novelStatusBarEnabled.collectAsState()
         val novelStatusBarShowTime by readerPreferences.novelStatusBarShowTime.collectAsState()
         val novelStatusBarShowBattery by readerPreferences.novelStatusBarShowBattery.collectAsState()
-        val novelStatusBarShowChapter by readerPreferences.novelStatusBarShowChapter.collectAsState()
+        val novelStatusBarShowChapterNumber by readerPreferences.novelStatusBarShowChapterNumber.collectAsState()
+        val novelStatusBarShowChapterTitle by readerPreferences.novelStatusBarShowChapterTitle.collectAsState()
         val novelStatusBarShowProgress by readerPreferences.novelStatusBarShowProgress.collectAsState()
+        val novelStatusBarPosition by readerPreferences.novelStatusBarPosition.collectAsState()
+        val novelStatusBarSize by readerPreferences.novelStatusBarSize.collectAsState()
+        val novelStatusBarShowCharging by readerPreferences.novelStatusBarShowCharging.collectAsState()
+        val novelStatusBarOrderRaw by readerPreferences.novelStatusBarOrder.collectAsState()
         val novelTtsControlsActive by readerPreferences.novelTtsControlsVisible.collectAsState()
-        val novelStatusBarChapterDisplay by readerPreferences.novelChapterTitleDisplay.collectAsState()
         val novelTheme by readerPreferences.novelTheme.collectAsState()
         val novelBgColorInt by readerPreferences.novelBackgroundColor.collectAsState()
         val novelFontColorInt by readerPreferences.novelFontColor.collectAsState()
         var statusBarCollapsed by remember { mutableStateOf(false) }
+        var statusBarHeightPx by remember { mutableIntStateOf(0) }
+        val density = LocalDensity.current
         val settingsScreenModel = remember {
             ReaderSettingsScreenModel(
                 readerState = viewModel.state,
@@ -376,23 +387,31 @@ class ReaderActivity : BaseActivity() {
 
             ContentOverlay(state = state)
 
-            AppBars(state = state)
+            val statusBarAtBottom = novelStatusBarPosition != "top"
+            val ttsOverlayBottomPadding = if (
+                isNovelMode && novelStatusBarEnabled && statusBarAtBottom && !state.menuVisible
+            ) {
+                with(density) { statusBarHeightPx.toDp() }
+            } else {
+                0.dp
+            }
+
+            AppBars(state = state, ttsOverlayBottomPadding = ttsOverlayBottomPadding)
 
             if (isNovelMode && !state.menuVisible && novelStatusBarEnabled) {
                 val chapter = state.novelVisibleChapter ?: state.currentChapter?.chapter
-                val chapterText: String? = chapter?.let { ch ->
-                    val numStr = if (ch.chapter_number >=
-                        0f
-                    ) {
+                val showChapterSegment = novelStatusBarShowChapterNumber || novelStatusBarShowChapterTitle
+                val chapterText: String? = chapter?.takeIf { showChapterSegment }?.let { ch ->
+                    val numStr = if (novelStatusBarShowChapterNumber && ch.chapter_number >= 0f) {
                         "Ch. ${formatChapterNumber(ch.chapter_number.toDouble())}"
                     } else {
                         null
                     }
-                    val nameStr = ch.name.ifEmpty { null }
-                    when (novelStatusBarChapterDisplay) {
-                        1 -> numStr ?: nameStr
-                        2 -> if (numStr != null && nameStr != null) "$numStr: $nameStr" else numStr ?: nameStr
-                        else -> nameStr ?: numStr
+                    val nameStr = if (novelStatusBarShowChapterTitle) ch.name.ifEmpty { null } else null
+                    when {
+                        numStr != null && nameStr != null -> "$numStr: $nameStr"
+                        numStr != null -> numStr
+                        else -> nameStr
                     }
                 }
                 val (bgInt, textInt) = remember(novelTheme, novelBgColorInt, novelFontColorInt) {
@@ -400,21 +419,27 @@ class ReaderActivity : BaseActivity() {
                 }
                 val readerBgColor = ComposeColor(bgInt)
                 val readerTextColor = ComposeColor(textInt)
-                val extraPad = if (novelTtsControlsActive) 56.dp else 0.dp
+                val statusBarOrder = remember(novelStatusBarOrderRaw) {
+                    novelStatusBarOrderRaw.deserializeStatusBarOrder()
+                }
                 NovelStatusBar(
                     chapterText = chapterText,
                     progressPercent = state.novelProgressPercent,
+                    order = statusBarOrder,
                     showTime = novelStatusBarShowTime,
-                    showBattery = novelStatusBarShowBattery,
-                    showChapter = novelStatusBarShowChapter,
+                    showChapter = showChapterSegment,
                     showProgress = novelStatusBarShowProgress,
+                    showBattery = novelStatusBarShowBattery,
+                    showCharging = novelStatusBarShowCharging,
                     backgroundColor = readerBgColor,
                     textColor = readerTextColor,
                     isCollapsed = statusBarCollapsed,
                     onToggleCollapse = { statusBarCollapsed = !statusBarCollapsed },
+                    size = novelStatusBarSize,
+                    onHeightChanged = { statusBarHeightPx = it },
                     modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = extraPad),
+                        .align(if (statusBarAtBottom) Alignment.BottomCenter else Alignment.TopCenter)
+                        .then(if (statusBarAtBottom) Modifier else Modifier.statusBarsPadding()),
                 )
             }
         }
@@ -677,7 +702,7 @@ class ReaderActivity : BaseActivity() {
     }
 
     @Composable
-    fun AppBars(state: ReaderViewModel.State) {
+    fun AppBars(state: ReaderViewModel.State, ttsOverlayBottomPadding: Dp = 0.dp) {
         if (!ifSourcesLoaded()) {
             return
         }
@@ -1027,6 +1052,7 @@ class ReaderActivity : BaseActivity() {
                 isWebView = state.viewer is NovelWebViewViewer,
                 bottomBarItems = bottomBarItems,
                 onQuotes = ::onQuotesClicked,
+                ttsOverlayBottomPadding = ttsOverlayBottomPadding,
             )
 
             androidx.activity.compose.BackHandler(enabled = isEditing && state.hasUnsavedChanges) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.ui.reader.setting
 import android.os.Build
 import androidx.compose.ui.graphics.BlendMode
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.presentation.reader.DefaultStatusBarOrder
 import eu.kanade.presentation.reader.appbars.DefaultBottomBarItems
 import eu.kanade.presentation.reader.appbars.serialize
+import eu.kanade.presentation.reader.serializeStatusBarOrder
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
@@ -430,7 +432,7 @@ class ReaderPreferences(
 
     val novelStatusBarOrder: Preference<String> = preferenceStore.getString(
         "pref_novel_status_bar_order",
-        "time,chapter,progress,battery",
+        DefaultStatusBarOrder.serializeStatusBarOrder(),
     )
     // endregion
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -400,13 +400,37 @@ class ReaderPreferences(
         "pref_novel_status_bar_show_battery",
         true,
     )
-    val novelStatusBarShowChapter: Preference<Boolean> = preferenceStore.getBoolean(
-        "pref_novel_status_bar_show_chapter",
+    val novelStatusBarShowChapterNumber: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_novel_status_bar_show_chapter_number",
+        true,
+    )
+    val novelStatusBarShowChapterTitle: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_novel_status_bar_show_chapter_title",
         true,
     )
     val novelStatusBarShowProgress: Preference<Boolean> = preferenceStore.getBoolean(
         "pref_novel_status_bar_show_progress",
         true,
+    )
+
+    val novelStatusBarPosition: Preference<String> = preferenceStore.getString(
+        "pref_novel_status_bar_position",
+        "bottom",
+    )
+
+    val novelStatusBarSize: Preference<String> = preferenceStore.getString(
+        "pref_novel_status_bar_size",
+        "small",
+    )
+
+    val novelStatusBarShowCharging: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_novel_status_bar_show_charging",
+        true,
+    )
+
+    val novelStatusBarOrder: Preference<String> = preferenceStore.getString(
+        "pref_novel_status_bar_order",
+        "time,chapter,progress,battery",
     )
     // endregion
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -1711,6 +1711,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 setScrollProgress(progress)
                 logcat(LogPriority.DEBUG) { "NovelViewer: Scroll restored to ${(progress * 100).toInt()}%" }
                 isRestoringScroll = false
+                lastSavedProgress = progress
+                activity.onNovelProgressChanged(progress)
             }
         }
 

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -909,6 +909,22 @@
     <string name="pref_novel_status_bar">Reading status bar</string>
     <string name="pref_novel_status_bar_show_time">Show current time</string>
     <string name="pref_novel_status_bar_show_battery">Show battery percentage</string>
-    <string name="pref_novel_status_bar_show_chapter">Show chapter title</string>
     <string name="pref_novel_status_bar_show_progress">Show reading progress</string>
+    <string name="pref_novel_status_bar_position">Status bar position</string>
+    <string name="pref_novel_status_bar_size">Status bar size</string>
+    <string name="novel_status_bar_size_small">Small</string>
+    <string name="novel_status_bar_size_medium">Medium</string>
+    <string name="novel_status_bar_position_top">Top</string>
+    <string name="novel_status_bar_position_bottom">Bottom</string>
+    <string name="pref_novel_status_bar_at_top">Status bar at top</string>
+    <string name="pref_novel_status_bar_show_chapter_number">Show chapter number</string>
+    <string name="pref_novel_status_bar_show_chapter_title">Show chapter title</string>
+    <string name="pref_novel_status_bar_show_charging">Show charging indicator</string>
+    <string name="pref_novel_status_bar_show_charging_summary">Battery icon reflects charging state when plugged in</string>
+    <string name="pref_novel_status_bar_customize">Customize status bar elements</string>
+    <string name="pref_novel_status_bar_customize_summary">Reorder and toggle time, chapter, progress and battery</string>
+    <string name="novel_status_bar_element_time">Time</string>
+    <string name="novel_status_bar_element_chapter">Chapter</string>
+    <string name="novel_status_bar_element_progress">Progress</string>
+    <string name="novel_status_bar_element_battery">Battery</string>
 </resources>


### PR DESCRIPTION
Add a new customization screen to reorder status bar elements (Time, Chapter, Progress, Battery) and toggle their visibility. The status bar can now be positioned at either the top or bottom of the reader and supports "small" and "medium" sizing options.

- Added `StatusBarElementsScreen` for reordering.
- Split chapter display into independent "Number" and "Title" toggles.
- Added a charging indicator to the battery icon.
- Improved layout logic to prevent long chapter titles from pushing fixed elements.
- Adjusted TTS overlay padding to avoid overlapping the status bar when it is positioned at the bottom.
