### PR TITLE
fix: delegate custom-source image fetch to base HttpSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Pull to refresh spinner will be more patient [@mrissaoussama](https://github.com/mrissaoussama) [#321](https://github.com/tsundoku-otaku/tsundoku/pull/321)
+- Deleage custom-source image fetch to base httpsource [@mrissaoussama](https://github.com/mrissaoussama) [#331](https://github.com/tsundoku-otaku/tsundoku/pull/331)
 - Disable text selection; fix textview crash on select spam [@mrissaoussama](https://github.com/mrissaoussama) [#311](https://github.com/tsundoku-otaku/tsundoku/pull/311)
 - Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)
 - CatalogueSource novel/manga sources [@mrissaoussama](https://github.com/mrissaoussama) [#309](https://github.com/tsundoku-otaku/tsundoku/pull/309)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -100,7 +100,7 @@ internal fun rebaseCustomSourcePage(
     return Page(
         page.index,
         rebaseCustomSourceUrl(page.url, customBaseUrl, sourceBaseUrl).orEmpty(),
-        page.imageUrl,
+        page.imageUrl?.let { rebaseCustomSourceUrl(it, customBaseUrl, sourceBaseUrl) },
         page.uri,
     ).also {
         it.text = page.text
@@ -727,6 +727,21 @@ class CustomNovelSource(
         return super.getPageList(chapter)
     }
 
+    // Delegate image resolution/download so the ext's own image interceptors and headers apply.
+    override suspend fun getImageUrl(page: Page): String {
+        (baseSource as? HttpSource)?.let { source ->
+            return source.getImageUrl(toBaseSourcePage(page))
+        }
+        return super.getImageUrl(page)
+    }
+
+    override suspend fun getImage(page: Page): Response {
+        (baseSource as? HttpSource)?.let { source ->
+            return source.getImage(toBaseSourcePage(page))
+        }
+        return super.getImage(page)
+    }
+
     // Route through buildAbsoluteUrl so an already-absolute stored url isn't glued onto baseUrl.
     override fun mangaDetailsRequest(manga: SManga): Request = GET(buildAbsoluteUrl(manga.url), headers)
 
@@ -1185,6 +1200,16 @@ class CustomNovelSource(
         }
     }
 
+    private fun toBaseSourcePage(page: Page, sourceBaseUrlOverride: String? = null): Page {
+        val override = sourceBaseUrlOverride ?: effectiveRebaseUrl
+        return Page(
+            page.index,
+            toBaseSourceUrl(page.url, override).orEmpty(),
+            page.imageUrl?.let { toBaseSourceUrl(it, override) },
+            page.uri,
+        ).also { it.text = page.text }
+    }
+
     /**
      * Builds an absolute URL from a relative or absolute path.
      * Handles redirects where the URL might already be absolute after a 301/302 redirect.
@@ -1366,5 +1391,5 @@ data class ContentSelectors(
     val removeBoilerplate: Boolean = true,
 )
 
-// Templates removed — use extension repos for pre-built novel source themes
+// Templates removed; use extension repos for pre-built novel source themes
 // (Madara, LightNovelWP, ReadNovelFull, ReadWN, WordPress Novel)

--- a/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/custom/CustomNovelSourceTest.kt
@@ -78,6 +78,53 @@ class CustomNovelSourceTest {
     }
 
     @Test
+    fun `rebasing a page also rebases its imageUrl to the custom host`() {
+        val page = Page(0, "https://old.example/chapter-1", "https://old.example/images/page-1.jpg")
+
+        val rebased = rebaseCustomSourcePage(page, "https://custom.example", "https://old.example")
+
+        assertEquals("https://custom.example/chapter-1", rebased.url)
+        assertEquals("https://custom.example/images/page-1.jpg", rebased.imageUrl)
+    }
+
+    @Test
+    fun `rebasing a page leaves a null imageUrl null`() {
+        val page = Page(0, "https://old.example/chapter-1")
+
+        assertEquals(null, rebaseCustomSourcePage(page, "https://custom.example", "https://old.example").imageUrl)
+    }
+
+    @Test
+    fun `rebasing a page leaves a third-party cdn imageUrl unchanged`() {
+        // A CDN/mirror host that isn't the delegated source's own host must not be glued onto
+        // the custom base -- it's already a valid absolute URL pointing elsewhere.
+        val page = Page(0, "https://old.example/chapter-1", "https://cdn.example/images/page-1.jpg")
+
+        val rebased = rebaseCustomSourcePage(page, "https://custom.example", "https://old.example")
+
+        assertEquals("https://custom.example/chapter-1", rebased.url)
+        assertEquals("https://cdn.example/images/page-1.jpg", rebased.imageUrl)
+    }
+
+    @Test
+    fun `a rebased page's url and imageUrl both map back to the delegated source host`() {
+        // Mirrors what CustomNovelSource.getImageUrl/getImage do: a Page rebased for display
+        // (source host -> custom host) must map back to the source host on both fields before
+        // being handed to the wrapped extension, so its own image interceptors/headers apply.
+        val original = Page(0, "https://old.example/chapter-1", "https://old.example/images/page-1.jpg")
+        val rebased = rebaseCustomSourcePage(original, "https://custom.example", "https://old.example")
+
+        assertEquals(
+            original.url,
+            mapCustomUrlToSourceUrl(rebased.url, "https://custom.example", "https://old.example"),
+        )
+        assertEquals(
+            original.imageUrl,
+            mapCustomUrlToSourceUrl(rebased.imageUrl, "https://custom.example", "https://old.example"),
+        )
+    }
+
+    @Test
     fun `toBaseSourceUrl restores delegated host from custom url`() {
         assertEquals(
             "https://old.example/series/test",


### PR DESCRIPTION
Override getImageUrl/getImage to route through the wrapped ext's HttpSource so its image interceptors and headers apply, mapping the page back to base-source URL space first. Also rebase page.imageUrl

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
