### PR TITLE
Fix/customsource improvements+ url build fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Mass import improvements and resume counting [@mrissaoussama](https://github.com/mrissaoussama) [#288](https://github.com/tsundoku-otaku/tsundoku/pull/288)
 - EPUBC ToC Subsection Fix [@mrissaoussama](https://github.com/mrissaoussama) [#315](https://github.com/tsundoku-otaku/tsundoku/pull/315)
 - Append clipboard added in edit quotes [@Rojikku](https://github.com/Rojikku) [#301](https://github.com/tsundoku-otaku/tsundoku/pull/301)
+- Customsource improvements and url build fixes [@mrissaoussama](https://github.com/mrissaoussama) [#322](https://github.com/tsundoku-otaku/tsundoku/pull/322)
 - Prevent duplicate custom sources [@mrissaoussama](https://github.com/mrissaoussama) [#294](https://github.com/tsundoku-otaku/tsundoku/pull/294)
 - Added novel extension repos entry into browse settings [@mrissaoussama](https://github.com/mrissaoussama) [#304](https://github.com/tsundoku-otaku/tsundoku/pull/304)
 - Added bulk import/export, block duplicate imports [@mrissaoussama](https://github.com/mrissaoussama) [#303](https://github.com/tsundoku-otaku/tsundoku/pull/303)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -898,7 +898,9 @@ class CustomNovelSource(
 
     override suspend fun fetchPageText(page: Page): String {
         val bs = baseSource
-        if (bs != null && bs.isNovelSource()) {
+        // A custom content selector wins over delegation: a mirror on a different engine than the
+        // base ext (e.g. novelphoenix vs novelfire) needs its own content extraction.
+        if (bs != null && bs.isNovelSource() && config.selectors.content.primary.isBlank()) {
             // For content fetching, we need absolute URLs (not relative paths)
             // buildAbsoluteUrl() converts relative to absolute on custom base
             val absoluteUrl = buildAbsoluteUrl(page.url)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -618,7 +618,7 @@ class CustomNovelSource(
         val chapters = generatedChapterEntries(resolvedPattern, start, end, sel.nameTemplate).map { entry ->
             SChapter.create().apply {
                 // Normalize to a path relative to baseUrl (getPageList rebuilds the absolute URL).
-                url = buildAbsoluteUrl(entry.url).removePrefix(baseUrl.trimEnd('/')).ifBlank { entry.url }
+                url = toRelativeStoredUrl(entry.url).ifBlank { entry.url }
                 name = entry.name
                 chapter_number = entry.number
             }
@@ -727,6 +727,15 @@ class CustomNovelSource(
         return super.getPageList(chapter)
     }
 
+    // Default HttpSource builds these as baseUrl + url. A stored url may be absolute (legacy
+    // entries, or a host that didn't match baseUrl at parse time), so route through
+    // buildAbsoluteUrl to avoid gluing baseUrl onto an absolute url.
+    override fun mangaDetailsRequest(manga: SManga): Request = GET(buildAbsoluteUrl(manga.url), headers)
+
+    override fun chapterListRequest(manga: SManga): Request = GET(buildAbsoluteUrl(manga.url), headers)
+
+    override fun pageListRequest(chapter: SChapter): Request = GET(buildAbsoluteUrl(chapter.url), headers)
+
     // ======================== Popular ========================
 
     override fun popularMangaRequest(page: Int): Request {
@@ -810,7 +819,7 @@ class CustomNovelSource(
             ?: document.selectFirst("a[href*=chapter]")
 
         return SChapter.create().apply {
-            url = link?.attr("abs:href")?.removePrefix(baseUrl) ?: ""
+            url = toRelativeStoredUrl(link?.attr("abs:href"))
             name = document.selectText(selectors.name)
                 ?: link?.text()?.trim()
                 ?: "Chapter"
@@ -854,7 +863,7 @@ class CustomNovelSource(
         return document.select(selectors.list).mapNotNull { element ->
             try {
                 val link = resolveLink(element, selectors.link)
-                val url = link?.attr("abs:href")?.removePrefix(baseUrl) ?: return@mapNotNull null
+                val url = toRelativeStoredUrl(link?.attr("abs:href")).ifBlank { return@mapNotNull null }
 
                 SChapter.create().apply {
                     this.url = url
@@ -1000,7 +1009,7 @@ class CustomNovelSource(
             try {
                 SManga.create().apply {
                     val link = resolveLink(element, selectors.link)
-                    url = link?.attr("abs:href")?.removePrefix(baseUrl) ?: return@mapNotNull null
+                    url = toRelativeStoredUrl(link?.attr("abs:href")).ifBlank { return@mapNotNull null }
                     title = element.selectText(selectors.title)
                         ?: link?.attr("title")?.ifBlank { null }
                         ?: link?.text()?.trim()
@@ -1197,6 +1206,22 @@ class CustomNovelSource(
 
         // Otherwise, it's a relative path - add slash between baseUrl and path
         return "$baseUrl/$trimmedUrl"
+    }
+
+    // Strips scheme+host so a stored url is always a path, even when the site's links use a
+    // different host than baseUrl (www vs non-www, mirrors). Without this, baseUrl + absoluteUrl
+    // glues into a broken host like "site.comhttps://..." on the next request.
+    private fun toRelativeStoredUrl(href: String?): String {
+        val value = normalizeCustomUrl(href)?.trim().orEmpty()
+        if (value.isBlank()) return ""
+        value.toHttpUrlOrNull()?.let { http ->
+            return buildString {
+                append(http.encodedPath)
+                http.encodedQuery?.let { append('?').append(it) }
+                http.encodedFragment?.let { append('#').append(it) }
+            }
+        }
+        return if (value.startsWith("/")) value else "/$value"
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -727,9 +727,7 @@ class CustomNovelSource(
         return super.getPageList(chapter)
     }
 
-    // Default HttpSource builds these as baseUrl + url. A stored url may be absolute (legacy
-    // entries, or a host that didn't match baseUrl at parse time), so route through
-    // buildAbsoluteUrl to avoid gluing baseUrl onto an absolute url.
+    // Route through buildAbsoluteUrl so an already-absolute stored url isn't glued onto baseUrl.
     override fun mangaDetailsRequest(manga: SManga): Request = GET(buildAbsoluteUrl(manga.url), headers)
 
     override fun chapterListRequest(manga: SManga): Request = GET(buildAbsoluteUrl(manga.url), headers)
@@ -898,8 +896,7 @@ class CustomNovelSource(
 
     override suspend fun fetchPageText(page: Page): String {
         val bs = baseSource
-        // A custom content selector wins over delegation: a mirror on a different engine than the
-        // base ext (e.g. novelphoenix vs novelfire) needs its own content extraction.
+        // A custom content selector overrides delegation.
         if (bs != null && bs.isNovelSource() && config.selectors.content.primary.isBlank()) {
             // For content fetching, we need absolute URLs (not relative paths)
             // buildAbsoluteUrl() converts relative to absolute on custom base
@@ -1210,9 +1207,7 @@ class CustomNovelSource(
         return "$baseUrl/$trimmedUrl"
     }
 
-    // Strips scheme+host so a stored url is always a path, even when the site's links use a
-    // different host than baseUrl (www vs non-www, mirrors). Without this, baseUrl + absoluteUrl
-    // glues into a broken host like "site.comhttps://..." on the next request.
+    // Strip scheme+host so a mismatched host (www, mirror) can't glue into baseUrl + url later.
     private fun toRelativeStoredUrl(href: String?): String {
         val value = normalizeCustomUrl(href)?.trim().orEmpty()
         if (value.isBlank()) return ""

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -1207,11 +1207,18 @@ class CustomNovelSource(
         return "$baseUrl/$trimmedUrl"
     }
 
-    // Strip scheme+host so a mismatched host (www, mirror) can't glue into baseUrl + url later.
+    // Strip scheme+host only when it's baseUrl itself (mod www.), so a same-site url stays
+    // portable across baseUrl edits. A genuinely different host (real mirror/CDN) is kept
+    // absolute -- buildAbsoluteUrl() passes absolute urls through untouched -- instead of being
+    // silently glued onto baseUrl and pointed at the wrong site.
     private fun toRelativeStoredUrl(href: String?): String {
         val value = normalizeCustomUrl(href)?.trim().orEmpty()
         if (value.isBlank()) return ""
         value.toHttpUrlOrNull()?.let { http ->
+            val baseHost = baseUrl.toHttpUrlOrNull()?.host?.removePrefix("www.")
+            if (baseHost == null || !http.host.removePrefix("www.").equals(baseHost, ignoreCase = true)) {
+                return value
+            }
             return buildString {
                 append(http.encodedPath)
                 http.encodedQuery?.let { append('?').append(it) }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import eu.kanade.tachiyomi.util.source.getChapterUrlOrNull
+import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
@@ -375,13 +377,15 @@ class CustomSourceManager(
         testMangaSource: String?,
         results: MutableMap<String, TestStepResult>,
     ) {
+        val detailsUrl = source.getMangaUrlOrNull(testManga) ?: testManga.url
         try {
             val details = source.getMangaDetails(testManga)
             val success = details.title.isNotBlank()
             results["details"] = TestStepResult(
                 success = success,
-                message = if (success) "Got details for: ${details.title}" else "Failed to get title",
+                message = if (success) "Got details for: ${details.title}" else "Failed to get title for $detailsUrl",
                 data = mapOf(
+                    "URL" to detailsUrl,
                     "Title" to details.title,
                     "Author" to (details.author ?: "N/A"),
                     "Description" to (details.description?.take(150)?.let { "$it..." } ?: "None"),
@@ -395,7 +399,7 @@ class CustomSourceManager(
                 ),
             )
         } catch (e: Exception) {
-            results["details"] = TestStepResult(success = false, message = "Error: ${e.message}")
+            results["details"] = TestStepResult(success = false, message = "Error for $detailsUrl: ${e.message}")
         }
 
         try {
@@ -429,6 +433,7 @@ class CustomSourceManager(
             if (chapters.isNotEmpty()) {
                 try {
                     val chapterToTest = chapters.last()
+                    val contentUrl = source.getChapterUrlOrNull(chapterToTest) ?: chapterToTest.url
                     val pages = source.getPageList(chapterToTest)
                     if (pages.isNotEmpty()) {
                         val content = source.fetchPageText(pages.first())
@@ -443,18 +448,18 @@ class CustomSourceManager(
                             message = if (content.isNotBlank()) {
                                 "Content length: ${content.length} chars"
                             } else {
-                                "Empty content - check content selectors or base source compatibility"
+                                "Empty content for $contentUrl - check content selectors or base source compatibility"
                             },
-                            data = mapOf("Preview" to preview),
+                            data = mapOf("URL" to contentUrl, "Preview" to preview),
                         )
                     } else {
                         results["content"] = TestStepResult(
                             success = false,
-                            message = "No pages returned from getPageList",
+                            message = "No pages returned from getPageList for $contentUrl",
                         )
                     }
                 } catch (e: Exception) {
-                    results["content"] = TestStepResult(success = false, message = "Error: ${e.message}")
+                    results["content"] = TestStepResult(success = false, message = "Error for ${chapters.last().url}: ${e.message}")
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -328,8 +328,14 @@ class CustomSourceManager(
         // Reading: details + chapters + content. Needs a sample novel; when this section is run on
         // its own, fetch one silently from whichever listing works instead of failing.
         if (all || section == SourceTestSection.READING) {
-            if (testManga == null) {
-                testManga = findSampleManga(source)?.also { testMangaSource = "auto" }
+            // The sample novel URL is the intended reading target; prefer it over a listing's first
+            // result, which can be a stray non-novel link (e.g. a genre page) from a loose selector.
+            val hasSample = !source.config.sampleNovelUrl.isNullOrBlank()
+            if (testManga == null || hasSample) {
+                findSampleManga(source)?.let {
+                    testManga = it
+                    testMangaSource = if (hasSample) "sample" else "auto"
+                }
             }
             if (testManga == null) {
                 results["reading"] = TestStepResult(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -436,9 +436,9 @@ class CustomSourceManager(
             )
 
             if (chapters.isNotEmpty()) {
+                val chapterToTest = chapters.last()
+                val contentUrl = source.getChapterUrlOrNull(chapterToTest) ?: chapterToTest.url
                 try {
-                    val chapterToTest = chapters.last()
-                    val contentUrl = source.getChapterUrlOrNull(chapterToTest) ?: chapterToTest.url
                     val pages = source.getPageList(chapterToTest)
                     if (pages.isNotEmpty()) {
                         val content = source.fetchPageText(pages.first())
@@ -464,7 +464,7 @@ class CustomSourceManager(
                         )
                     }
                 } catch (e: Exception) {
-                    results["content"] = TestStepResult(success = false, message = "Error for ${chapters.last().url}: ${e.message}")
+                    results["content"] = TestStepResult(success = false, message = "Error for $contentUrl: ${e.message}")
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomSourceManager.kt
@@ -328,8 +328,7 @@ class CustomSourceManager(
         // Reading: details + chapters + content. Needs a sample novel; when this section is run on
         // its own, fetch one silently from whichever listing works instead of failing.
         if (all || section == SourceTestSection.READING) {
-            // The sample novel URL is the intended reading target; prefer it over a listing's first
-            // result, which can be a stray non-novel link (e.g. a genre page) from a loose selector.
+            // Prefer the sample novel over a listing's first result, which may be a stray non-novel link.
             val hasSample = !source.config.sampleNovelUrl.isNullOrBlank()
             if (testManga == null || hasSample) {
                 findSampleManga(source)?.let {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1761,9 +1761,13 @@ class CustomSourceEditorScreen(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                } // browse/detail/chapter selectors only apply to a from-scratch (non-delegated) source
 
-                    Text(stringResource(TDMR.strings.custom_source_chapter_content), fontWeight = FontWeight.Medium)
+                // Content selectors + sample/advanced are shown even when delegating to a base
+                // extension, so a mirror on a different engine can override content extraction.
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(stringResource(TDMR.strings.custom_source_chapter_content), fontWeight = FontWeight.Medium)
                     OutlinedTextField(
                         value = contentPrimarySelector,
                         onValueChange = { contentPrimarySelector = it },
@@ -1843,8 +1847,6 @@ class CustomSourceEditorScreen(
                         singleLine = true,
                         supportingText = { Text(stringResource(TDMR.strings.custom_source_sample_novel_url_desc)) },
                     )
-                } // end if (selectedBasedOnSourceId == null)
-
                 errorMessage?.let {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -71,6 +71,7 @@ import eu.kanade.tachiyomi.jsplugin.JsPluginManager
 import eu.kanade.tachiyomi.source.custom.CustomSourceConfig
 import eu.kanade.tachiyomi.source.custom.SourceTestResult
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -1091,6 +1092,14 @@ class CustomSourceEditorScreen(
                 )
             }
         }
+        fun openUrlTrailing(url: String): @Composable () -> Unit = {
+            IconButton(onClick = { navigator.push(WebViewScreen(firstPageUrl(url))) }) {
+                Icon(
+                    Icons.Outlined.Language,
+                    contentDescription = stringResource(TDMR.strings.custom_source_pick_from_site),
+                )
+            }
+        }
 
         Scaffold(
             topBar = {
@@ -1378,6 +1387,7 @@ class CustomSourceEditorScreen(
                             value = popularUrl,
                             onValueChange = { popularUrl = it },
                             label = { Text(stringResource(TDMR.strings.custom_source_popular_url)) },
+                            trailingIcon = openUrlTrailing(popularUrl),
                             modifier = Modifier.fillMaxWidth(),
                             placeholder = { Text(stringResource(TDMR.strings.custom_source_popular_url_hint)) },
                         )
@@ -1388,6 +1398,7 @@ class CustomSourceEditorScreen(
                             value = latestUrl,
                             onValueChange = { latestUrl = it },
                             label = { Text(stringResource(TDMR.strings.custom_source_latest_url)) },
+                            trailingIcon = openUrlTrailing(latestUrl),
                             modifier = Modifier.fillMaxWidth(),
                         )
                     }
@@ -1397,6 +1408,7 @@ class CustomSourceEditorScreen(
                             value = searchUrl,
                             onValueChange = { searchUrl = it },
                             label = { Text(stringResource(TDMR.strings.custom_source_search_url)) },
+                            trailingIcon = openUrlTrailing(searchUrl),
                             modifier = Modifier.fillMaxWidth(),
                             placeholder = { Text(stringResource(TDMR.strings.custom_source_search_url_hint)) },
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1763,7 +1763,9 @@ class CustomSourceEditorScreen(
 
                 }
 
-                // Content + sample/advanced stay editable when delegating, so a mirror can override content.
+                // Content + sample/advanced stay editable when delegating, so a mirror can override
+                // content. Still novel-only: manga sources delegate content entirely to the base source.
+                if (isNovel) {
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(stringResource(TDMR.strings.custom_source_chapter_content), fontWeight = FontWeight.Medium)
@@ -1846,6 +1848,7 @@ class CustomSourceEditorScreen(
                         singleLine = true,
                         supportingText = { Text(stringResource(TDMR.strings.custom_source_sample_novel_url_desc)) },
                     )
+                }
                 errorMessage?.let {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1079,7 +1079,7 @@ class CustomSourceEditorScreen(
         var pickerUrl by remember { mutableStateOf("") }
         var pickerLabel by remember { mutableStateOf("") }
         fun firstPageUrl(u: String): String =
-            u.replace("{page}", "1").replace("{query}", "a").ifBlank { baseUrl }
+            u.replace("{baseUrl}", baseUrl).replace("{page}", "1").replace("{query}", "a").ifBlank { baseUrl }
         fun pickTrailing(url: String, fieldLabel: String, set: (String) -> Unit): @Composable () -> Unit = {
             IconButton(onClick = {
                 pickerUrl = url.ifBlank { baseUrl }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -1761,10 +1761,9 @@ class CustomSourceEditorScreen(
                         }
                     }
 
-                } // browse/detail/chapter selectors only apply to a from-scratch (non-delegated) source
+                }
 
-                // Content selectors + sample/advanced are shown even when delegating to a base
-                // extension, so a mirror on a different engine can override content extraction.
+                // Content + sample/advanced stay editable when delegating, so a mirror can override content.
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(stringResource(TDMR.strings.custom_source_chapter_content), fontWeight = FontWeight.Medium)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/customsource/ElementSelectorScreen.kt
@@ -2556,8 +2556,8 @@ internal val ELEMENT_SELECTOR_JS = """
 internal fun deriveSearchUrl(url: String, baseUrl: String, userQuery: String): String? {
     if (userQuery.isBlank()) return null
 
-    val baseHost = runCatching { java.net.URI(baseUrl.trimEnd('/')).host }.getOrNull()
-    val currentHost = runCatching { java.net.URI(url).host }.getOrNull()
+    val baseHost = runCatching { java.net.URI(baseUrl.trimEnd('/')).host }.getOrNull()?.removePrefix("www.")
+    val currentHost = runCatching { java.net.URI(url).host }.getOrNull()?.removePrefix("www.")
     if (baseHost != null && currentHost != null && !currentHost.equals(baseHost, ignoreCase = true)) {
         return null
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/customsource/SelectorUrlAlgorithmsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/customsource/SelectorUrlAlgorithmsTest.kt
@@ -81,4 +81,12 @@ class SelectorUrlAlgorithmsTest {
         assertNull(deriveSearchUrl("https://site.com/?s=other", "https://site.com", "sword"))
         assertNull(deriveSearchUrl("https://site.com/?s=sword", "https://site.com", ""))
     }
+
+    @Test
+    fun `deriveSearchUrl matches across www and non-www hosts`() {
+        assertEquals(
+            "https://www.site.com/search?keyword={query}",
+            deriveSearchUrl("https://www.site.com/search?keyword=World", "https://site.com", "World"),
+        )
+    }
 }


### PR DESCRIPTION
- Ignore www when running search pattern detection
- make source test use sample novel url if available
- let custom sources that derive from another source be able to override the ch content selector.
- add webview selector icons to latest/popuar/search inputs
- fixed some url matching logic that build urls incorrectly in custom source.