### PR TITLE
feat(reader): adjust vertical progress bar dimensions and remove perc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Option for tag normalization during entry updates [@mrissaoussama](https://github.com/mrissaoussama) [#287](https://github.com/tsundoku-otaku/tsundoku/pull/287)
 - Reader Status Bar [@Rojikku](https://github.com/Rojikku) [#302](https://github.com/tsundoku-otaku/tsundoku/pull/302)
 
+
+### Changed
+- Adjust vertical progress bar dimensions; remove percent [@mrissaoussama](https://github.com/mrissaoussama) [#319](https://github.com/tsundoku-otaku/tsundoku/pull/319)
+
+
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - Novel download queue improvements to prevent errors [@mrissaoussama](https://github.com/mrissaoussama) [#284](https://github.com/tsundoku-otaku/tsundoku/pull/284)

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -92,8 +92,8 @@ private const val PROGRESS_SLIDER_MODE_HORIZONTAL = "horizontal"
 private const val PROGRESS_SLIDER_MODE_VERTICAL_LEFT = "vertical_left"
 private const val PROGRESS_SLIDER_MODE_VERTICAL_RIGHT = "vertical_right"
 private const val VERTICAL_PROGRESS_SIZE_HALF = "half"
-private val VERTICAL_PROGRESS_CONTAINER_WIDTH = 40.dp
-private val VERTICAL_PROGRESS_EDGE_INSET = 6.dp
+private val VERTICAL_PROGRESS_CONTAINER_WIDTH = 6.dp
+private val VERTICAL_PROGRESS_EDGE_INSET = 3.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -772,8 +772,6 @@ private fun NovelVerticalProgressSlider(
             .padding(horizontal = 10.dp, vertical = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "$currentProgress%")
-
         Box(
             modifier = Modifier
                 .weight(1f)


### PR DESCRIPTION
…entage

* Reduce `VERTICAL_PROGRESS_CONTAINER_WIDTH` to 6.dp and `VERTICAL_PROGRESS_EDGE_INSET` to 3.dp.
* Remove the percentage text display from the vertical progress bar.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
