### PR TITLE
Migrate to 1.6 - Deprecate RefreshContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix a rare translation queue exception [@mrissaoussama](https://github.com/mrissaoussama) [#286](https://github.com/tsundoku-otaku/tsundoku/pull/286)
 
 ### Other
+- Deprecate RefreshContext for 1.6 [@Rojikku](https://github.com/Rojikku) [#325](https://github.com/tsundoku-otaku/tsundoku/pull/325)
 - jsplugins should surface fetch errors [@mrissaoussama](https://github.com/mrissaoussama) [#293](https://github.com/tsundoku-otaku/tsundoku/pull/293)
 - Improve extension repo URL format parsing [@mrissaoussama](https://github.com/mrissaoussama) [#316](https://github.com/tsundoku-otaku/tsundoku/pull/316)
 - Optimize bulk data clearing and chapter removal [@mrissaoussama](https://github.com/mrissaoussama) [#313](https://github.com/tsundoku-otaku/tsundoku/pull/313)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -24,7 +24,6 @@ import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.notification.Notifications
-import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
@@ -480,12 +479,12 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         if (skipChapterFetch) return emptyList()
 
         val existingChapters = getChaptersByMangaId.await(manga.id)
-        val refreshContext = RefreshContext(
-            mangaId = manga.id,
-            existingChapters = existingChapters.toRefreshContextChapters(),
-            lastFetchTime = manga.lastUpdate,
-        )
-        val chapters = source.getChapterList(manga.toSManga(), refreshContext)
+        val chapters = source.getMangaUpdate(
+            manga.toSManga(),
+            existingChapters.toRefreshContextChapters(),
+            fetchDetails = false,
+            fetchChapters = true,
+        ).chapters
 
         // Get manga from database to account for if it was removed during the update and
         // to get latest data so it doesn't get overwritten later on

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -41,7 +41,6 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.translation.TranslationJob
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.source.Source
-import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
@@ -763,13 +762,13 @@ class MangaScreenModel(
         try {
             withIOContext {
                 val existingChapters = getMangaAndChapters.awaitChapters(state.manga.id)
-                val refreshContext = RefreshContext(
-                    mangaId = state.manga.id,
-                    existingChapters = if (forceRefresh) emptyList() else existingChapters.toRefreshContextChapters(),
-                    lastFetchTime = state.manga.lastUpdate,
-                    forceRefresh = forceRefresh,
-                )
-                val chapters = state.source.getChapterList(state.manga.toSManga(), refreshContext)
+                val passthroughChapters = if (forceRefresh) emptyList() else existingChapters.toRefreshContextChapters()
+                val chapters = state.source.getMangaUpdate(
+                    state.manga.toSManga(),
+                    passthroughChapters,
+                    fetchDetails = false,
+                    fetchChapters = true,
+                ).chapters
 
                 val newChapters = syncChaptersWithSource.await(
                     chapters,

--- a/app/src/test/java/eu/kanade/tachiyomi/source/SourceRefreshContextTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/SourceRefreshContextTest.kt
@@ -73,6 +73,8 @@ class SourceRefreshContextTest {
         override suspend fun getPageList(chapter: SChapter): List<Page> = throw UnsupportedOperationException()
         override suspend fun getChapterList(manga: SManga): List<SChapter> =
             error("legacy path must not be used when override is present")
+
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
             receivedContext = context
             return context.existingChapters

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.source
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.SMangaUpdate
@@ -31,6 +32,7 @@ interface CatalogueSource : Source {
         filters: FilterList,
     ): MangasPage = fetchSearchManga(page, query, filters).awaitSingle()
 
+    @Suppress("DEPRECATION")
     override suspend fun getMangaUpdate(
         manga: SManga,
         chapters: List<SChapter>,
@@ -40,8 +42,29 @@ interface CatalogueSource : Source {
         // Delegate to the suspend getMangaDetails/getChapterList so sources that only
         // override those (e.g. novel sources) work. The suspend defaults themselves fall
         // back to the deprecated fetch* Observables for legacy extensions.
+        //
+        // Chapters route through the (fork-only, deprecated) context-aware overload so
+        // extensions still on that API keep getting existingChapters with zero functional
+        // loss until they migrate to reading it straight from this method's `chapters` param.
+        // mangaId/lastFetchTime have no equivalent at this layer, so they're passed as dummy
+        // values; forceRefresh is inferred the same way callers already signal it upstream,
+        // by passing an empty chapters list.
         val asyncManga = if (fetchDetails) async { getMangaDetails(manga) } else null
-        val asyncChapters = if (fetchChapters) async { getChapterList(manga) } else null
+        val asyncChapters = if (fetchChapters) {
+            async {
+                getChapterList(
+                    manga,
+                    RefreshContext(
+                        mangaId = 0L,
+                        existingChapters = chapters,
+                        lastFetchTime = 0L,
+                        forceRefresh = chapters.isEmpty(),
+                    ),
+                )
+            }
+        } else {
+            null
+        }
         SMangaUpdate(asyncManga?.await() ?: manga, asyncChapters?.await() ?: chapters)
     }
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -128,11 +128,16 @@ interface Source {
     /**
      * Get all the available chapters for a manga.
      *
-     * @since extensions-lib 1.6
+     * @since extensions-lib 1.6 (tsundoku fork only, superseded by [getMangaUpdate])
      * @param manga the manga to update.
      * @param context refresh context containing existing local state
      * @return the chapters for the manga.
      */
+    @Deprecated(
+        "Fork-only API superseded by upstream's getMangaUpdate, which now accepts existing chapters directly. " +
+            "Kept temporarily so already-published extensions keep working; migrate to getMangaUpdate.",
+        ReplaceWith("getMangaUpdate"),
+    )
     @Suppress("DEPRECATION")
     suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
         // Default implementation falls back to original method for backwards compatibility

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -299,6 +299,12 @@ abstract class HttpSource : CatalogueSource {
      * @param context refresh context containing existing local state
      * @return the chapters for the manga
      */
+    @Suppress("OVERRIDE_DEPRECATION")
+    @Deprecated(
+        "Fork-only API superseded by upstream's getMangaUpdate, which now accepts existing chapters directly. " +
+            "Kept temporarily so already-published extensions keep working; migrate to getMangaUpdate.",
+        ReplaceWith("getMangaUpdate"),
+    )
     override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
         return getChapterList(manga)
     }


### PR DESCRIPTION
Migrates code to use the new 1.6 chapters in getMangaUpdate, deprecates the getChapterList with RefreshContext.