### PR TITLE
Fix/massimport UI

### DIFF
--- a/.github/workflows/lint-translations.yml
+++ b/.github/workflows/lint-translations.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Install xmllint
+        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+
       - name: xmllint locale resources
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Pull to refresh spinner will be more patient [@mrissaoussama](https://github.com/mrissaoussama) [#321](https://github.com/tsundoku-otaku/tsundoku/pull/321)
+- Improve massimport - Notification dedupe,v erious fixes [@mrissaoussama](https://github.com/mrissaoussama) [#333](https://github.com/tsundoku-otaku/tsundoku/pull/333)
 - Deleage custom-source image fetch to base httpsource [@mrissaoussama](https://github.com/mrissaoussama) [#331](https://github.com/tsundoku-otaku/tsundoku/pull/331)
 - Disable text selection; fix textview crash on select spam [@mrissaoussama](https://github.com/mrissaoussama) [#311](https://github.com/tsundoku-otaku/tsundoku/pull/311)
 - Prevent issue where novel UI appeared in manga reader [@mrissaoussama](https://github.com/mrissaoussama) [#276](https://github.com/tsundoku-otaku/tsundoku/pull/276)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
@@ -31,6 +31,22 @@ class MassImport(
 ) {
     private val missingSourceHostLogCache = ConcurrentHashMap<String, Boolean>()
 
+    companion object {
+        private val GLUE_REGEX = Regex("(?<=[^\\s])(?=https?://)")
+        private val SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+\\-.]*://")
+
+        // Shared tokenizer for every entry point so the "valid" count matches what the import
+        // walks. Splits on comma/semicolon/space/tab and de-glues separator-less URLs.
+        fun tokenizeLine(line: String): List<String> {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return emptyList()
+            return trimmed.replace(GLUE_REGEX, "\n")
+                .split('\n', ',', ';', ' ', '\t')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+        }
+    }
+
     suspend fun resolveMangaUrl(url: String, path: String, source: CatalogueSource): Manga {
         val inputUrl = normalizeSourcePath(source, path)
         // No search-by-URL or slash-toggle fallbacks here: they never resolved anything reliably
@@ -196,15 +212,11 @@ class MassImport(
     }
 
     fun parseUrls(text: String): List<String> {
-        val preprocessed = text
-            .replace(Regex("(?<=[^\\s])(?=https?://)"), "\n")
-            .replace(Regex("(?<!https?:)//+"), "/")
-
-        return preprocessed
-            .split("\n", ",", ";", " ")
-            .map { it.trim() }
-            .filter { it.isNotEmpty() && (it.startsWith("http://") || it.startsWith("https://")) }
+        return text.lineSequence()
+            .flatMap { tokenizeLine(it).asSequence() }
+            .filter { it.startsWith("http://") || it.startsWith("https://") }
             .distinctBy { urlDedupKey(it) }
+            .toList()
     }
 
     data class UrlAnalysisResult(
@@ -224,7 +236,7 @@ class MassImport(
             emptySet()
         }
 
-        val rawLines = text.split("\n", ",", ";", " ").map { it.trim() }.filter { it.isNotEmpty() }
+        val rawLines = text.lineSequence().flatMap { tokenizeLine(it).asSequence() }
         val validUrls = mutableListOf<String>()
         val invalidUrls = mutableListOf<Pair<String, String>>()
         val duplicateUrls = mutableListOf<String>()
@@ -261,10 +273,6 @@ class MassImport(
         UrlAnalysisResult(validUrls, invalidUrls, duplicateUrls, alreadyInLibrary)
     }
 
-    private fun stripScheme(url: String): String {
-        return url.trim().replace(Regex("^[a-zA-Z][a-zA-Z0-9+\\-.]*://"), "").lowercase()
-    }
-
     private fun urlDedupKey(url: String): String {
         return try {
             val uri = URI(url.trim())
@@ -275,7 +283,15 @@ class MassImport(
                 if (!q.isNullOrBlank()) append('?').append(q)
             }
         } catch (_: Exception) {
-            stripScheme(url).removeSuffix("/")
+            // Unparseable URL: lowercase only the host, preserve case-sensitive path.
+            val noScheme = url.trim().replace(SCHEME_REGEX, "")
+            val slash = noScheme.indexOf('/')
+            val key = if (slash < 0) {
+                noScheme.lowercase()
+            } else {
+                noScheme.substring(0, slash).lowercase() + noScheme.substring(slash)
+            }
+            key.removeSuffix("/")
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -108,7 +108,7 @@ fun MassImportDialog(
     var pendingUrls by remember { mutableStateOf(initialText) }
     var urlText by remember { mutableStateOf("") }
     // A picked file is streamed to disk and staged here instead of being loaded into the text
-    // field — a large URL file would otherwise build a multi-hundred-MB String and OOM.
+    // field - a large URL file would otherwise build a multi-hundred-MB String and OOM.
     var pickedFile by remember { mutableStateOf<File?>(null) }
     var pickedFileCount by remember { mutableIntStateOf(0) }
     var pickedFileLoadedFiles by remember { mutableIntStateOf(0) }
@@ -153,7 +153,7 @@ fun MassImportDialog(
             if (uris.isEmpty()) return@rememberLauncherForActivityResult
 
             // Stream picked files to a temp file instead of accumulating in memory + the text
-            // field — a large URL list would OOM before the import even starts.
+            // field - a large URL list would OOM before the import even starts.
             dialogScope.launch(Dispatchers.IO) {
                 val tmp = File(context.cacheDir, "mass_import_pick_${System.nanoTime()}.txt")
                 try {
@@ -190,7 +190,7 @@ fun MassImportDialog(
                     }
 
                     // Dialog disposed mid-read: the loop has no suspension points, so the scope's
-                    // cancellation surfaces here — treat the pick as abandoned (tmp deleted below).
+                    // cancellation surfaces here - treat the pick as abandoned (tmp deleted below).
                     ensureActive()
 
                     if (count > 0) {
@@ -414,15 +414,13 @@ fun MassImportDialog(
                                 onPause = { MassImportJob.pauseBatch(context, batch.id) },
                                 onResume = { MassImportJob.resumeBatch(context, batch.id) },
                                 onRetryFailed = {
-                                    MassImportJob.retryFailed(context, batch.id)
-                                    // Cancelled batches also re-queue the unprocessed remainder, not
-                                    // just the errors.
-                                    val remaining = if (batch.status == MassImportJob.BatchStatus.Cancelled) {
-                                        (batch.total - batch.progress).coerceAtLeast(0)
-                                    } else {
-                                        0
+                                    // Toast the actual re-queued count from retryFailed, not an
+                                    // estimate that double-counts URLs in both errors and tail.
+                                    MassImportJob.retryFailed(context, batch.id) { queued ->
+                                        dialogScope.launch(Dispatchers.Main) {
+                                            context.toast(String.format(toastRequeuedErrors, queued))
+                                        }
                                     }
-                                    context.toast(String.format(toastRequeuedErrors, batch.errored + remaining))
                                 },
                                 onCopyUrls = {
                                     if (batch.total > CLIPBOARD_COPY_LIMIT) {
@@ -494,7 +492,7 @@ fun MassImportDialog(
                     modifier = Modifier.padding(bottom = 8.dp),
                 )
 
-                // categories already filtered by contentType from subscribeByContentType — just strip system categories
+                // categories already filtered by contentType from subscribeByContentType - just strip system categories
                 val userCategories = remember(categories) {
                     categories
                         .asSequence()
@@ -1229,7 +1227,7 @@ private fun BatchItem(
                     }
 
                     // Retry failed (terminal batches only). Gate on the count, not the in-memory
-                    // list — after a restart the persisted error log may have entries the live
+                    // list - after a restart the persisted error log may have entries the live
                     // list lost. A cancelled batch that never reached every URL also offers retry
                     // (it re-queues the errored URLs plus the unprocessed remainder).
                     val isTerminal = batch.status == MassImportJob.BatchStatus.Completed ||

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -92,6 +92,7 @@ import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
+import java.io.IOException
 
 // Clipboard crosses a binder transaction (~1MB cap); past this count a huge list would throw
 // TransactionTooLargeException, so the user is pointed at export-to-file instead.
@@ -106,18 +107,25 @@ private fun writeTempUrlsFile(context: Context, text: String): File {
 }
 
 // Concatenate staged url files (+ optional typed text) into one temp file, streamed reader ->
-// writer so a large join never loads a file into memory. Consumes the inputs.
+// writer so a large join never loads a file into memory. Consumes the inputs on success; on a read
+// failure it throws without deleting anything so the caller can surface the error and let the user
+// retry instead of silently dropping the urls that failed to read.
 private fun joinUrlFiles(context: Context, files: List<File>, extraText: String?): File {
     val out = File(context.cacheDir, "mass_import_join_${System.nanoTime()}.txt")
+    val failed = ArrayList<File>()
     out.bufferedWriter().use { writer ->
         files.forEach { f ->
-            runCatching { f.bufferedReader().use { it.copyTo(writer) } }
+            if (runCatching { f.bufferedReader().use { it.copyTo(writer) } }.isFailure) failed.add(f)
             writer.write("\n")
         }
         if (!extraText.isNullOrBlank()) {
             writer.write(extraText)
             writer.write("\n")
         }
+    }
+    if (failed.isNotEmpty()) {
+        out.delete()
+        throw IOException("Failed to read ${failed.size} staged import file(s): ${failed.joinToString { it.name }}")
     }
     files.forEach { runCatching { it.delete() } }
     return out
@@ -821,6 +829,12 @@ fun MassImportDialog(
                         urlText = ""
                         pendingUrls = ""
 
+                        fun restoreStagedFiles(files: List<File>) {
+                            pickedFiles = files
+                            pickedFileCount = files.size
+                            pickedFileLoadedFiles = files.size
+                        }
+
                         fun startFile(file: File) {
                             if (splitByDomain) {
                                 MassImportJob.startFromFileSplitByHost(
@@ -849,23 +863,29 @@ fun MassImportDialog(
                         // per-file streaming: staged files stay separate (or are joined) on disk
                         // and typed text becomes its own file, so nothing large hits memory.
                         if (separateFilePerBatch || splitByDomain) {
-                            val batchFiles = withContext(Dispatchers.IO) {
-                                if (separateFilePerBatch) {
-                                    // One batch per picked file; typed text is its own batch.
-                                    val files = ArrayList(staged)
-                                    if (combinedRawText.isNotBlank()) {
-                                        files.add(writeTempUrlsFile(context, combinedRawText))
-                                    }
-                                    files
-                                } else {
-                                    // Not separating files, but splitting by domain: fold
-                                    // everything into one file, then split it below.
-                                    if (staged.isNotEmpty() || combinedRawText.isNotBlank()) {
-                                        listOf(joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() }))
+                            val batchFiles = try {
+                                withContext(Dispatchers.IO) {
+                                    if (separateFilePerBatch) {
+                                        // One batch per picked file; typed text is its own batch.
+                                        val files = ArrayList(staged)
+                                        if (combinedRawText.isNotBlank()) {
+                                            files.add(writeTempUrlsFile(context, combinedRawText))
+                                        }
+                                        files
                                     } else {
-                                        emptyList()
+                                        // Not separating files, but splitting by domain: fold
+                                        // everything into one file, then split it below.
+                                        if (staged.isNotEmpty() || combinedRawText.isNotBlank()) {
+                                            listOf(joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() }))
+                                        } else {
+                                            emptyList()
+                                        }
                                     }
                                 }
+                            } catch (e: IOException) {
+                                restoreStagedFiles(staged)
+                                context.toast(e.message ?: "Failed to read import files")
+                                return@launch
                             }
                             batchFiles.forEach { startFile(it) }
                             return@launch
@@ -874,8 +894,14 @@ fun MassImportDialog(
                         // Default: staged files (if any) are joined with typed text into a single
                         // batch on disk (large imports never touch memory).
                         if (staged.isNotEmpty()) {
-                            val joined = withContext(Dispatchers.IO) {
-                                joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() })
+                            val joined = try {
+                                withContext(Dispatchers.IO) {
+                                    joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() })
+                                }
+                            } catch (e: IOException) {
+                                restoreStagedFiles(staged)
+                                context.toast(e.message ?: "Failed to read import files")
+                                return@launch
                             }
                             startFile(joined)
                             return@launch

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -149,7 +149,6 @@ fun MassImportDialog(
     // boundaries; joined on import when that option is off.
     var pickedFiles by remember { mutableStateOf<List<File>>(emptyList()) }
     var pickedFileCount by remember { mutableIntStateOf(0) }
-    var pickedFileLoadedFiles by remember { mutableIntStateOf(0) }
 
     // Staged files that never got imported would otherwise leak in cacheDir; on import the
     // staged refs are cleared first, so this only deletes abandoned files.
@@ -240,7 +239,6 @@ fun MassImportDialog(
                         previous.forEach { old -> runCatching { old.delete() } }
                         pickedFiles = staged
                         pickedFileCount = count
-                        pickedFileLoadedFiles = staged.size
                         withContext(Dispatchers.Main) {
                             context.toast(String.format(toastAddedUrlsFromFiles, count, staged.size))
                         }
@@ -737,7 +735,7 @@ fun MassImportDialog(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = String.format(toastAddedUrlsFromFiles, pickedFileCount, pickedFileLoadedFiles),
+                            text = String.format(toastAddedUrlsFromFiles, pickedFileCount, pickedFiles.size),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.primary,
                         )
@@ -748,7 +746,6 @@ fun MassImportDialog(
                             }
                             pickedFiles = emptyList()
                             pickedFileCount = 0
-                            pickedFileLoadedFiles = 0
                         }) {
                             Text(stringResource(TDMR.strings.mass_import_button_clear))
                         }
@@ -823,16 +820,20 @@ fun MassImportDialog(
                         val splitByDomain = novelDownloadPreferences.massImportSplitByDomain().get()
 
                         val staged = pickedFiles
+                        val stagedCount = pickedFileCount
+                        val previousUrlText = urlText
+                        val previousPendingUrls = pendingUrls
                         pickedFiles = emptyList()
                         pickedFileCount = 0
-                        pickedFileLoadedFiles = 0
                         urlText = ""
                         pendingUrls = ""
 
-                        fun restoreStagedFiles(files: List<File>) {
+                        // Restore both staged files and typed text on read failure.
+                        fun restoreInputs(files: List<File>) {
                             pickedFiles = files
-                            pickedFileCount = files.size
-                            pickedFileLoadedFiles = files.size
+                            pickedFileCount = stagedCount
+                            urlText = previousUrlText
+                            pendingUrls = previousPendingUrls
                         }
 
                         fun startFile(file: File) {
@@ -883,7 +884,7 @@ fun MassImportDialog(
                                     }
                                 }
                             } catch (e: IOException) {
-                                restoreStagedFiles(staged)
+                                restoreInputs(staged)
                                 context.toast(e.message ?: "Failed to read import files")
                                 return@launch
                             }
@@ -899,7 +900,7 @@ fun MassImportDialog(
                                     joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() })
                                 }
                             } catch (e: IOException) {
-                                restoreStagedFiles(staged)
+                                restoreInputs(staged)
                                 context.toast(e.message ?: "Failed to read import files")
                                 return@launch
                             }

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -2,6 +2,7 @@
 
 package eu.kanade.presentation.library.components
 
+import android.content.Context
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -84,6 +85,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -94,6 +96,32 @@ import java.io.File
 // Clipboard crosses a binder transaction (~1MB cap); past this count a huge list would throw
 // TransactionTooLargeException, so the user is pointed at export-to-file instead.
 private const val CLIPBOARD_COPY_LIMIT = 5_000
+
+// Write typed URL text to its own temp file so a "separate file per batch" import can treat it as
+// one more source without materializing it alongside the staged files.
+private fun writeTempUrlsFile(context: Context, text: String): File {
+    val file = File(context.cacheDir, "mass_import_typed_${System.nanoTime()}.txt")
+    file.bufferedWriter().use { it.write(text); it.write("\n") }
+    return file
+}
+
+// Concatenate staged url files (+ optional typed text) into one temp file, streamed reader ->
+// writer so a large join never loads a file into memory. Consumes the inputs.
+private fun joinUrlFiles(context: Context, files: List<File>, extraText: String?): File {
+    val out = File(context.cacheDir, "mass_import_join_${System.nanoTime()}.txt")
+    out.bufferedWriter().use { writer ->
+        files.forEach { f ->
+            runCatching { f.bufferedReader().use { it.copyTo(writer) } }
+            writer.write("\n")
+        }
+        if (!extraText.isNullOrBlank()) {
+            writer.write(extraText)
+            writer.write("\n")
+        }
+    }
+    files.forEach { runCatching { it.delete() } }
+    return out
+}
 
 @Composable
 fun MassImportDialog(
@@ -107,17 +135,22 @@ fun MassImportDialog(
     val dialogScope = rememberCoroutineScope()
     var pendingUrls by remember { mutableStateOf(initialText) }
     var urlText by remember { mutableStateOf("") }
-    // A picked file is streamed to disk and staged here instead of being loaded into the text
-    // field - a large URL file would otherwise build a multi-hundred-MB String and OOM.
-    var pickedFile by remember { mutableStateOf<File?>(null) }
+    // Picked files are streamed to disk (one temp file each) and staged here instead of being
+    // loaded into the text field - a large URL file would otherwise build a multi-hundred-MB
+    // String and OOM. Kept per-file so the "separate file per batch" option can preserve
+    // boundaries; joined on import when that option is off.
+    var pickedFiles by remember { mutableStateOf<List<File>>(emptyList()) }
     var pickedFileCount by remember { mutableIntStateOf(0) }
     var pickedFileLoadedFiles by remember { mutableIntStateOf(0) }
 
-    // A staged file that never got imported would otherwise leak in cacheDir; on import the
-    // staged ref is cleared first, so this only deletes abandoned files.
+    // Staged files that never got imported would otherwise leak in cacheDir; on import the
+    // staged refs are cleared first, so this only deletes abandoned files.
     DisposableEffect(Unit) {
         onDispose {
-            pickedFile?.let { f -> Thread { runCatching { f.delete() } }.start() }
+            val abandoned = pickedFiles
+            if (abandoned.isNotEmpty()) {
+                Thread { abandoned.forEach { f -> runCatching { f.delete() } } }.start()
+            }
         }
     }
     // Restore persisted batches lazily, only when the dialog is opened. Interrupted batches come
@@ -152,18 +185,19 @@ fun MassImportDialog(
         onResult = { uris ->
             if (uris.isEmpty()) return@rememberLauncherForActivityResult
 
-            // Stream picked files to a temp file instead of accumulating in memory + the text
-            // field - a large URL list would OOM before the import even starts.
+            // Stream each picked file to its own temp file instead of accumulating in memory + the
+            // text field - a large URL list would OOM before the import even starts. Kept separate
+            // so per-file batches stay possible; joined on import when that option is off.
             dialogScope.launch(Dispatchers.IO) {
-                val tmp = File(context.cacheDir, "mass_import_pick_${System.nanoTime()}.txt")
+                val staged = ArrayList<File>(uris.size)
                 try {
                     var count = 0
-                    var loadedFiles = 0
                     var readError = false
-                    try {
-                        tmp.bufferedWriter().use { writer ->
-                            for (uri in uris) {
-                                var hadContent = false
+                    for ((index, uri) in uris.withIndex()) {
+                        val tmp = File(context.cacheDir, "mass_import_pick_${System.nanoTime()}_$index.txt")
+                        var hadContent = false
+                        try {
+                            tmp.bufferedWriter().use { writer ->
                                 runCatching {
                                     context.contentResolver.openInputStream(uri)?.bufferedReader()?.useLines { lines ->
                                         for (raw in lines) {
@@ -180,36 +214,37 @@ fun MassImportDialog(
                                     if (it is CancellationException) throw it
                                     readError = true
                                 }
-                                if (hadContent) loadedFiles++
                             }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                            readError = true
                         }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (_: Exception) {
-                        readError = true
+                        if (hadContent) staged.add(tmp) else runCatching { tmp.delete() }
                     }
 
                     // Dialog disposed mid-read: the loop has no suspension points, so the scope's
-                    // cancellation surfaces here - treat the pick as abandoned (tmp deleted below).
+                    // cancellation surfaces here - treat the pick as abandoned (temps deleted below).
                     ensureActive()
 
                     if (count > 0) {
-                        pickedFile?.let { old -> runCatching { old.delete() } }
-                        pickedFile = tmp
+                        val previous = pickedFiles
+                        previous.forEach { old -> runCatching { old.delete() } }
+                        pickedFiles = staged
                         pickedFileCount = count
-                        pickedFileLoadedFiles = loadedFiles
+                        pickedFileLoadedFiles = staged.size
                         withContext(Dispatchers.Main) {
-                            context.toast(String.format(toastAddedUrlsFromFiles, count, loadedFiles))
+                            context.toast(String.format(toastAddedUrlsFromFiles, count, staged.size))
                         }
                     } else {
-                        runCatching { tmp.delete() }
+                        staged.forEach { runCatching { it.delete() } }
                         withContext(Dispatchers.Main) {
                             context.toast(if (readError) toastErrorReadingFile else toastNoReadableUrls)
                         }
                     }
                 } catch (e: CancellationException) {
-                    // Not staged yet, so the DisposableEffect can't clean it up.
-                    runCatching { tmp.delete() }
+                    // Not staged yet, so the DisposableEffect can't clean them up.
+                    staged.forEach { runCatching { it.delete() } }
                     throw e
                 }
             }
@@ -276,6 +311,7 @@ fun MassImportDialog(
     var syncChapterList by remember { mutableStateOf(false) }
 
     val massImportNovels = remember { Injekt.get<MassImport>() }
+    val novelDownloadPreferences = remember { Injekt.get<NovelDownloadPreferences>() }
 
     val queue by MassImportJob.sharedQueue.collectAsState()
 
@@ -684,7 +720,7 @@ fun MassImportDialog(
                 }
 
                 // Staged-file indicator (content lives on disk, not in the text field)
-                if (pickedFile != null) {
+                if (pickedFiles.isNotEmpty()) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -698,8 +734,11 @@ fun MassImportDialog(
                             color = MaterialTheme.colorScheme.primary,
                         )
                         TextButton(onClick = {
-                            pickedFile?.let { f -> dialogScope.launch(Dispatchers.IO) { runCatching { f.delete() } } }
-                            pickedFile = null
+                            val toDelete = pickedFiles
+                            if (toDelete.isNotEmpty()) {
+                                dialogScope.launch(Dispatchers.IO) { toDelete.forEach { runCatching { it.delete() } } }
+                            }
+                            pickedFiles = emptyList()
                             pickedFileCount = 0
                             pickedFileLoadedFiles = 0
                         }) {
@@ -761,7 +800,7 @@ fun MassImportDialog(
             }
         },
         confirmButton = {
-            val hasUrls = pendingUrls.isNotBlank() || urlText.isNotBlank() || pickedFile != null
+            val hasUrls = pendingUrls.isNotBlank() || urlText.isNotBlank() || pickedFiles.isNotEmpty()
 
             TextButton(
                 onClick = {
@@ -772,38 +811,80 @@ fun MassImportDialog(
                             else -> urlText
                         }
 
-                        // A staged file holds the URLs on disk (large imports never touch memory).
-                        // Append any typed text to it, then import straight from the file.
-                        val staged = pickedFile
-                        if (staged != null) {
-                            pickedFile = null
-                            pickedFileCount = 0
-                            pickedFileLoadedFiles = 0
-                            urlText = ""
-                            pendingUrls = ""
-                            if (combinedRawText.isNotBlank()) {
-                                withContext(Dispatchers.IO) {
-                                    runCatching { staged.appendText("\n" + combinedRawText) }
+                        val separateFilePerBatch = novelDownloadPreferences.massImportSeparateFilePerBatch().get()
+                        val splitByDomain = novelDownloadPreferences.massImportSplitByDomain().get()
+
+                        val staged = pickedFiles
+                        pickedFiles = emptyList()
+                        pickedFileCount = 0
+                        pickedFileLoadedFiles = 0
+                        urlText = ""
+                        pendingUrls = ""
+
+                        fun startFile(file: File) {
+                            if (splitByDomain) {
+                                MassImportJob.startFromFileSplitByHost(
+                                    context = context,
+                                    source = file,
+                                    addToLibrary = true,
+                                    fetchDetails = fetchDetails,
+                                    categoryId = selectedCategoryId ?: 0L,
+                                    fetchChapters = syncChapterList,
+                                    preferredSourceId = preferredSourceId,
+                                )
+                            } else {
+                                MassImportJob.startFromFile(
+                                    context = context,
+                                    urlsFile = file,
+                                    addToLibrary = true,
+                                    fetchDetails = fetchDetails,
+                                    categoryId = selectedCategoryId ?: 0L,
+                                    fetchChapters = syncChapterList,
+                                    preferredSourceId = preferredSourceId,
+                                )
+                            }
+                        }
+
+                        // Any option that changes batch boundaries routes everything through
+                        // per-file streaming: staged files stay separate (or are joined) on disk
+                        // and typed text becomes its own file, so nothing large hits memory.
+                        if (separateFilePerBatch || splitByDomain) {
+                            val batchFiles = withContext(Dispatchers.IO) {
+                                if (separateFilePerBatch) {
+                                    // One batch per picked file; typed text is its own batch.
+                                    val files = ArrayList(staged)
+                                    if (combinedRawText.isNotBlank()) {
+                                        files.add(writeTempUrlsFile(context, combinedRawText))
+                                    }
+                                    files
+                                } else {
+                                    // Not separating files, but splitting by domain: fold
+                                    // everything into one file, then split it below.
+                                    if (staged.isNotEmpty() || combinedRawText.isNotBlank()) {
+                                        listOf(joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() }))
+                                    } else {
+                                        emptyList()
+                                    }
                                 }
                             }
-                            MassImportJob.startFromFile(
-                                context = context,
-                                urlsFile = staged,
-                                addToLibrary = true,
-                                fetchDetails = fetchDetails,
-                                categoryId = selectedCategoryId ?: 0L,
-                                fetchChapters = syncChapterList,
-                                preferredSourceId = preferredSourceId,
-                            )
+                            batchFiles.forEach { startFile(it) }
+                            return@launch
+                        }
+
+                        // Default: staged files (if any) are joined with typed text into a single
+                        // batch on disk (large imports never touch memory).
+                        if (staged.isNotEmpty()) {
+                            val joined = withContext(Dispatchers.IO) {
+                                joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() })
+                            }
+                            startFile(joined)
                             return@launch
                         }
 
                         val useRawTextFastPath = combinedRawText.length > 100_000
                         if (useRawTextFastPath) {
-                            // combinedRawText already holds the data; drop the (possibly
-                            // multi-MB) Compose-state copies so they can be reclaimed.
-                            urlText = ""
-                            pendingUrls = ""
+                            // combinedRawText already holds the data; the Compose-state copies were
+                            // already cleared above so they can be reclaimed.
                             MassImportJob.start(
                                 context = context,
                                 urls = emptyList(),
@@ -817,8 +898,7 @@ fun MassImportDialog(
                         } else {
                             val uniqueUrls = withContext(Dispatchers.Default) {
                                 val set = LinkedHashSet<String>()
-                                if (pendingUrls.isNotBlank()) set.addAll(massImportNovels.parseUrls(pendingUrls))
-                                if (urlText.isNotBlank()) set.addAll(massImportNovels.parseUrls(urlText))
+                                if (combinedRawText.isNotBlank()) set.addAll(massImportNovels.parseUrls(combinedRawText))
                                 set.toList()
                             }
 
@@ -832,8 +912,6 @@ fun MassImportDialog(
                                 preferredSourceId = preferredSourceId,
                             )
                         }
-                        urlText = ""
-                        pendingUrls = ""
                     }
                 },
                 enabled = hasUrls,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -102,6 +102,7 @@ import tachiyomi.data.DatabaseMaintenance
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
 import tachiyomi.domain.manga.model.MangaUpdate
@@ -131,6 +132,7 @@ object SettingsAdvancedScreen : SearchableSettings {
         val basePreferences = remember { Injekt.get<BasePreferences>() }
         val networkPreferences = remember { Injekt.get<NetworkPreferences>() }
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val novelDownloadPreferences = remember { Injekt.get<NovelDownloadPreferences>() }
 
         val libraryPageSize by libraryPreferences.experimentalLibraryPageSize.collectAsState()
 
@@ -203,6 +205,28 @@ object SettingsAdvancedScreen : SearchableSettings {
             getLibraryGroup(libraryPreferences = libraryPreferences),
             getReaderGroup(basePreferences = basePreferences),
             getExtensionsGroup(basePreferences = basePreferences),
+            getMassImportGroup(novelDownloadPreferences = novelDownloadPreferences),
+        )
+    }
+
+    @Composable
+    private fun getMassImportGroup(
+        novelDownloadPreferences: NovelDownloadPreferences,
+    ): Preference.PreferenceGroup {
+        return Preference.PreferenceGroup(
+            title = stringResource(TDMR.strings.pref_category_mass_import),
+            preferenceItems = listOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = novelDownloadPreferences.massImportSeparateFilePerBatch(),
+                    title = stringResource(TDMR.strings.pref_mass_import_separate_file_per_batch),
+                    subtitle = stringResource(TDMR.strings.pref_mass_import_separate_file_per_batch_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = novelDownloadPreferences.massImportSplitByDomain(),
+                    title = stringResource(TDMR.strings.pref_mass_import_split_by_domain),
+                    subtitle = stringResource(TDMR.strings.pref_mass_import_split_by_domain_summary),
+                ),
+            ),
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -123,6 +123,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
     private var lastNotificationTime = 0L
     private var lastNotifiedProgress = -1
     private var lastNotificationStatus: String? = null
+    private var currentBatchId = ""
 
     // Serializes the memory-pressure back-off so concurrent fetch coroutines don't all spin
     // (and previously all fire System.gc()) at once.
@@ -152,6 +153,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         val missingSourceHosts = ConcurrentHashMap.newKeySet<String>()
 
         val jobBatchId = inputData.getString(KEY_BATCH_ID) ?: ""
+        currentBatchId = jobBatchId
         val resumeOffset = inputData.getInt(KEY_RESUME_OFFSET, 0).coerceAtLeast(0)
         // Exit instead of parking in the pause loop: a parked foreground worker burns the
         // Android 15 dataSync time budget. Resume flips the status before re-enqueueing.
@@ -241,7 +243,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                         Result.failure()
                     }
                 } finally {
-                    context.cancelNotification(Notifications.ID_MASS_IMPORT_PROGRESS)
+                    context.cancelNotification(progressNotificationId(currentBatchId))
                     runCatching { File(streamFilePath).delete() }
                     liveErroredUrls.remove(batchId)
                 }
@@ -283,7 +285,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     Result.failure()
                 }
             } finally {
-                context.cancelNotification(Notifications.ID_MASS_IMPORT_PROGRESS)
+                context.cancelNotification(progressNotificationId(currentBatchId))
                 inputData.getString(KEY_URLS_FILE)?.let { path -> runCatching { File(path).delete() } }
                 inputData.getString(KEY_RAW_TEXT_FILE)?.let { path -> runCatching { File(path).delete() } }
                 liveErroredUrls.remove(batchId)
@@ -293,7 +295,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         return ForegroundInfo(
-            Notifications.ID_MASS_IMPORT_PROGRESS,
+            progressNotificationId(currentBatchId),
             notificationBuilder.build(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
@@ -1117,7 +1119,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     ),
                 )
             }.build()
-            context.notify(Notifications.ID_MASS_IMPORT_PROGRESS, notification)
+            context.notify(progressNotificationId(currentBatchId), notification)
 
             lastNotificationTime = now
             lastNotifiedProgress = current
@@ -1125,9 +1127,13 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
     }
 
-    // Distinct id per batch so concurrent completions don't overwrite each other. Far from the
-    // app's small negative ids, so no collision.
-    private fun completionNotificationId(batchId: String): Int = 600_000 + (batchId.hashCode() and 0xFFFF)
+    // Per-batch ids so concurrent batches don't clobber each other's notification. Two disjoint
+    // positive bands 100M apart (progress vs completion); 24-bit spread makes collisions negligible.
+    private fun progressNotificationId(batchId: String): Int =
+        if (batchId.isEmpty()) Notifications.ID_MASS_IMPORT_PROGRESS else 600_000_000 + (batchId.hashCode() and 0xFFFFFF)
+
+    private fun completionNotificationId(batchId: String): Int =
+        if (batchId.isEmpty()) Notifications.ID_MASS_IMPORT_COMPLETE else 700_000_000 + (batchId.hashCode() and 0xFFFFFF)
 
     private fun showCompletionNotification(batchId: String, added: Int, skipped: Int, errored: Int, message: String?) {
         val text = message ?: "Added: $added, Skipped: $skipped, Errors: $errored"
@@ -1800,7 +1806,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     eldest: MutableMap.MutableEntry<String, java.io.BufferedWriter>,
                 ): Boolean {
                     if (size > MAX_OPEN_DOMAIN_WRITERS) {
-                        runCatching { eldest.value.flush(); eldest.value.close() }
+                        runCatching { eldest.value.close() }
                         return true
                     }
                     return false
@@ -1834,17 +1840,20 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             try {
                 source.bufferedReader().useLines { lines ->
                     for (raw in lines) {
-                        val line = raw.trim()
-                        if (line.isEmpty()) continue
-                        val host = splitHostKey(line)
-                        val writer = if (host == null) overflowWriter() else writerFor(host)
-                        writer.write(line)
-                        writer.write("\n")
+                        // Tokenize first so multi-URL lines route per-host instead of failing URI
+                        // parse and spilling to overflow.
+                        for (line in MassImport.tokenizeLine(raw)) {
+                            val host = splitHostKey(line)
+                            val writer = if (host == null) overflowWriter() else writerFor(host)
+                            writer.write(line)
+                            writer.write("\n")
+                        }
                     }
                 }
             } finally {
-                open.values.forEach { runCatching { it.flush(); it.close() } }
-                runCatching { overflowWriter?.flush(); overflowWriter?.close() }
+                // close() flushes; keep them separate so one writer's failure can't skip the rest.
+                open.values.forEach { runCatching { it.close() } }
+                runCatching { overflowWriter?.close() }
             }
 
             runCatching { source.delete() }
@@ -2112,6 +2121,10 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
         private fun deleteBatchFiles(context: Context, batchId: String) {
             runCatching { File(context.cacheDir, "mass_import_$batchId.txt").delete() }
+            // Result file (createFileInCacheDir prefers externalCacheDir) would otherwise leak.
+            val resultName = "tsundoku_mass_import_results_${batchId.ifEmpty { "unknown" }}.txt"
+            runCatching { File(context.cacheDir, resultName).delete() }
+            context.externalCacheDir?.let { runCatching { File(it, resultName).delete() } }
             MassImportStore.delete(context, batchId)
             lastMetaWrite.remove(batchId)
         }
@@ -2201,40 +2214,50 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                 var wrote = 0
                 val ok = runCatching {
                     tmp.bufferedWriter().use { w ->
-                        MassImportStore.forEachError(appContext, batchId) { url, _ ->
-                            val t = url.trim()
-                            if (t.isNotEmpty()) {
-                                w.write(t)
-                                w.newLine()
-                                wrote++
-                            }
-                        }
-                        if (wrote == 0) {
-                            // Pre-log / in-memory-only batch: bounded preview fallback.
-                            getErroredUrls(appContext, batchId, limit = META_ERROR_PREVIEW).forEach {
-                                w.write(it)
-                                w.newLine()
-                                wrote++
-                            }
+                        fun emit(url: String) {
+                            w.write(url)
+                            w.newLine()
+                            wrote++
                         }
                         if (includeRemaining) {
+                            // Single pass emits each URL once (tail overlaps errored URLs otherwise);
+                            // only the errored set is held in memory, the tail streams.
+                            val errored = HashSet<String>()
+                            MassImportStore.forEachError(appContext, batchId) { url, _ ->
+                                val t = url.trim()
+                                if (t.isNotEmpty()) errored.add(t)
+                            }
                             // Conservative offset (matches resume): processing is out of order, so
                             // re-do the overlap rather than risk dropping an unfinished URL. URLs
                             // already imported skip instantly on the re-run.
                             val offset = (batch.progress - (MAX_LOOKAHEAD + MAX_CONCURRENCY)).coerceAtLeast(0)
-                            MassImportStore.openUrlsReader(appContext, batchId)?.use { reader ->
-                                var idx = 0
-                                reader.lineSequence().forEach { line ->
-                                    val t = line.trim()
-                                    if (t.isNotEmpty()) {
-                                        if (idx >= offset) {
-                                            w.write(t)
-                                            w.newLine()
-                                            wrote++
+                            val reader = MassImportStore.openUrlsReader(appContext, batchId)
+                            if (reader != null) {
+                                reader.use {
+                                    var idx = 0
+                                    it.lineSequence().forEach { line ->
+                                        val t = line.trim()
+                                        if (t.isNotEmpty()) {
+                                            if (idx >= offset || t in errored) emit(t)
+                                            idx++
                                         }
-                                        idx++
                                     }
                                 }
+                            } else {
+                                errored.forEach { emit(it) }
+                            }
+                            if (wrote == 0) {
+                                getErroredUrls(appContext, batchId, limit = META_ERROR_PREVIEW).forEach { emit(it) }
+                            }
+                        } else {
+                            // Completed batch: only errors, streamed (no tail, so no overlap).
+                            MassImportStore.forEachError(appContext, batchId) { url, _ ->
+                                val t = url.trim()
+                                if (t.isNotEmpty()) emit(t)
+                            }
+                            if (wrote == 0) {
+                                // Pre-log / in-memory-only batch: bounded preview fallback.
+                                getErroredUrls(appContext, batchId, limit = META_ERROR_PREVIEW).forEach { emit(it) }
                             }
                         }
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -14,6 +14,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
+import eu.kanade.domain.manga.interactor.MassImport
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.jsplugin.source.JsSource
@@ -84,6 +85,10 @@ private const val MAX_LOOKAHEAD = 512
 
 // Bound the retained per-URL error detail so a mostly-failing huge import can't OOM.
 private const val MAX_TRACKED_ERRORS = 2000
+
+// Cap the run-scoped dedup seen-set. Past this many unique URLs, dedup disables and the DB
+// insert-if-not-exists guard takes over, so a multi-million unique list can't OOM on the set.
+private const val MAX_DEDUP_KEYS = 2_000_000
 
 // Hard ceiling on a single source fetch so one hanging/oversized request can't freeze
 // the batch (at low concurrency one stuck URL blocks all the rest).
@@ -166,7 +171,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             // exhausted, park the batch as interrupted (resumable) and finish so the WorkSpec goes
             // terminal instead of re-firing. It resumes when the mass-import dialog is next opened
             // (app in foreground, where the foreground start is allowed).
-            notifyForegroundLimitReached()
+            notifyForegroundLimitReached(jobBatchId)
             return if (runAttemptCount < MAX_FOREGROUND_START_RETRIES) {
                 Result.retry()
             } else {
@@ -193,16 +198,9 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             return withIOContext {
                 try {
                     // Streaming count for the progress denominator; materializing would OOM.
+                    // Same tokenizer as the flow below so the denominator matches what is walked.
                     val totalCount = file.bufferedReader().useLines { lines ->
-                        lines.sumOf { raw ->
-                            if (raw.contains(',') || raw.contains(';')) {
-                                raw.split(',', ';').count { it.isNotBlank() }
-                            } else if (raw.trim().isNotBlank()) {
-                                1
-                            } else {
-                                0
-                            }
-                        }
+                        lines.sumOf { raw -> MassImport.tokenizeLine(raw).size }
                     }
 
                     // Cold flow re-reads the file on collection; O(1) memory. No dedup: the
@@ -210,15 +208,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     val urlFlow = kotlinx.coroutines.flow.flow {
                         file.bufferedReader().useLines { lines ->
                             for (raw in lines) {
-                                if (raw.contains(',') || raw.contains(';')) {
-                                    for (part in raw.split(',', ';')) {
-                                        val t = part.trim()
-                                        if (t.isNotBlank()) emit(t)
-                                    }
-                                } else {
-                                    val t = raw.trim()
-                                    if (t.isNotBlank()) emit(t)
-                                }
+                                for (t in MassImport.tokenizeLine(raw)) emit(t)
                             }
                         }
                     }
@@ -234,7 +224,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                 } catch (e: Exception) {
                     if (e is CancellationException) {
                         // Still Running = system stop (time limit, process pressure), not a
-                        // user pause/cancel — schedule a delayed background resume.
+                        // user pause/cancel - schedule a delayed background resume.
                         if (batchStatus(batchId) == BatchStatus.Running) scheduleBackgroundResume(batchId)
                         Result.success()
                     } else {
@@ -275,7 +265,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) {
-                    // Still Running = system stop, not user pause/cancel — schedule a delayed
+                    // Still Running = system stop, not user pause/cancel - schedule a delayed
                     // background resume.
                     if (batchStatus(batchId) == BatchStatus.Running) scheduleBackgroundResume(batchId)
                     Result.success()
@@ -321,14 +311,14 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
     }
 
-    private fun notifyForegroundLimitReached() {
+    private fun notifyForegroundLimitReached(batchId: String) {
         val notification = context.notificationBuilder(Notifications.CHANNEL_MASS_IMPORT) {
             setSmallIcon(android.R.drawable.stat_sys_warning)
             setContentTitle("Mass import paused")
-            setContentText("Android background time limit reached — open the app and resume the import")
+            setContentText("Android background time limit reached - open the app and resume the import")
             setAutoCancel(true)
         }.build()
-        context.notify(Notifications.ID_MASS_IMPORT_COMPLETE, notification)
+        context.notify(completionNotificationId(batchId), notification)
     }
 
     private suspend fun performImport(
@@ -355,9 +345,9 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             return ImportResult(added = 0, skipped = 0, errored = totalCount)
         }
 
-        // Each run re-walks the full URL list, so prior log entries are stale. Cleared only once
-        // processing actually starts — the degenerate aborts above keep the previous logs intact.
-        if (batchId.isNotEmpty()) {
+        // Clear logs only on a fresh start; a resume (resumeOffset > 0) must append to the failures
+        // recorded before the pause, not wipe them. Degenerate aborts above keep prior logs intact.
+        if (batchId.isNotEmpty() && resumeOffset == 0) {
             MassImportStore.clearErrors(context, batchId)
             MassImportStore.clearSkipped(context, batchId)
         }
@@ -417,8 +407,13 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         val pendingAddIds = java.util.Collections.synchronizedList(mutableListOf<Long>())
         val flushBatchSize = 50
         val activeImports = ConcurrentHashMap<String, Boolean>()
-        // Guards against the same URL being processed concurrently; size bounded by concurrency.
-        val inFlightUrls = ConcurrentHashMap.newKeySet<String>()
+        // Run-scoped seen-set: dedups the whole run, not just the concurrent window. Never removed
+        // and capped; past the cap the DB insert-if-not-exists guard takes over to bound memory.
+        val seenUrls = ConcurrentHashMap.newKeySet<String>()
+        fun markNewUrl(url: String): Boolean {
+            if (seenUrls.size >= MAX_DEDUP_KEYS) return true
+            return seenUrls.add(url)
+        }
 
         val erroredUrls = java.util.Collections.synchronizedList(mutableListOf<String>())
         val errorMessages = ConcurrentHashMap<String, String>()
@@ -547,9 +542,9 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     }
 
                     flow {
-                        // Concurrent duplicate: processing both wastes a fetch and double-counts
-                        // "added" (the insert itself is insert-if-not-exists, so no corruption).
-                        if (!inFlightUrls.add(url)) {
+                        // Duplicate anywhere in the run: skip to avoid a wasted fetch and
+                        // double-counted "added" (the insert is insert-if-not-exists regardless).
+                        if (!markNewUrl(url)) {
                             if (shouldCount) {
                                 skippedCount.incrementAndGet()
                                 recordSkip(url, "Duplicate")
@@ -565,7 +560,6 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                             return@flow
                         }
                         if (!awaitResumed(batchId)) {
-                            inFlightUrls.remove(url)
                             return@flow
                         }
 
@@ -584,7 +578,6 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                     erroredUrlsPreview = synchronized(erroredUrls) { erroredUrls.take(10) },
                                 )
                             }
-                            inFlightUrls.remove(url)
                             return@flow
                         }
 
@@ -619,7 +612,6 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                     erroredCount.get(),
                                 )
                             }
-                            inFlightUrls.remove(url)
                             return@flow
                         }
 
@@ -631,7 +623,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                             // Hold the per-source permit across delay + fetch so same-source requests
                             // run serially spaced by delayMs. Pause is re-checked after acquiring the
                             // permit (queued URLs would otherwise keep importing long after pause),
-                            // but parking happens OUTSIDE it — semaphores are global, so a paused
+                            // but parking happens OUTSIDE it - semaphores are global, so a paused
                             // batch holding one would starve other batches on the same source.
                             val success = if (shouldThrottle) {
                                 val sourceSemaphore = sourceSemaphores.computeIfAbsent(source.id) { Semaphore(1) }
@@ -713,7 +705,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                         recordSkip(url, "Already in library")
                                     }
                                 }
-                                // null: batch was cancelled while queued — nothing processed.
+                                // null: batch was cancelled while queued - nothing processed.
                                 null -> {
                                     cancelledWhileQueued = true
                                     return@flow
@@ -729,7 +721,6 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                                 recordError(url, e.message ?: "Unknown error")
                             }
                         } finally {
-                            inFlightUrls.remove(url)
                             activeImports.remove(url)
                             // Cancelled-while-queued URLs were never processed, and resume-overlap URLs
                             // were already counted before the pause; don't count either.
@@ -852,7 +843,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         if (batchId.isEmpty()) return
         if (_sharedQueue.value.any { it.id == batchId }) return
         val meta = MassImportStore.loadMeta(context, batchId) ?: return
-        // Preview only — the full list can be millions of lines and lives on disk.
+        // Preview only - the full list can be millions of lines and lives on disk.
         val urls = MassImportStore.loadUrlsPreview(context, batchId, URL_PREVIEW_LIMIT)
         val restored = meta.toBatch(urls)
         _sharedQueue.update { list -> if (list.any { it.id == batchId }) list else list + restored }
@@ -1126,6 +1117,10 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
     }
 
+    // Distinct id per batch so concurrent completions don't overwrite each other. Far from the
+    // app's small negative ids, so no collision.
+    private fun completionNotificationId(batchId: String): Int = 600_000 + (batchId.hashCode() and 0xFFFF)
+
     private fun showCompletionNotification(batchId: String, added: Int, skipped: Int, errored: Int, message: String?) {
         val text = message ?: "Added: $added, Skipped: $skipped, Errors: $errored"
 
@@ -1147,12 +1142,14 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             }
         }
 
-        context.notify(Notifications.ID_MASS_IMPORT_COMPLETE, notificationBuilder.build())
+        context.notify(completionNotificationId(batchId), notificationBuilder.build())
     }
 
     private fun writeResultFile(batchId: String, added: Int, skipped: Int, errored: Int): File? {
         try {
-            val file = context.createFileInCacheDir("tsundoku_mass_import_results.txt")
+            // Per-batch filename so a batch finishing first can't overwrite another's linked results.
+            val safeId = batchId.ifEmpty { "unknown" }
+            val file = context.createFileInCacheDir("tsundoku_mass_import_results_$safeId.txt")
             file.bufferedWriter().use { out ->
                 out.write("=== Mass Import Results ===\n")
                 out.write(
@@ -1344,7 +1341,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         // 10-entry batch preview plus the not-yet-flushed disk log.
         private val liveErroredUrls = ConcurrentHashMap<String, MutableList<String>>()
 
-        // Meta keeps only an error preview — the full error log lives in the store's per-batch
+        // Meta keeps only an error preview - the full error log lives in the store's per-batch
         // errors file, so the json stays small no matter how many URLs fail.
         private const val META_ERROR_PREVIEW = 100
 
@@ -1412,17 +1409,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         // Lazy, no dedup: persisted count and the worker's progress total must agree, so both
         // tokenize identically. Never materializes the full list.
         private fun rawTextTokenSequence(rawText: String): Sequence<String> {
-            return rawText.lineSequence()
-                .flatMap { line ->
-                    val trimmed = line.trim()
-                    if (trimmed.isBlank()) {
-                        emptySequence()
-                    } else if (trimmed.contains(',') || trimmed.contains(';')) {
-                        trimmed.split(',', ';').asSequence().map { it.trim() }.filter { it.isNotBlank() }
-                    } else {
-                        sequenceOf(trimmed)
-                    }
-                }
+            return rawText.lineSequence().flatMap { MassImport.tokenizeLine(it).asSequence() }
         }
 
         fun restoreActiveJobsFromWorkManager(context: Context) {
@@ -1709,15 +1696,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                 val count = runCatching {
                     staged.bufferedReader().useLines { lines ->
                         val tokens = lines
-                            .flatMap { line ->
-                                val t = line.trim()
-                                when {
-                                    t.isBlank() -> emptySequence()
-                                    t.contains(',') || t.contains(';') ->
-                                        t.split(',', ';').asSequence().map { it.trim() }.filter { it.isNotBlank() }
-                                    else -> sequenceOf(t)
-                                }
-                            }
+                            .flatMap { MassImport.tokenizeLine(it).asSequence() }
                             .onEach { if (preview.size < URL_PREVIEW_LIMIT) preview.add(it) }
                         MassImportStore.saveUrlsStreaming(appContext, batchId, tokens)
                     }
@@ -1780,7 +1759,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         fun cancelBatch(context: Context, batchId: String) {
             context.workManager.cancelUniqueWork("${TAG}_$batchId")
             // No live worker = no finally-block cleanup; delete the staged file here. Safe
-            // alongside a worker mid-cancel — an open reader survives the unlink.
+            // alongside a worker mid-cancel - an open reader survives the unlink.
             runCatching { File(context.cacheDir, "mass_import_$batchId.txt").delete() }
             _sharedQueue.update { list ->
                 list.map {
@@ -1840,7 +1819,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             // reports the cancellation asynchronously, so a stale entry can still read RUNNING for a
             // moment; force a fresh worker (REPLACE swaps any zombie). Already-Running recovery:
             // require no active worker so we DON'T cancel a genuinely live worker (REPLACE would make
-            // it reschedule itself, looping) — enqueue only when nothing is actually executing.
+            // it reschedule itself, looping) - enqueue only when nothing is actually executing.
             reenqueueIfNoWorker(
                 context,
                 batchId,
@@ -1964,7 +1943,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         fun resumeAll(context: Context) {
             // Paused batches flip to Running and force a fresh worker. Batches already reading
             // Running but with no live worker (lost background-resume / abort race) are recovered
-            // too, but only if nothing is actually executing — otherwise we'd cancel a live worker.
+            // too, but only if nothing is actually executing - otherwise we'd cancel a live worker.
             val pausedIds = _sharedQueue.value.filter { it.status == BatchStatus.Paused }.map { it.id }
             val runningIds = _sharedQueue.value.filter { it.status == BatchStatus.Running }.map { it.id }
             _sharedQueue.update { list ->
@@ -2074,7 +2053,9 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             return count
         }
 
-        fun retryFailed(context: Context, batchId: String) {
+        // onQueued reports the actual re-queued count (deduped errors + unprocessed tail) so the
+        // toast can't over-report by summing sets that overlap.
+        fun retryFailed(context: Context, batchId: String, onQueued: ((Int) -> Unit)? = null) {
             val appContext = context.applicationContext
             val inMemory = _sharedQueue.value.find { it.id == batchId }
             persistScope.launch {
@@ -2083,7 +2064,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     ?: return@launch
 
                 // A cancelled batch never reached every URL, so re-queue the errored URLs AND the
-                // unprocessed tail — not just the errors. A completed batch walked the whole list,
+                // unprocessed tail - not just the errors. A completed batch walked the whole list,
                 // so only its errors are retried.
                 val includeRemaining = batch.total > 0 && batch.progress < batch.total
 
@@ -2146,6 +2127,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
                     excludedHosts = batch.excludedHosts,
                     preferredSourceId = batch.preferredSourceId,
                 )
+                onQueued?.invoke(wrote)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -100,6 +100,14 @@ private const val NOTIFICATION_MIN_DELTA = 5
 // in-app error log. Stops a mostly-failing huge import from writing a gigantic results file.
 private const val RESULT_FILE_ERROR_CAP = 5000
 
+// Cap simultaneously-open per-host writers when splitting a mass-import file by domain so a file
+// with many distinct hosts can't exhaust file descriptors; evicted writers reopen in append mode.
+private const val MAX_OPEN_DOMAIN_WRITERS = 24
+
+// Cap distinct per-host files; hosts past this spill into one shared overflow batch so a
+// pathological file (a unique host per line) can't create unbounded files/batches.
+private const val MAX_DOMAIN_FILES = 300
+
 class MassImportJob(private val context: Context, workerParams: WorkerParameters) :
     CoroutineWorker(context, workerParams) {
 
@@ -1730,6 +1738,117 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
 
                 enqueueBatchWorker(appContext, batchId, payload)
             }
+        }
+
+        /**
+         * Split [source] into one file per URL host and start a separate batch for each. Streamed
+         * with a bounded LRU of open writers (evicted writers reopen in append mode) so a huge
+         * multi-host file stays within a fixed file-descriptor and memory budget. Hosts beyond
+         * [MAX_DOMAIN_FILES] and host-less lines spill into a single overflow batch. [source] is
+         * consumed once split; on any split failure it falls back to a single batch.
+         */
+        fun startFromFileSplitByHost(
+            context: Context,
+            source: File,
+            categoryId: Long = 0L,
+            addToLibrary: Boolean = true,
+            fetchDetails: Boolean = true,
+            fetchChapters: Boolean = false,
+            excludedHosts: List<String> = emptyList(),
+            preferredSourceId: Long? = null,
+        ) {
+            if (!source.exists()) return
+            val appContext = context.applicationContext
+            persistScope.launch {
+                val parts = runCatching { splitFileByHost(appContext, source) }.getOrElse { e ->
+                    logcat(LogPriority.ERROR, e) { "Mass import: host split failed; importing as one batch" }
+                    listOf(source)
+                }
+                parts.forEach { part ->
+                    startFromFile(
+                        context = appContext,
+                        urlsFile = part,
+                        categoryId = categoryId,
+                        addToLibrary = addToLibrary,
+                        fetchDetails = fetchDetails,
+                        fetchChapters = fetchChapters,
+                        excludedHosts = excludedHosts,
+                        preferredSourceId = preferredSourceId,
+                    )
+                }
+            }
+        }
+
+        private fun splitHostKey(line: String): String? =
+            runCatching { URI(line).host?.lowercase()?.removePrefix("www.") }.getOrNull()?.takeIf { it.isNotBlank() }
+
+        /**
+         * Group [source]'s lines into per-host cache files. Bounded FD/memory: at most
+         * [MAX_OPEN_DOMAIN_WRITERS] writers stay open (access-ordered LRU, reopened in append mode
+         * when a host recurs), and at most [MAX_DOMAIN_FILES] host files are created before the
+         * remainder (and host-less lines) go to one overflow file. Deletes [source] when done.
+         */
+        private fun splitFileByHost(context: Context, source: File): List<File> {
+            val dir = context.applicationContext.cacheDir
+            val stamp = System.nanoTime()
+            val hostFiles = LinkedHashMap<String, File>()
+            var overflow: File? = null
+            var overflowWriter: java.io.BufferedWriter? = null
+
+            val open = object : LinkedHashMap<String, java.io.BufferedWriter>(16, 0.75f, true) {
+                override fun removeEldestEntry(
+                    eldest: MutableMap.MutableEntry<String, java.io.BufferedWriter>,
+                ): Boolean {
+                    if (size > MAX_OPEN_DOMAIN_WRITERS) {
+                        runCatching { eldest.value.flush(); eldest.value.close() }
+                        return true
+                    }
+                    return false
+                }
+            }
+
+            fun overflowWriter(): java.io.BufferedWriter {
+                overflowWriter?.let { return it }
+                val f = File(dir, "mass_import_split_${stamp}_overflow.txt")
+                overflow = f
+                return f.bufferedWriter().also { overflowWriter = it }
+            }
+
+            fun writerFor(host: String): java.io.BufferedWriter {
+                open[host]?.let { return it }
+                val existing = hostFiles[host]
+                val target: File
+                val append: Boolean
+                if (existing != null) {
+                    target = existing
+                    append = true
+                } else {
+                    if (hostFiles.size >= MAX_DOMAIN_FILES) return overflowWriter()
+                    target = File(dir, "mass_import_split_${stamp}_${hostFiles.size}.txt")
+                    hostFiles[host] = target
+                    append = false
+                }
+                return java.io.BufferedWriter(java.io.FileWriter(target, append)).also { open[host] = it }
+            }
+
+            try {
+                source.bufferedReader().useLines { lines ->
+                    for (raw in lines) {
+                        val line = raw.trim()
+                        if (line.isEmpty()) continue
+                        val host = splitHostKey(line)
+                        val writer = if (host == null) overflowWriter() else writerFor(host)
+                        writer.write(line)
+                        writer.write("\n")
+                    }
+                }
+            } finally {
+                open.values.forEach { runCatching { it.flush(); it.close() } }
+                runCatching { overflowWriter?.flush(); overflowWriter?.close() }
+            }
+
+            runCatching { source.delete() }
+            return ArrayList<File>(hostFiles.values).apply { overflow?.let { add(it) } }
         }
 
         fun stop(context: Context) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -1876,10 +1876,11 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
 
         fun cancelBatch(context: Context, batchId: String) {
+            val appContext = context.applicationContext
             context.workManager.cancelUniqueWork("${TAG}_$batchId")
-            // No live worker = no finally-block cleanup; delete the staged file here. Safe
-            // alongside a worker mid-cancel - an open reader survives the unlink.
-            runCatching { File(context.cacheDir, "mass_import_$batchId.txt").delete() }
+            // No live worker = no finally-block cleanup; delete the staged file off the main
+            // thread. Safe alongside a worker mid-cancel - an open reader survives the unlink.
+            persistScope.launch { runCatching { File(appContext.cacheDir, "mass_import_$batchId.txt").delete() } }
             _sharedQueue.update { list ->
                 list.map {
                     @Suppress("ktlint:standard:max-line-length")
@@ -2086,27 +2087,33 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
         }
 
         fun removeBatch(context: Context, batchId: String) {
+            val appContext = context.applicationContext
             context.workManager.cancelUniqueWork("${TAG}_$batchId")
-            runCatching { File(context.cacheDir, "mass_import_$batchId.txt").delete() }
-            MassImportStore.delete(context, batchId)
-            lastMetaWrite.remove(batchId)
-            _sharedQueue.update { list ->
-                list.filter { it.id != batchId }
-            }
+            // Drop from the live queue immediately (in-memory only), then delete the on-disk
+            // batch off the main thread: MassImportStore.delete does several SAF round-trips
+            // under a global lock, which would ANR if run on the UI thread.
+            _sharedQueue.update { list -> list.filter { it.id != batchId } }
+            persistScope.launch { deleteBatchFiles(appContext, batchId) }
         }
 
         fun clearCompleted(context: Context) {
-            _sharedQueue.update { list ->
-                list.filter { batch ->
-                    val done = batch.status == BatchStatus.Completed || batch.status == BatchStatus.Cancelled
-                    if (done) {
-                        runCatching { File(context.cacheDir, "mass_import_${batch.id}.txt").delete() }
-                        MassImportStore.delete(context, batch.id)
-                        lastMetaWrite.remove(batch.id)
-                    }
-                    !done
-                }
-            }
+            val appContext = context.applicationContext
+            val doneIds = _sharedQueue.value
+                .filter { it.status == BatchStatus.Completed || it.status == BatchStatus.Cancelled }
+                .map { it.id }
+            if (doneIds.isEmpty()) return
+            // Keep the flow update pure (it may re-run under CAS contention) and never touch
+            // disk on the main thread; the per-batch SAF deletes below would ANR with many
+            // completed batches (e.g. after a split-by-domain import).
+            val doneSet = doneIds.toHashSet()
+            _sharedQueue.update { list -> list.filterNot { it.id in doneSet } }
+            persistScope.launch { doneIds.forEach { deleteBatchFiles(appContext, it) } }
+        }
+
+        private fun deleteBatchFiles(context: Context, batchId: String) {
+            runCatching { File(context.cacheDir, "mass_import_$batchId.txt").delete() }
+            MassImportStore.delete(context, batchId)
+            lastMetaWrite.remove(batchId)
         }
 
         // From disk: the live queue only retains a preview.

--- a/domain/src/main/java/tachiyomi/domain/download/service/NovelDownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/NovelDownloadPreferences.kt
@@ -108,6 +108,24 @@ class NovelDownloadPreferences(
     )
 
     /**
+     * When multiple files are picked for mass import, import each file as its own queue/batch
+     * instead of concatenating them into a single batch.
+     */
+    fun massImportSeparateFilePerBatch() = preferenceStore.getBoolean(
+        "novel_mass_import_separate_file_per_batch",
+        false,
+    )
+
+    /**
+     * Split the imported URLs by host so each domain becomes its own queue/batch. Streamed to
+     * per-host temp files with a bounded number of open writers, so large files don't OOM.
+     */
+    fun massImportSplitByDomain() = preferenceStore.getBoolean(
+        "novel_mass_import_split_by_domain",
+        false,
+    )
+
+    /**
      * Stored source-specific overrides as JSON string
      * Format: Map<sourceId: Long, SourceOverride>
      */

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -865,6 +865,11 @@
     <string name="pref_experimental_library_pagination_summary">Load each category a page at a time (default 300, newest first) and load more as you scroll, instead of holding the whole library in memory. Sorting, filtering and search apply to the entries loaded so far. Restart after changing.</string>
     <string name="pref_experimental_library_page_size">Experimental: library page size</string>
     <string name="pref_experimental_library_page_size_summary">Entries loaded per category per page when pagination is on. Lower means less memory but more loads while scrolling. Currently %1$d. Restart after changing.</string>
+    <string name="pref_category_mass_import">Mass import</string>
+    <string name="pref_mass_import_separate_file_per_batch">Separate queue per file</string>
+    <string name="pref_mass_import_separate_file_per_batch_summary">When importing multiple files at once, add each file as its own queue instead of joining them into one.</string>
+    <string name="pref_mass_import_split_by_domain">Split by domain</string>
+    <string name="pref_mass_import_split_by_domain_summary">Put each website\'s URLs in its own queue. Streamed to disk so large files won\'t run out of memory; queues past a safe limit are combined into one.</string>
     <string name="pref_js_plugin_native_cheerio">Use native cheerio for JS plugins</string>
     <string name="pref_js_plugin_native_cheerio_summary">Experimental: parse plugin HTML with bundled real cheerio (full API) instead of the Jsoup wrapper. Slower but more compatible. Reopen the chapter to apply.</string>
     <string name="action_hide_source_name">Hide source name</string>


### PR DESCRIPTION
- dedup, notification, and retry-count correctness

- per-file and per-domain queue options in advanced settings

- the main thread isn't blocked anymore when clearing mass-import batches