### PR TITLE
portable translations+ quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
+- Translations and quotes more organized/portable [@mrissaoussama](https://github.com/mrissaoussama) [#336](https://github.com/tsundoku-otaku/tsundoku/pull/336)
 - A ton of Arabic translations [@OtakuArab](https://github.com/OtakuArab) [#327](https://github.com/tsundoku-otaku/tsundoku/pull/327)
 - Alt titles are now searchable [@mrissaoussama](https://github.com/mrissaoussama) [#337](https://github.com/tsundoku-otaku/tsundoku/pull/337)
 - Novel download queue improvements to prevent errors [@mrissaoussama](https://github.com/mrissaoussama) [#284](https://github.com/tsundoku-otaku/tsundoku/pull/284)

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -183,7 +183,7 @@ class DomainModule : InjektModule {
         addFactory { GetBookmarkedChaptersByMangaId(get()) }
         addFactory { GetChapterByUrlAndMangaId(get()) }
         addFactory { UpdateChapter(get()) }
-        addFactory { SetReadStatus(get(), get(), get(), get(), get()) }
+        addFactory { SetReadStatus(get(), get(), get(), get(), get(), get()) }
         addFactory { ShouldUpdateDbChapter() }
         addFactory { SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         addFactory { GetAvailableScanlators(get()) }

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -185,7 +185,7 @@ class DomainModule : InjektModule {
         addFactory { UpdateChapter(get()) }
         addFactory { SetReadStatus(get(), get(), get(), get(), get(), get()) }
         addFactory { ShouldUpdateDbChapter() }
-        addFactory { SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+        addFactory { SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         addFactory { GetAvailableScanlators(get()) }
         addFactory { FilterChaptersForDownload(get(), get(), get()) }
         addFactory { RemoveChapters(get()) }

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -11,6 +11,8 @@ import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -21,6 +23,7 @@ class SetReadStatus(
     private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
     private val translatedChapterRepository: TranslatedChapterRepository,
+    private val sourceManager: SourceManager,
 ) {
 
     private val sourceTrackerDispatcher: SourceTrackerDispatcher by lazy { Injekt.get() }
@@ -54,8 +57,18 @@ class SetReadStatus(
         }
 
         if (read) {
-            chaptersToUpdate.forEach { chapter ->
-                translatedChapterRepository.deleteAllForChapter(chapter.id)
+            chaptersToUpdate.groupBy { it.mangaId }.forEach { (mangaId, chapters) ->
+                try {
+                    val manga = mangaRepository.getMangaById(mangaId)
+                    val sourceName = sourceManager.getOrStub(manga.source).toString()
+                    chapters.forEach { chapter ->
+                        translatedChapterRepository.deleteAllForChapter(
+                            TranslationLocator(sourceName, manga.title, chapter.name, chapter.url),
+                        )
+                    }
+                } catch (e: Exception) {
+                    logcat(LogPriority.WARN, e) { "Failed to delete translations on mark-as-read for manga $mangaId" }
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -58,16 +58,20 @@ class SetReadStatus(
 
         if (read) {
             chaptersToUpdate.groupBy { it.mangaId }.forEach { (mangaId, chapters) ->
-                try {
-                    val manga = mangaRepository.getMangaById(mangaId)
+                val manga = mangaRepository.getMangaByIdOrNull(mangaId)
+                if (manga == null) {
+                    logcat(LogPriority.WARN) { "Skipping translation cleanup: manga $mangaId not found" }
+                } else {
                     val sourceName = sourceManager.getOrStub(manga.source).toString()
                     chapters.forEach { chapter ->
-                        translatedChapterRepository.deleteAllForChapter(
-                            TranslationLocator(sourceName, manga.title, chapter.name, chapter.url),
-                        )
+                        try {
+                            translatedChapterRepository.deleteAllForChapter(
+                                TranslationLocator(sourceName, manga.title, chapter.name, chapter.url),
+                            )
+                        } catch (e: Exception) {
+                            logcat(LogPriority.WARN, e) { "Failed to delete translations for chapter ${chapter.id}" }
+                        }
                     }
-                } catch (e: Exception) {
-                    logcat(LogPriority.WARN, e) { "Failed to delete translations on mark-as-read for manga $mangaId" }
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -21,6 +21,7 @@ import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.chapter.service.ChapterRecognition
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import tachiyomi.source.local.isLocal
 import java.lang.Long.max
 import java.time.ZonedDateTime
@@ -36,6 +37,7 @@ class SyncChaptersWithSource(
     private val getChaptersByMangaId: GetChaptersByMangaId,
     private val getExcludedScanlators: GetExcludedScanlators,
     private val libraryPreferences: LibraryPreferences,
+    private val translatedChapterRepository: TranslatedChapterRepository,
 ) {
 
     /**
@@ -129,6 +131,15 @@ class SyncChaptersWithSource(
 
                     if (shouldRenameChapter) {
                         downloadManager.renameChapter(source, manga, dbChapter, chapter)
+                    }
+                    if (dbChapter.name != chapter.name) {
+                        translatedChapterRepository.renameChapter(
+                            source.toString(),
+                            manga.title,
+                            dbChapter.name,
+                            chapter.name,
+                            chapter.url,
+                        )
                     }
 
                     var toChangeChapter = dbChapter.copy(

--- a/app/src/main/java/eu/kanade/domain/download/interactor/DeleteDownload.kt
+++ b/app/src/main/java/eu/kanade/domain/download/interactor/DeleteDownload.kt
@@ -5,6 +5,7 @@ import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 
 class DeleteDownload(
@@ -17,8 +18,11 @@ class DeleteDownload(
         sourceManager.get(manga.source)?.let { source ->
             downloadManager.deleteChapters(chapters.toList(), manga, source)
         }
+        val sourceName = sourceManager.getOrStub(manga.source).toString()
         chapters.forEach { chapter ->
-            translatedChapterRepository.deleteAllForChapter(chapter.id)
+            translatedChapterRepository.deleteAllForChapter(
+                TranslationLocator(sourceName, manga.title, chapter.name, chapter.url),
+            )
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/MassImportDialog.kt
@@ -102,7 +102,10 @@ private const val CLIPBOARD_COPY_LIMIT = 5_000
 // one more source without materializing it alongside the staged files.
 private fun writeTempUrlsFile(context: Context, text: String): File {
     val file = File(context.cacheDir, "mass_import_typed_${System.nanoTime()}.txt")
-    file.bufferedWriter().use { it.write(text); it.write("\n") }
+    file.bufferedWriter().use {
+        it.write(text)
+        it.write("\n")
+    }
     return file
 }
 
@@ -877,7 +880,15 @@ fun MassImportDialog(
                                         // Not separating files, but splitting by domain: fold
                                         // everything into one file, then split it below.
                                         if (staged.isNotEmpty() || combinedRawText.isNotBlank()) {
-                                            listOf(joinUrlFiles(context, staged, combinedRawText.takeIf { it.isNotBlank() }))
+                                            listOf(
+                                                joinUrlFiles(
+                                                    context,
+                                                    staged,
+                                                    combinedRawText.takeIf {
+                                                        it.isNotBlank()
+                                                    },
+                                                ),
+                                            )
                                         } else {
                                             emptyList()
                                         }
@@ -925,7 +936,11 @@ fun MassImportDialog(
                         } else {
                             val uniqueUrls = withContext(Dispatchers.Default) {
                                 val set = LinkedHashSet<String>()
-                                if (combinedRawText.isNotBlank()) set.addAll(massImportNovels.parseUrls(combinedRawText))
+                                if (combinedRawText.isNotBlank()) {
+                                    set.addAll(
+                                        massImportNovels.parseUrls(combinedRawText),
+                                    )
+                                }
                                 set.toList()
                             }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -68,6 +68,8 @@ import eu.kanade.presentation.more.settings.screen.debug.DebugInfoScreen
 import eu.kanade.tachiyomi.data.database.DatabaseMaintenanceJob
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.library.MetadataUpdateJob
+import eu.kanade.tachiyomi.data.storage.QuotesPortableMigrator
+import eu.kanade.tachiyomi.data.storage.TranslationsPortableMigrator
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.network.PREF_DOH_360
@@ -1234,6 +1236,46 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_delete_all_translations),
                     subtitle = stringResource(MR.strings.pref_delete_all_translations_subtitle),
                     onClick = { showDeleteTranslationsDialog = true },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_migrate_quotes_portable),
+                    subtitle = stringResource(MR.strings.pref_migrate_quotes_portable_subtitle),
+                    onClick = {
+                        scope.launch {
+                            val count = try {
+                                QuotesPortableMigrator.run()
+                            } catch (e: Exception) {
+                                logcat(LogPriority.ERROR, e)
+                                withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
+                                return@launch
+                            }
+                            withUIContext {
+                                context.toast(
+                                    context.contextStringResource(MR.strings.pref_portable_migration_done, count),
+                                )
+                            }
+                        }
+                    },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_migrate_translations_portable),
+                    subtitle = stringResource(MR.strings.pref_migrate_translations_portable_subtitle),
+                    onClick = {
+                        scope.launch {
+                            val count = try {
+                                TranslationsPortableMigrator.run()
+                            } catch (e: Exception) {
+                                logcat(LogPriority.ERROR, e)
+                                withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
+                                return@launch
+                            }
+                            withUIContext {
+                                context.toast(
+                                    context.contextStringResource(MR.strings.pref_portable_migration_done, count),
+                                )
+                            }
+                        }
+                    },
                 ),
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(MR.strings.pref_clear_temp_files),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -278,6 +278,7 @@ object SettingsAdvancedScreen : SearchableSettings {
         val scope = rememberCoroutineScope()
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
         var showDeleteTranslationsDialog by remember { mutableStateOf(false) }
+        var portableMigrationRunning by remember { mutableStateOf(false) }
         var showNormalizeUrlsDialog by remember { mutableStateOf(false) }
         var showRemoveDuplicatesDialog by remember { mutableStateOf(false) }
         var removeDoubleSlashes by remember { mutableStateOf(true) }
@@ -1241,18 +1242,23 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_migrate_quotes_portable),
                     subtitle = stringResource(MR.strings.pref_migrate_quotes_portable_subtitle),
                     onClick = {
-                        scope.launch {
-                            val count = try {
-                                QuotesPortableMigrator.run()
-                            } catch (e: Exception) {
-                                logcat(LogPriority.ERROR, e)
-                                withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
-                                return@launch
-                            }
-                            withUIContext {
-                                context.toast(
-                                    context.contextStringResource(MR.strings.pref_portable_migration_done, count),
-                                )
+                        if (!portableMigrationRunning) {
+                            portableMigrationRunning = true
+                            scope.launch {
+                                val count = try {
+                                    QuotesPortableMigrator.run()
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.ERROR, e)
+                                    withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
+                                    return@launch
+                                } finally {
+                                    portableMigrationRunning = false
+                                }
+                                withUIContext {
+                                    context.toast(
+                                        context.contextStringResource(MR.strings.pref_portable_migration_done, count),
+                                    )
+                                }
                             }
                         }
                     },
@@ -1261,18 +1267,23 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_migrate_translations_portable),
                     subtitle = stringResource(MR.strings.pref_migrate_translations_portable_subtitle),
                     onClick = {
-                        scope.launch {
-                            val count = try {
-                                TranslationsPortableMigrator.run()
-                            } catch (e: Exception) {
-                                logcat(LogPriority.ERROR, e)
-                                withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
-                                return@launch
-                            }
-                            withUIContext {
-                                context.toast(
-                                    context.contextStringResource(MR.strings.pref_portable_migration_done, count),
-                                )
+                        if (!portableMigrationRunning) {
+                            portableMigrationRunning = true
+                            scope.launch {
+                                val count = try {
+                                    TranslationsPortableMigrator.run()
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.ERROR, e)
+                                    withUIContext { context.toast(MR.strings.pref_portable_migration_error) }
+                                    return@launch
+                                } finally {
+                                    portableMigrationRunning = false
+                                }
+                                withUIContext {
+                                    context.toast(
+                                        context.contextStringResource(MR.strings.pref_portable_migration_done, count),
+                                    )
+                                }
                             }
                         }
                     },

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
@@ -688,7 +688,9 @@ private fun QuoteItem(
                 )
             }
             Text(
-                text = quote.chapterName,
+                text = quote.paragraphIndex
+                    ?.let { "${quote.chapterName}  ·  ¶${it + 1}" }
+                    ?: quote.chapterName,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.weight(1f),

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/QuotesSheet.kt
@@ -66,6 +66,7 @@ import tachiyomi.presentation.core.i18n.stringResource
 @Composable
 fun QuotesSheet(
     quotes: List<Quote>,
+    novelTitle: String,
     onDismiss: () -> Unit,
     onQuoteClick: (Quote) -> Unit,
     onQuoteDelete: (Quote) -> Unit,
@@ -187,7 +188,7 @@ fun QuotesSheet(
                         onClick = {
                             val quote = selectedQuote.value
                             if (quote != null) {
-                                val textToCopy = "\"${quote.content}\"\n\n- ${quote.novelName}, ${quote.chapterName}"
+                                val textToCopy = "\"${quote.content}\"\n\n- $novelTitle, ${quote.chapterName}"
                                 clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(textToCopy))
                             }
                             selectedQuote.value = null

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -31,6 +31,7 @@ import tachiyomi.i18n.MR
 import tachiyomi.source.local.isLocalNovel
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.IOException
 
 /**
  * This class is used to manage chapter downloads in the application. It must be instantiated once
@@ -455,22 +456,45 @@ class DownloadManager(
             logcat(LogPriority.ERROR, it) { "Failed to create destination download folder for ${manga.title}" }
             return false
         }
-        copyContentsRecursive(oldFolder, destFolder)
+        if (!copyContentsRecursive(oldFolder, destFolder)) {
+            // Deleting the source after a partial copy would lose the un-copied chapters. Keep it so
+            // the move can be retried; the non-empty-destination guard above blocks a re-copy.
+            logcat(LogPriority.ERROR) { "Copy incomplete moving downloads for ${manga.title}; keeping source" }
+            cache.invalidateCache()
+            return false
+        }
         deleteRecursive(oldFolder)
         cache.invalidateCache()
         return true
     }
 
-    private fun copyContentsRecursive(src: UniFile, dest: UniFile) {
+    // Returns true only if every child copied; a false result must prevent deleting the source.
+    private fun copyContentsRecursive(src: UniFile, dest: UniFile): Boolean {
+        var ok = true
         src.listFiles()?.forEach { child ->
-            val name = child.name ?: return@forEach
+            val name = child.name
+            if (name == null) {
+                ok = false
+                return@forEach
+            }
             if (child.isDirectory) {
-                dest.createDirectory(name)?.let { copyContentsRecursive(child, it) }
+                val destChild = dest.findFile(name)?.takeIf { it.isDirectory } ?: dest.createDirectory(name)
+                if (destChild == null || !copyContentsRecursive(child, destChild)) ok = false
             } else {
-                val out = dest.createFile(name) ?: return@forEach
-                child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+                val out = dest.createFile(name)
+                if (out == null) {
+                    ok = false
+                } else {
+                    try {
+                        child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+                    } catch (e: IOException) {
+                        logcat(LogPriority.ERROR) { "Failed to copy download '$name': ${e.message}" }
+                        ok = false
+                    }
+                }
             }
         }
+        return ok
     }
 
     private fun deleteRecursive(file: UniFile) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
@@ -430,6 +431,51 @@ class DownloadManager(
         } else {
             logcat(LogPriority.ERROR) { "Failed to rename manga download folder: ${oldFolder.name}" }
         }
+    }
+
+    /**
+     * Moves a manga's downloads from one source folder to another (e.g. on migration). SAF renameTo
+     * only renames within the same parent, so this copies the tree then deletes the original. Denies
+     * the move if the destination already holds downloads.
+     *
+     * @return true if the move succeeded or there was nothing to move.
+     */
+    suspend fun moveMangaToNewSource(manga: Manga, oldSource: Source, newSource: Source): Boolean {
+        if (oldSource.id == newSource.id) return true
+        val oldFolder = provider.findMangaDir(manga.title, oldSource) ?: return true
+
+        val existingNew = provider.findMangaDir(manga.title, newSource)
+        if (existingNew != null && !existingNew.listFiles().isNullOrEmpty()) {
+            logcat(LogPriority.WARN) { "Downloads already exist for ${manga.title} under new source; not moving" }
+            return false
+        }
+
+        downloader.removeFromQueue(manga)
+        val destFolder = provider.getMangaDir(manga.title, newSource).getOrElse {
+            logcat(LogPriority.ERROR, it) { "Failed to create destination download folder for ${manga.title}" }
+            return false
+        }
+        copyContentsRecursive(oldFolder, destFolder)
+        deleteRecursive(oldFolder)
+        cache.invalidateCache()
+        return true
+    }
+
+    private fun copyContentsRecursive(src: UniFile, dest: UniFile) {
+        src.listFiles()?.forEach { child ->
+            val name = child.name ?: return@forEach
+            if (child.isDirectory) {
+                dest.createDirectory(name)?.let { copyContentsRecursive(child, it) }
+            } else {
+                val out = dest.createFile(name) ?: return@forEach
+                child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+            }
+        }
+    }
+
+    private fun deleteRecursive(file: UniFile) {
+        if (file.isDirectory) file.listFiles()?.forEach { deleteRecursive(it) }
+        file.delete()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -457,9 +457,10 @@ class DownloadManager(
             return false
         }
         if (!copyContentsRecursive(oldFolder, destFolder)) {
-            // Deleting the source after a partial copy would lose the un-copied chapters. Keep it so
-            // the move can be retried; the non-empty-destination guard above blocks a re-copy.
-            logcat(LogPriority.ERROR) { "Copy incomplete moving downloads for ${manga.title}; keeping source" }
+            // Keep the source (it still holds every chapter) but drop the half-copied destination,
+            // otherwise the non-empty-destination guard above would block every future retry.
+            logcat(LogPriority.ERROR) { "Copy incomplete moving downloads for ${manga.title}; reverting" }
+            deleteRecursive(destFolder)
             cache.invalidateCache()
             return false
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/epub/EpubExportJob.kt
@@ -45,6 +45,7 @@ import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.model.TranslationMode
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import tachiyomi.i18n.novel.TDMR
@@ -213,13 +214,6 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                         continue
                     }
 
-                    // Identify which chapters have translations
-                    val translatedChapterIds = if (translationMode != TranslationMode.ORIGINAL) {
-                        translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
-                    } else {
-                        emptySet()
-                    }
-
                     val chapterContents = mutableListOf<ChapterContent>()
                     val isLocalSource = source.isLocal() || manga.isLocalNovel()
                     val localEpubContexts = mutableMapOf<String, LocalEpubContext>()
@@ -239,7 +233,21 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                                 )
                             }
 
-                            val hasTranslation = chapter.id in translatedChapterIds
+                            val chapterTranslations = if (translationMode != TranslationMode.ORIGINAL) {
+                                try {
+                                    translatedChapterRepository.getAllTranslationsForChapter(
+                                        TranslationLocator(source.toString(), manga.title, chapter.name, chapter.url),
+                                    )
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.WARN, e) {
+                                        "Failed to get translations for chapter: ${chapter.name}"
+                                    }
+                                    emptyList()
+                                }
+                            } else {
+                                emptyList()
+                            }
+                            val hasTranslation = chapterTranslations.isNotEmpty()
                             val localReference = if (isLocalSource) parseLocalEpubReference(chapter.url) else null
                             val localContext = localReference?.let {
                                 getOrCreateLocalEpubContext(it, localEpubContexts)
@@ -302,16 +310,7 @@ class EpubExportJob(private val context: Context, workerParams: WorkerParameters
                             // Translated content
                             var translatedContent: String? = null
                             if (translationMode != TranslationMode.ORIGINAL && hasTranslation) {
-                                try {
-                                    val translations = translatedChapterRepository.getAllTranslationsForChapter(
-                                        chapter.id,
-                                    )
-                                    translatedContent = translations.firstOrNull()?.translatedContent
-                                } catch (e: Exception) {
-                                    logcat(LogPriority.WARN, e) {
-                                        "Failed to get translation for chapter: ${chapter.name}"
-                                    }
-                                }
+                                translatedContent = chapterTranslations.firstOrNull()?.translatedContent
                             }
 
                             val keepLocalOriginalSlot = isLocalSource && isDownloaded

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -1130,10 +1130,20 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
     // Per-batch ids so concurrent batches don't clobber each other's notification. Two disjoint
     // positive bands 100M apart (progress vs completion); 24-bit spread makes collisions negligible.
     private fun progressNotificationId(batchId: String): Int =
-        if (batchId.isEmpty()) Notifications.ID_MASS_IMPORT_PROGRESS else 600_000_000 + (batchId.hashCode() and 0xFFFFFF)
+        if (batchId.isEmpty()) {
+            Notifications.ID_MASS_IMPORT_PROGRESS
+        } else {
+            600_000_000 +
+                (batchId.hashCode() and 0xFFFFFF)
+        }
 
     private fun completionNotificationId(batchId: String): Int =
-        if (batchId.isEmpty()) Notifications.ID_MASS_IMPORT_COMPLETE else 700_000_000 + (batchId.hashCode() and 0xFFFFFF)
+        if (batchId.isEmpty()) {
+            Notifications.ID_MASS_IMPORT_COMPLETE
+        } else {
+            700_000_000 +
+                (batchId.hashCode() and 0xFFFFFF)
+        }
 
     private fun showCompletionNotification(batchId: String, added: Int, skipped: Int, errored: Int, message: String?) {
         val text = message ?: "Added: $added, Skipped: $skipped, Errors: $errored"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.data.storage
+
+import android.app.Application
+import eu.kanade.tachiyomi.ui.reader.quote.NovelQuotes
+import eu.kanade.tachiyomi.ui.reader.quote.QuoteManager
+import kotlinx.serialization.json.Json
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Moves quotes from the legacy id-keyed layout (quotes/novel_{id}.json) to the portable
+ * source/title layout used by [QuoteManager]. Invoked manually from Advanced settings;
+ * idempotent (only touches files still in the legacy layout).
+ */
+object QuotesPortableMigrator {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun run(): Int {
+        val context = Injekt.get<Application>()
+        val storageManager = Injekt.get<StorageManager>()
+        val mangaRepository = Injekt.get<MangaRepository>()
+        val sourceManager = Injekt.get<SourceManager>()
+
+        val quotesDir = storageManager.getQuotesDirectory() ?: return 0
+        val legacyFiles = quotesDir.listFiles()
+            ?.filter { f -> f.name?.let { it.startsWith("novel_") && it.endsWith(".json") } == true }
+            ?: return 0
+
+        val quoteManager = QuoteManager(context)
+        var migrated = 0
+        for (file in legacyFiles) {
+            val name = file.name ?: continue
+            val novelId = name.removePrefix("novel_").removeSuffix(".json").toLongOrNull() ?: continue
+            try {
+                val content = file.openInputStream().use { String(it.readBytes()) }
+                val quotes = json.decodeFromString<NovelQuotes>(content).quotes
+                if (quotes.isEmpty()) {
+                    file.delete()
+                    continue
+                }
+                val manga = mangaRepository.getMangaById(novelId)
+                val sourceName = sourceManager.getOrStub(manga.source).toString()
+                quoteManager.saveQuotes(sourceName, manga.title, quotes)
+                // saveQuotes swallows IO errors; only drop the legacy file once the
+                // new one is confirmed written, so a failed write can't lose quotes.
+                if (quoteManager.getQuotes(sourceName, manga.title).size == quotes.size) {
+                    file.delete()
+                    migrated++
+                }
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) { "Failed to migrate quotes file $name" }
+            }
+        }
+        return migrated
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
@@ -45,12 +45,13 @@ object QuotesPortableMigrator {
                 }
                 val manga = mangaRepository.getMangaById(novelId)
                 val sourceName = sourceManager.getOrStub(manga.source).toString()
-                quoteManager.saveQuotes(sourceName, manga.title, quotes)
-                // saveQuotes swallows IO errors; only drop the legacy file once the
-                // new one is confirmed written, so a failed write can't lose quotes.
-                if (quoteManager.getQuotes(sourceName, manga.title).size == quotes.size) {
+                // Only drop the legacy file once the new one is confirmed written,
+                // so a failed write can't lose quotes.
+                if (quoteManager.saveQuotes(sourceName, manga.title, quotes)) {
                     file.delete()
                     migrated++
+                } else {
+                    logcat(LogPriority.WARN) { "Quote migration write failed for $name, keeping legacy file" }
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.WARN, e) { "Failed to migrate quotes file $name" }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/QuotesPortableMigrator.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.data.storage
 import android.app.Application
 import eu.kanade.tachiyomi.ui.reader.quote.NovelQuotes
 import eu.kanade.tachiyomi.ui.reader.quote.QuoteManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
@@ -20,16 +22,16 @@ import uy.kohesive.injekt.api.get
 object QuotesPortableMigrator {
     private val json = Json { ignoreUnknownKeys = true }
 
-    suspend fun run(): Int {
+    suspend fun run(): Int = withContext(Dispatchers.IO) {
         val context = Injekt.get<Application>()
         val storageManager = Injekt.get<StorageManager>()
         val mangaRepository = Injekt.get<MangaRepository>()
         val sourceManager = Injekt.get<SourceManager>()
 
-        val quotesDir = storageManager.getQuotesDirectory() ?: return 0
+        val quotesDir = storageManager.getQuotesDirectory() ?: return@withContext 0
         val legacyFiles = quotesDir.listFiles()
             ?.filter { f -> f.name?.let { it.startsWith("novel_") && it.endsWith(".json") } == true }
-            ?: return 0
+            ?: return@withContext 0
 
         val quoteManager = QuoteManager(context)
         var migrated = 0
@@ -43,7 +45,7 @@ object QuotesPortableMigrator {
                     file.delete()
                     continue
                 }
-                val manga = mangaRepository.getMangaById(novelId)
+                val manga = mangaRepository.getMangaByIdOrNull(novelId) ?: continue
                 val sourceName = sourceManager.getOrStub(manga.source).toString()
                 // Only drop the legacy file once the new one is confirmed written,
                 // so a failed write can't lose quotes.
@@ -57,6 +59,6 @@ object QuotesPortableMigrator {
                 logcat(LogPriority.WARN, e) { "Failed to migrate quotes file $name" }
             }
         }
-        return migrated
+        migrated
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
@@ -1,0 +1,86 @@
+package eu.kanade.tachiyomi.data.storage
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.repository.ChapterRepository
+import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.storage.service.StorageManager
+import tachiyomi.domain.translation.model.TranslatedChapter
+import tachiyomi.domain.translation.model.TranslationLocator
+import tachiyomi.domain.translation.repository.TranslatedChapterRepository
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Converts translations from the legacy flat, id-keyed layout
+ * (translations/{chapterId}_{lang}.html) to the portable source/novel/language/chapter
+ * layout. Invoked manually from Advanced settings; idempotent (only touches flat files).
+ */
+object TranslationsPortableMigrator {
+    private val flatFileRegex = Regex("^(\\d+)_(.+?)\\.html(\\.tmp)?$")
+    private val metaRegex = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+)(?::[a-f0-9]{64})? -->\\n?")
+
+    suspend fun run(): Int {
+        val storageManager = Injekt.get<StorageManager>()
+        val translatedChapterRepository = Injekt.get<TranslatedChapterRepository>()
+        val chapterRepository = Injekt.get<ChapterRepository>()
+        val mangaRepository = Injekt.get<MangaRepository>()
+        val sourceManager = Injekt.get<SourceManager>()
+
+        val translationsDir = storageManager.getTranslationsDirectory() ?: return 0
+
+        val flatFiles = translationsDir.listFiles()
+            ?.filter { !it.isDirectory && flatFileRegex.matches(it.name.orEmpty()) }
+            .orEmpty()
+
+        var migrated = 0
+        for (file in flatFiles) {
+            val name = file.name ?: continue
+            val match = flatFileRegex.matchEntire(name) ?: continue
+            val chapterId = match.groupValues[1].toLongOrNull() ?: continue
+            val lang = match.groupValues[2]
+            val isTmp = match.groupValues[3].isNotEmpty()
+            try {
+                val chapter = chapterRepository.getChapterById(chapterId)
+                if (chapter == null) {
+                    // Chapter no longer exists, so the translation can't be relocated; drop it.
+                    file.delete()
+                    continue
+                }
+                val manga = mangaRepository.getMangaById(chapter.mangaId)
+                val locator = TranslationLocator(
+                    sourceName = sourceManager.getOrStub(manga.source).toString(),
+                    novelTitle = manga.title,
+                    chapterName = chapter.name,
+                    chapterUrl = chapter.url,
+                )
+
+                val raw = file.openInputStream().bufferedReader().use { it.readText() }
+                val metaMatch = metaRegex.find(raw)
+                val engineId = metaMatch?.groupValues?.get(1) ?: "unknown"
+                val date = metaMatch?.groupValues?.get(2)?.toLongOrNull() ?: 0L
+                val content = if (metaMatch != null) raw.removeRange(metaMatch.range).trimStart('\n') else raw
+
+                val translated = TranslatedChapter(
+                    chapterId = 0,
+                    mangaId = 0,
+                    targetLanguage = lang,
+                    engineId = engineId,
+                    translatedContent = content,
+                    dateTranslated = date,
+                )
+                if (isTmp) {
+                    translatedChapterRepository.upsertTmpTranslation(locator, translated)
+                } else {
+                    translatedChapterRepository.upsertTranslation(locator, translated)
+                }
+                file.delete()
+                migrated++
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) { "Failed to migrate translation file $name" }
+            }
+        }
+        return migrated
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
@@ -75,7 +75,9 @@ object TranslationsPortableMigrator {
                 } else {
                     translatedChapterRepository.upsertTranslation(locator, translated)
                 }
-                file.delete()
+                if (!file.delete()) {
+                    logcat(LogPriority.WARN) { "Migrated $name but could not remove the legacy file" }
+                }
                 migrated++
             } catch (e: Exception) {
                 logcat(LogPriority.WARN, e) { "Failed to migrate translation file $name" }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/TranslationsPortableMigrator.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.data.storage
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.repository.ChapterRepository
@@ -21,14 +23,14 @@ object TranslationsPortableMigrator {
     private val flatFileRegex = Regex("^(\\d+)_(.+?)\\.html(\\.tmp)?$")
     private val metaRegex = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+)(?::[a-f0-9]{64})? -->\\n?")
 
-    suspend fun run(): Int {
+    suspend fun run(): Int = withContext(Dispatchers.IO) {
         val storageManager = Injekt.get<StorageManager>()
         val translatedChapterRepository = Injekt.get<TranslatedChapterRepository>()
         val chapterRepository = Injekt.get<ChapterRepository>()
         val mangaRepository = Injekt.get<MangaRepository>()
         val sourceManager = Injekt.get<SourceManager>()
 
-        val translationsDir = storageManager.getTranslationsDirectory() ?: return 0
+        val translationsDir = storageManager.getTranslationsDirectory() ?: return@withContext 0
 
         val flatFiles = translationsDir.listFiles()
             ?.filter { !it.isDirectory && flatFileRegex.matches(it.name.orEmpty()) }
@@ -48,7 +50,7 @@ object TranslationsPortableMigrator {
                     file.delete()
                     continue
                 }
-                val manga = mangaRepository.getMangaById(chapter.mangaId)
+                val manga = mangaRepository.getMangaByIdOrNull(chapter.mangaId) ?: continue
                 val locator = TranslationLocator(
                     sourceName = sourceManager.getOrStub(manga.source).toString(),
                     novelTitle = manga.title,
@@ -83,6 +85,6 @@ object TranslationsPortableMigrator {
                 logcat(LogPriority.WARN, e) { "Failed to migrate translation file $name" }
             }
         }
-        return migrated
+        migrated
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -36,6 +36,7 @@ import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.translation.model.TranslatedChapter
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.model.TranslationProgress
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.model.TranslationStatus
@@ -397,12 +398,19 @@ class TranslationService(
         val source = sourceManager.get(manga.source)
             ?: throw IllegalStateException("Source ${manga.source} not found")
 
+        val locator = TranslationLocator(
+            sourceName = sourceManager.getOrStub(manga.source).toString(),
+            novelTitle = manga.title,
+            chapterName = chapter.name,
+            chapterUrl = chapter.url,
+        )
+
         logcat(LogPriority.DEBUG) { "Starting translation for chapter: ${chapter.name}" }
 
         // Check if already translated (skip unless forceRetranslate)
         if (!task.forceRetranslate) {
             val existingTranslation = translatedChapterRepository.getTranslatedChapter(
-                task.chapterId,
+                locator,
                 task.targetLanguage,
             )
             if (existingTranslation != null) {
@@ -459,7 +467,7 @@ class TranslationService(
 
         // Check for existing partial translation to resume from
         val existingTmpParagraphs = run {
-            val tmp = translatedChapterRepository.getTmpTranslation(task.chapterId, task.targetLanguage)
+            val tmp = translatedChapterRepository.getTmpTranslation(locator, task.targetLanguage)
             if (tmp != null) {
                 TranslationHtmlUtils.splitParagraphsPreserving(
                     TranslationHtmlUtils.extractTextFromHtml(tmp.translatedContent),
@@ -544,7 +552,7 @@ class TranslationService(
 
             // Check for cancellation
             if (_progressState.value.isCancelling) {
-                savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                savePartialTranslation(locator, task, engine.id.toString(), allTranslated, translatedTitle)
                 throw CancellationException("Translation cancelled by user")
             }
 
@@ -598,7 +606,7 @@ class TranslationService(
                     }
                     break
                 } catch (e: CancellationException) {
-                    savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                    savePartialTranslation(locator, task, engine.id.toString(), allTranslated, translatedTitle)
                     throw e
                 } catch (e: Exception) {
                     logcat(LogPriority.ERROR, e) {
@@ -637,7 +645,7 @@ class TranslationService(
         if (failedChunkIndex >= 0) {
             // Save partial translation as .tmp for resume
             if (allTranslated.isNotEmpty()) {
-                savePartialTranslation(task, engine.id.toString(), allTranslated, translatedTitle)
+                savePartialTranslation(locator, task, engine.id.toString(), allTranslated, translatedTitle)
                 logcat(LogPriority.WARN) {
                     "Saved partial translation (${allTranslated.size} paragraphs) for chapter ${chapter.name}"
                 }
@@ -662,7 +670,7 @@ class TranslationService(
             translatedContent = translatedHtml,
             dateTranslated = System.currentTimeMillis(),
         )
-        translatedChapterRepository.upsertTranslation(translatedChapter)
+        translatedChapterRepository.upsertTranslation(locator, translatedChapter)
 
         logcat(LogPriority.DEBUG) { "Successfully translated and saved chapter ${chapter.name}" }
 
@@ -697,6 +705,7 @@ class TranslationService(
      * Uses [TranslationHtmlUtils.buildTranslatedHtml] (fix DRY 2.1).
      */
     private suspend fun savePartialTranslation(
+        locator: TranslationLocator,
         task: TranslationTask,
         engineId: String,
         translatedParagraphs: List<String>,
@@ -715,7 +724,7 @@ class TranslationService(
             dateTranslated = System.currentTimeMillis(),
         )
         try {
-            translatedChapterRepository.upsertTmpTranslation(partial)
+            translatedChapterRepository.upsertTmpTranslation(locator, partial)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Failed to save partial translation" }
         }
@@ -885,8 +894,7 @@ class TranslationService(
      */
     suspend fun translateChapterContent(
         content: String,
-        chapterId: Long? = null,
-        mangaId: Long? = null,
+        locator: TranslationLocator? = null,
         sourceLanguage: String? = null,
         targetLanguage: String? = null,
     ): String {
@@ -902,10 +910,10 @@ class TranslationService(
             return content
         }
 
-        if (chapterId != null) {
-            val existingTranslation = translatedChapterRepository.getTranslatedChapter(chapterId, tgtLang)
+        if (locator != null) {
+            val existingTranslation = translatedChapterRepository.getTranslatedChapter(locator, tgtLang)
             if (TranslationCachePolicy.shouldServeCached(existingTranslation)) {
-                logcat(LogPriority.DEBUG) { "Using cached translation for chapter $chapterId (lang: $tgtLang)" }
+                logcat(LogPriority.DEBUG) { "Using cached translation for ${locator.chapterName} (lang: $tgtLang)" }
                 return existingTranslation!!.translatedContent
             }
         }
@@ -917,7 +925,8 @@ class TranslationService(
         val plainText = TranslationHtmlUtils.extractTextFromHtml(contentWithoutImages)
 
         logcat(LogPriority.DEBUG) {
-            "translateChapterContent: chapterId=$chapterId srcLang=$srcLang tgtLang=$tgtLang plainText=${plainText.length} chars"
+            "translateChapterContent: chapter=${locator?.chapterName} srcLang=$srcLang tgtLang=$tgtLang " +
+                "plainText=${plainText.length} chars"
         }
 
         // Translate the plain text
@@ -931,25 +940,25 @@ class TranslationService(
                     translatedHtml = TranslationHtmlUtils.reinsertImages(translatedHtml, preservedImages)
                 }
 
-                // Save translation to database
-                if (chapterId != null && mangaId != null) {
+                // Persist translation for future use
+                if (locator != null) {
                     val engine = translationEngineManager.getEngine()
                     val translatedChapter = TranslatedChapter(
-                        chapterId = chapterId,
-                        mangaId = mangaId,
+                        chapterId = 0,
+                        mangaId = 0,
                         targetLanguage = tgtLang,
                         engineId = engine?.id?.toString() ?: "unknown",
                         translatedContent = translatedHtml,
                         dateTranslated = System.currentTimeMillis(),
                     )
                     try {
-                        translatedChapterRepository.upsertTranslation(translatedChapter)
-                        logcat(LogPriority.DEBUG) { "Saved translation for chapter $chapterId (lang: $tgtLang)" }
+                        translatedChapterRepository.upsertTranslation(locator, translatedChapter)
+                        logcat(LogPriority.DEBUG) { "Saved translation for ${locator.chapterName} (lang: $tgtLang)" }
                     } catch (e: CancellationException) {
-                        logcat(LogPriority.DEBUG) { "Translation save was cancelled for chapter $chapterId" }
+                        logcat(LogPriority.DEBUG) { "Translation save was cancelled for ${locator.chapterName}" }
                         throw e
                     } catch (e: Exception) {
-                        logcat(LogPriority.ERROR, e) { "Failed to save translation to database" }
+                        logcat(LogPriority.ERROR, e) { "Failed to save translation" }
                     }
                 }
 
@@ -963,39 +972,14 @@ class TranslationService(
     }
 
     /**
-     * Get translated content from database if available.
-     */
-    suspend fun getTranslatedContent(
-        chapterId: Long,
-        targetLanguage: String? = null,
-    ): String? {
-        val tgtLang = targetLanguage ?: translationPreferences.targetLanguage().get()
-        return translatedChapterRepository.getTranslatedChapter(chapterId, tgtLang)?.translatedContent
-    }
-
-    /**
-     * Check if a translation exists for a chapter.
+     * Check if a translation exists for a chapter locator in the given (or default) language.
      */
     suspend fun hasTranslation(
-        chapterId: Long,
+        locator: TranslationLocator,
         targetLanguage: String? = null,
     ): Boolean {
         val tgtLang = targetLanguage ?: translationPreferences.targetLanguage().get()
-        return translatedChapterRepository.hasTranslation(chapterId, tgtLang)
-    }
-
-    /**
-     * Get all available translation languages for a manga.
-     */
-    suspend fun getTranslatedLanguages(chapterIds: Collection<Long>): List<String> {
-        return translatedChapterRepository.getTranslatedLanguagesForChapters(chapterIds)
-    }
-
-    /**
-     * Delete a translation.
-     */
-    suspend fun deleteTranslation(chapterId: Long, targetLanguage: String) {
-        translatedChapterRepository.deleteTranslation(chapterId, targetLanguage)
+        return translatedChapterRepository.hasTranslation(locator, tgtLang)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationService.kt
@@ -940,7 +940,6 @@ class TranslationService(
                     translatedHtml = TranslationHtmlUtils.reinsertImages(translatedHtml, preservedImages)
                 }
 
-                // Persist translation for future use
                 if (locator != null) {
                     val engine = translationEngineManager.getEngine()
                     val translatedChapter = TranslatedChapter(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -477,6 +477,11 @@ class CustomNovelSource(
     override val supportsLatest: Boolean
         get() = config.latestUrl != null || baseSource?.supportsLatest == true
 
+    // Must match StubSource.toString() so translations/quotes resolve to the same on-disk directory
+    // whether this source is loaded or currently stubbed. Novel sources render as "Name (LANG) (JS)".
+    override fun toString(): String =
+        if (isNovelSource) "$name (${lang.uppercase()}) (JS)" else "$name (${lang.uppercase()})"
+
     override val client = network.cloudflareClient
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -151,8 +151,21 @@ class MigrateMangaScreenModel(
                         // while the DB already points at the new one (orphaned data). Only preserves
                         // data for same-URL migrations (e.g. JS->KT); different-site moves change
                         // chapter URLs and won't line up.
-                        runCatching { downloadManager.moveMangaToNewSource(manga, oldSource, newSource) }
-                            .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" } }
+                        // moveMangaToNewSource reports non-crash failures (destination collision,
+                        // partial copy) via a false return, not an exception, so branch on the value:
+                        // leave the manga on its old source rather than flipping the DB onto downloads
+                        // that never moved. It can be retried once the conflict is resolved.
+                        val downloadsMoved = runCatching {
+                            downloadManager.moveMangaToNewSource(manga, oldSource, newSource)
+                        }.onFailure {
+                            logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" }
+                        }.getOrDefault(false)
+                        if (!downloadsMoved) {
+                            logcat(LogPriority.WARN) {
+                                "Skipping quick migrate for ${manga.title}: download relocation did not complete"
+                            }
+                            continue
+                        }
                         runCatching {
                             translatedChapterRepository.moveNovel(
                                 oldSource.toString(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -146,11 +146,11 @@ class MigrateMangaScreenModel(
                     try {
                         val oldSource = sourceManager.getOrStub(manga.source)
                         val newSource = sourceManager.getOrStub(targetSourceId)
-                        updateManga.await(MangaUpdate(id = manga.id, source = targetSourceId, url = newUrl))
-                        migratedIds.add(manga.id)
-                        // Downloads and translations are keyed by source, so relocate them to the new
-                        // source or they'd be orphaned. Only preserves data for same-URL migrations
-                        // (e.g. JS->KT); different-site moves change chapter URLs and won't line up.
+                        // Relocate source-keyed data (downloads/translations/quotes) BEFORE flipping the
+                        // DB source, so a crash in between can't leave files under the old source name
+                        // while the DB already points at the new one (orphaned data). Only preserves
+                        // data for same-URL migrations (e.g. JS->KT); different-site moves change
+                        // chapter URLs and won't line up.
                         runCatching { downloadManager.moveMangaToNewSource(manga, oldSource, newSource) }
                             .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" } }
                         runCatching {
@@ -169,6 +169,8 @@ class MigrateMangaScreenModel(
                                 manga.title,
                             )
                         }.onFailure { logcat(LogPriority.ERROR, it) { "Failed to move quotes on quick migrate" } }
+                        updateManga.await(MangaUpdate(id = manga.id, source = targetSourceId, url = newUrl))
+                        migratedIds.add(manga.id)
                     } catch (_: Exception) {
                         // Skip entries that fail to update; the rest still migrate.
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -40,6 +40,11 @@ class MigrateMangaScreenModel(
     private val sourceTrackerDispatcher: SourceTrackerDispatcher = Injekt.get(),
     private val trackPreferences: TrackPreferences = Injekt.get(),
     private val getManga: tachiyomi.domain.manga.interactor.GetManga = Injekt.get(),
+    private val downloadManager: eu.kanade.tachiyomi.data.download.DownloadManager = Injekt.get(),
+    private val translatedChapterRepository: tachiyomi.domain.translation.repository.TranslatedChapterRepository =
+        Injekt.get(),
+    private val quoteManager: eu.kanade.tachiyomi.ui.reader.quote.QuoteManager =
+        eu.kanade.tachiyomi.ui.reader.quote.QuoteManager(Injekt.get<android.app.Application>()),
 ) : StateScreenModel<MigrateMangaScreenModel.State>(State()) {
 
     private val _events: Channel<MigrationMangaEvent> = Channel()
@@ -139,8 +144,31 @@ class MigrateMangaScreenModel(
                 val migratedIds = mutableListOf<Long>()
                 for ((manga, newUrl) in quickMigrateTargets(selectedManga, targetFavoriteUrls)) {
                     try {
+                        val oldSource = sourceManager.getOrStub(manga.source)
+                        val newSource = sourceManager.getOrStub(targetSourceId)
                         updateManga.await(MangaUpdate(id = manga.id, source = targetSourceId, url = newUrl))
                         migratedIds.add(manga.id)
+                        // Downloads and translations are keyed by source, so relocate them to the new
+                        // source or they'd be orphaned. Only preserves data for same-URL migrations
+                        // (e.g. JS->KT); different-site moves change chapter URLs and won't line up.
+                        runCatching { downloadManager.moveMangaToNewSource(manga, oldSource, newSource) }
+                            .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" } }
+                        runCatching {
+                            translatedChapterRepository.moveNovel(
+                                oldSource.toString(),
+                                manga.title,
+                                newSource.toString(),
+                                manga.title,
+                            )
+                        }.onFailure { logcat(LogPriority.ERROR, it) { "Failed to move translations on quick migrate" } }
+                        runCatching {
+                            quoteManager.moveNovel(
+                                oldSource.toString(),
+                                manga.title,
+                                newSource.toString(),
+                                manga.title,
+                            )
+                        }.onFailure { logcat(LogPriority.ERROR, it) { "Failed to move quotes on quick migrate" } }
                     } catch (_: Exception) {
                         // Skip entries that fail to update; the rest still migrate.
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1038,8 +1038,10 @@ class LibraryScreenModel(
 
             if (deleteTranslations) {
                 mangas.forEach { manga ->
-                    val chapters = getChaptersByMangaId.await(manga.id)
-                    translatedChapterRepository.deleteAllForChapters(chapters.map { it.id })
+                    translatedChapterRepository.deleteAllForManga(
+                        sourceManager.getOrStub(manga.source).toString(),
+                        manga.title,
+                    )
                 }
             }
 
@@ -1098,8 +1100,10 @@ class LibraryScreenModel(
 
                 if (deleteTranslations) {
                     mangas.forEach { manga ->
-                        val chapters = getChaptersByMangaId.await(manga.id)
-                        translatedChapterRepository.deleteAllForChapters(chapters.map { it.id })
+                        translatedChapterRepository.deleteAllForManga(
+                            sourceManager.getOrStub(manga.source).toString(),
+                            manga.title,
+                        )
                     }
                 }
 
@@ -1646,16 +1650,7 @@ class LibraryScreenModel(
                         var firstChapterNum = Double.MAX_VALUE
                         var lastChapterNum = Double.MIN_VALUE
 
-                        // Get translated chapter IDs for this manga if translation mode needs them
-                        val translatedChapterIds =
-                            @Suppress("ktlint:standard:max-line-length")
-                            if (options.translationMode !=
-                                tachiyomi.domain.translation.model.TranslationMode.ORIGINAL
-                            ) {
-                                translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
-                            } else {
-                                emptySet()
-                            }
+                        val exportSourceName = sourceManager.getOrStub(manga.source).toString()
 
                         for ((chapterIndex, chapter) in chapters.withIndex()) {
                             // Check if chapter is downloaded first
@@ -1667,8 +1662,29 @@ class LibraryScreenModel(
                                 manga.source,
                             )
 
-                            // Check if chapter has translation
-                            val hasTranslation = chapter.id in translatedChapterIds
+                            val chapterTranslations =
+                                if (options.translationMode !=
+                                    tachiyomi.domain.translation.model.TranslationMode.ORIGINAL
+                                ) {
+                                    try {
+                                        translatedChapterRepository.getAllTranslationsForChapter(
+                                            tachiyomi.domain.translation.model.TranslationLocator(
+                                                exportSourceName,
+                                                manga.title,
+                                                chapter.name,
+                                                chapter.url,
+                                            ),
+                                        )
+                                    } catch (e: Exception) {
+                                        logcat(LogPriority.WARN, e) {
+                                            "Failed to get translations for chapter: ${chapter.name}"
+                                        }
+                                        emptyList()
+                                    }
+                                } else {
+                                    emptyList()
+                                }
+                            val hasTranslation = chapterTranslations.isNotEmpty()
 
                             if (isDownloaded) hasDownloads = true
 
@@ -1679,22 +1695,8 @@ class LibraryScreenModel(
 
                             // Try to get translated content first if translation mode needs it
                             var content: String? = null
-                            @Suppress("ktlint:standard:max-line-length")
-                            if (options.translationMode != tachiyomi.domain.translation.model.TranslationMode.ORIGINAL &&
-                                hasTranslation
-                            ) {
-                                @Suppress("ktlint:standard:max-line-length")
-                                try {
-                                    @Suppress("ktlint:standard:max-line-length")
-                                    val translations = translatedChapterRepository.getAllTranslationsForChapter(
-                                        chapter.id,
-                                    )
-                                    content = translations.firstOrNull()?.translatedContent
-                                } catch (e: Exception) {
-                                    logcat(LogPriority.WARN, e) {
-                                        "Failed to get translation for chapter: ${chapter.name}"
-                                    }
-                                }
+                            if (hasTranslation) {
+                                content = chapterTranslations.firstOrNull()?.translatedContent
                             }
 
                             // Fall back to original content if no translation or not preferred

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1652,6 +1652,30 @@ class LibraryScreenModel(
 
                         val exportSourceName = sourceManager.getOrStub(manga.source).toString()
 
+                        // Resolve every chapter's translations in a single novel scan instead of one
+                        // directory scan per chapter (O(chapters) SAF walks on large novels).
+                        val translationsByChapterId =
+                            if (options.translationMode !=
+                                tachiyomi.domain.translation.model.TranslationMode.ORIGINAL
+                            ) {
+                                try {
+                                    translatedChapterRepository.getAllTranslationsForNovel(
+                                        exportSourceName,
+                                        manga.title,
+                                        chapters.map {
+                                            tachiyomi.domain.translation.model.ChapterRef(it.id, it.name, it.url)
+                                        },
+                                    )
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.WARN, e) {
+                                        "Failed to get translations for novel: ${manga.title}"
+                                    }
+                                    emptyMap()
+                                }
+                            } else {
+                                emptyMap()
+                            }
+
                         for ((chapterIndex, chapter) in chapters.withIndex()) {
                             // Check if chapter is downloaded first
                             val isDownloaded = downloadManager.isChapterDownloaded(
@@ -1662,28 +1686,7 @@ class LibraryScreenModel(
                                 manga.source,
                             )
 
-                            val chapterTranslations =
-                                if (options.translationMode !=
-                                    tachiyomi.domain.translation.model.TranslationMode.ORIGINAL
-                                ) {
-                                    try {
-                                        translatedChapterRepository.getAllTranslationsForChapter(
-                                            tachiyomi.domain.translation.model.TranslationLocator(
-                                                exportSourceName,
-                                                manga.title,
-                                                chapter.name,
-                                                chapter.url,
-                                            ),
-                                        )
-                                    } catch (e: Exception) {
-                                        logcat(LogPriority.WARN, e) {
-                                            "Failed to get translations for chapter: ${chapter.name}"
-                                        }
-                                        emptyList()
-                                    }
-                                } else {
-                                    emptyList()
-                                }
+                            val chapterTranslations = translationsByChapterId[chapter.id].orEmpty()
                             val hasTranslation = chapterTranslations.isNotEmpty()
 
                             if (isDownloaded) hasDownloads = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreenModel.kt
@@ -806,8 +806,10 @@ class DuplicateDetectionScreenModel(
 
             if (deleteTranslations) {
                 selectedManga.forEach { manga ->
-                    val chapters = getChaptersByMangaId.await(manga.id)
-                    translatedChapterRepository.deleteAllForChapters(chapters.map { it.id })
+                    translatedChapterRepository.deleteAllForManga(
+                        sourceManager.getOrStub(manga.source).toString(),
+                        manga.title,
+                    )
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -91,6 +91,7 @@ import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.storage.service.StorageManager
 import tachiyomi.domain.track.interactor.GetTracks
+import tachiyomi.domain.translation.model.ChapterRef
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
@@ -133,6 +134,7 @@ class MangaScreenModel(
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val storageManager: StorageManager = Injekt.get(),
     private val mangaRepository: MangaRepository = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get(),
     private val translatedChapterRepository: TranslatedChapterRepository = Injekt.get(),
     private val translationService: TranslationService = Injekt.get(),
@@ -201,11 +203,7 @@ class MangaScreenModel(
             ) { mangaAndChapters, _, _, _ -> mangaAndChapters }
                 .flowWithLifecycle(lifecycle)
                 .collectLatest { (manga, chapters) ->
-                    val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(
-                        chapters.map {
-                            it.id
-                        },
-                    )
+                    val translatedChapterIds = translatedChapterIdsFor(manga, chapters)
                     updateSuccessState {
                         it.copy(
                             manga = manga,
@@ -247,7 +245,7 @@ class MangaScreenModel(
 
             val manga = mangaDeferred.await()
             val chapters = chaptersDeferred.await()
-            val translatedChapterIds = translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
+            val translatedChapterIds = translatedChapterIdsFor(manga, chapters)
             val chapterListItems = chapters.toChapterListItems(manga, translatedChapterIds)
 
             if (!manga.favorite) {
@@ -258,7 +256,7 @@ class MangaScreenModel(
             val needRefreshChapter = chapterListItems.isEmpty()
 
             // Show what we have earlier
-            val source = Injekt.get<SourceManager>().getOrStub(manga.source)
+            val source = sourceManager.getOrStub(manga.source)
             mutableState.update {
                 State.Success(
                     manga = manga,
@@ -1362,10 +1360,23 @@ class MangaScreenModel(
         }
     }
 
+    private suspend fun translatedChapterIdsFor(manga: Manga, chapters: List<Chapter>): Set<Long> =
+        translatedChapterRepository.filterTranslatedChapters(
+            sourceName = sourceManager.getOrStub(manga.source).toString(),
+            novelTitle = manga.title,
+            targetLanguage = translationService.getLastTargetLanguage(),
+            chapters = chapters.map { ChapterRef(it.id, it.name, it.url) },
+        )
+
     fun deleteTranslations(chapters: List<Chapter>) {
+        val manga = successState?.manga ?: return
         screenModelScope.launchNonCancellable {
             val chapterIds = chapters.map { it.id }.toSet()
-            translatedChapterRepository.deleteAllForChapters(chapterIds)
+            translatedChapterRepository.deleteAllForChapters(
+                sourceName = sourceManager.getOrStub(manga.source).toString(),
+                novelTitle = manga.title,
+                chapters = chapters.map { ChapterRef(it.id, it.name, it.url) },
+            )
             // Update the UI to reflect that these chapters no longer have translations
             updateSuccessState { state ->
                 state.copy(
@@ -1585,11 +1596,7 @@ class MangaScreenModel(
             val chaptersToTranslate = if (forceRetranslate) {
                 downloadedChapters
             } else {
-                val translatedIds = translatedChapterRepository.getTranslatedChapterIds(
-                    downloadedChapters.map {
-                        it.id
-                    },
-                )
+                val translatedIds = translatedChapterIdsFor(manga, downloadedChapters)
                 downloadedChapters.filter { it.id !in translatedIds }
             }
 
@@ -1632,7 +1639,7 @@ class MangaScreenModel(
             val chaptersToTranslate = if (forceRetranslate) {
                 chapters
             } else {
-                val translatedIds = translatedChapterRepository.getTranslatedChapterIds(chapters.map { it.id })
+                val translatedIds = translatedChapterIdsFor(manga, chapters)
                 chapters.filter { it.id !in translatedIds }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -622,19 +622,24 @@ class MangaScreenModel(
         screenModelScope.launchIO {
             val current = mangaRepository.getMangaByIdOrNull(mangaId)
             val oldTitle = current?.title
-            updateManga.awaitUpdateTitle(mangaId, newMainTitle)
-            updateManga.awaitUpdateAlternativeTitles(mangaId, updatedAltTitles)
-            getLibraryManga.applyMangaDetailUpdate(mangaId) {
-                it.copy(title = newMainTitle, alternativeTitles = updatedAltTitles)
-            }
-            // Quotes/translations are stored under directories keyed on the title, so move them
-            // to follow the rename or they'd be orphaned under the old title.
+            // Downloads/quotes/translations all live under directories keyed on the title. Relocate
+            // them BEFORE committing the new title to the DB so a failure can't leave the DB pointing
+            // at a title with no files behind it (the same ordering the source-migration path uses).
+            // Each move is best-effort like DownloadManager.renameManga and is serialized against
+            // concurrent writes by the per-novel lock inside the quote/translation repositories.
             if (current != null && oldTitle != null && oldTitle != newMainTitle) {
                 val sourceName = sourceManager.getOrStub(current.source).toString()
+                runCatching { downloadManager.renameManga(current, newMainTitle) }
+                    .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move downloads on title swap" } }
                 runCatching { quoteManager.renameNovel(sourceName, oldTitle, newMainTitle) }
                     .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move quotes on title swap" } }
                 runCatching { translatedChapterRepository.renameNovel(sourceName, oldTitle, newMainTitle) }
                     .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move translations on title swap" } }
+            }
+            updateManga.awaitUpdateTitle(mangaId, newMainTitle)
+            updateManga.awaitUpdateAlternativeTitles(mangaId, updatedAltTitles)
+            getLibraryManga.applyMangaDetailUpdate(mangaId) {
+                it.copy(title = newMainTitle, alternativeTitles = updatedAltTitles)
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -41,6 +41,7 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.translation.TranslationJob
 import eu.kanade.tachiyomi.data.translation.TranslationService
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.ui.reader.quote.QuoteManager
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
@@ -150,6 +151,8 @@ class MangaScreenModel(
 
     val source: Source?
         get() = successState?.source
+
+    private val quoteManager by lazy { QuoteManager(Injekt.get<android.app.Application>()) }
 
     private val isFavorited: Boolean
         get() = manga?.favorite ?: false
@@ -617,10 +620,21 @@ class MangaScreenModel(
      */
     fun swapMainTitle(newMainTitle: String, updatedAltTitles: List<String>) {
         screenModelScope.launchIO {
+            val current = mangaRepository.getMangaByIdOrNull(mangaId)
+            val oldTitle = current?.title
             updateManga.awaitUpdateTitle(mangaId, newMainTitle)
             updateManga.awaitUpdateAlternativeTitles(mangaId, updatedAltTitles)
             getLibraryManga.applyMangaDetailUpdate(mangaId) {
                 it.copy(title = newMainTitle, alternativeTitles = updatedAltTitles)
+            }
+            // Quotes/translations are stored under directories keyed on the title, so move them
+            // to follow the rename or they'd be orphaned under the old title.
+            if (current != null && oldTitle != null && oldTitle != newMainTitle) {
+                val sourceName = sourceManager.getOrStub(current.source).toString()
+                runCatching { quoteManager.renameNovel(sourceName, oldTitle, newMainTitle) }
+                    .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move quotes on title swap" } }
+                runCatching { translatedChapterRepository.renameNovel(sourceName, oldTitle, newMainTitle) }
+                    .onFailure { logcat(LogPriority.ERROR, it) { "Failed to move translations on title swap" } }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1738,6 +1738,11 @@ class ReaderActivity : BaseActivity() {
             is NovelWebViewViewer -> viewer.pendingSelectedText ?: viewer.getSelectedText()
             else -> null
         }
+        val paragraphIndex = when (val viewer = viewModel.state.value.viewer) {
+            is NovelViewer -> viewer.getSelectedParagraphIndex()
+            is NovelWebViewViewer -> viewer.pendingParagraphIndex
+            else -> null
+        }
         val chapterName = when (val viewer = viewModel.state.value.viewer) {
             is NovelViewer -> viewer.getCurrentChapterName()
             is NovelWebViewViewer -> viewer.getCurrentChapterName()
@@ -1745,11 +1750,15 @@ class ReaderActivity : BaseActivity() {
         }
 
         if (selectedText != null && chapterName != null) {
-            viewModel.saveQuote(selectedText, chapterName)
+            viewModel.saveQuote(selectedText, chapterName, paragraphIndex)
             // Clear selection after adding quote
             when (val viewer = viewModel.state.value.viewer) {
                 is NovelViewer -> viewer.clearTextSelection()
-                is NovelWebViewViewer -> viewer.clearTextSelection()
+                is NovelWebViewViewer -> {
+                    viewer.clearTextSelection()
+                    viewer.pendingSelectedText = null
+                    viewer.pendingParagraphIndex = null
+                }
             }
             toast("Quote saved!")
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -545,6 +545,7 @@ class ReaderActivity : BaseActivity() {
         if (showQuotesState.value) {
             QuotesSheet(
                 quotes = quotesState.value,
+                novelTitle = state.manga?.title.orEmpty(),
                 onDismiss = {
                     showQuotesSheet = false
                 },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -97,6 +97,7 @@ import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.source.local.isLocal
 import tachiyomi.source.local.isLocalNovel
@@ -592,10 +593,15 @@ class ReaderViewModel @JvmOverloads constructor(
             translationPreferences.translationEnabled().get() &&
             translationPreferences.smartAutoTranslate().get()
         ) {
-            val chapterId = chapter.chapter.id ?: return
+            val locator = TranslationLocator(
+                sourceName = sourceManager.getOrStub(currentManga.source).toString(),
+                novelTitle = currentManga.title,
+                chapterName = chapter.chapter.name,
+                chapterUrl = chapter.chapter.url,
+            )
             viewModelScope.launchIO {
                 // Already cached for this chapter+lang: the viewer serves it, no API call.
-                if (translationService.hasTranslation(chapterId)) return@launchIO
+                if (translationService.hasTranslation(locator)) return@launchIO
                 translationService.enqueue(
                     manga = currentManga,
                     chapter = chapter.chapter.toDomainChapter()!!,
@@ -1155,7 +1161,25 @@ class ReaderViewModel @JvmOverloads constructor(
 
     /** Whether a cached translation exists for [chapterId] in the current target language. */
     suspend fun hasCachedTranslation(chapterId: Long): Boolean {
-        return translationService.hasTranslation(chapterId)
+        val locator = buildTranslationLocator(chapterId) ?: return false
+        return translationService.hasTranslation(locator)
+    }
+
+    /**
+     * Build a portable [TranslationLocator] for [chapterId] (or the current chapter when null),
+     * resolving the chapter from the loaded list plus the current manga and source.
+     */
+    private fun buildTranslationLocator(chapterId: Long?): TranslationLocator? {
+        val currentManga = manga ?: return null
+        val chapter = chapterId?.let { id -> chapterList.firstOrNull { it.chapter.id == id }?.chapter }
+            ?: getCurrentChapter()?.chapter
+            ?: return null
+        return TranslationLocator(
+            sourceName = sourceManager.getOrStub(currentManga.source).toString(),
+            novelTitle = currentManga.title,
+            chapterName = chapter.name,
+            chapterUrl = chapter.url,
+        )
     }
 
     /**
@@ -1181,8 +1205,7 @@ class ReaderViewModel @JvmOverloads constructor(
         }
         return translationService.translateChapterContent(
             content = content,
-            chapterId = chapterId,
-            mangaId = mangaId,
+            locator = buildTranslationLocator(chapterId),
         )
     }
 
@@ -1685,36 +1708,43 @@ class ReaderViewModel @JvmOverloads constructor(
     }
 
     // Quotes functionality
+    private fun quoteSourceName(): String? = getSource()?.toString()
+
     fun getQuotes(): List<Quote> {
         val manga = manga ?: return emptyList()
-        return quoteManager.getQuotes(manga.id)
+        val sourceName = quoteSourceName() ?: return emptyList()
+        return quoteManager.getQuotes(sourceName, manga.title)
     }
 
-    fun saveQuote(text: String, chapterName: String) {
+    fun saveQuote(text: String, chapterName: String, paragraphIndex: Int? = null) {
         val manga = manga ?: return
-        val chapter = getCurrentChapter()?.chapter ?: return
+        val sourceName = quoteSourceName() ?: return
         val quote = Quote(
             novelName = manga.title,
             chapterName = chapterName,
             content = text,
             timestamp = System.currentTimeMillis(),
+            paragraphIndex = paragraphIndex,
         )
-        quoteManager.addQuote(manga.id, quote)
+        quoteManager.addQuote(sourceName, manga.title, quote)
     }
 
     fun deleteQuote(quote: Quote) {
         val manga = manga ?: return
-        quoteManager.removeQuote(manga.id, quote.id)
+        val sourceName = quoteSourceName() ?: return
+        quoteManager.removeQuote(sourceName, manga.title, quote.id)
     }
 
     fun updateQuote(quote: Quote) {
         val manga = manga ?: return
-        quoteManager.updateQuote(manga.id, quote)
+        val sourceName = quoteSourceName() ?: return
+        quoteManager.updateQuote(sourceName, manga.title, quote)
     }
 
     fun reorderQuotes(quotes: List<Quote>) {
         val manga = manga ?: return
-        quoteManager.reorderQuotes(manga.id, quotes)
+        val sourceName = quoteSourceName() ?: return
+        quoteManager.reorderQuotes(sourceName, manga.title, quotes)
     }
 
     sealed interface Dialog {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1719,8 +1719,11 @@ class ReaderViewModel @JvmOverloads constructor(
     fun saveQuote(text: String, chapterName: String, paragraphIndex: Int? = null) {
         val manga = manga ?: return
         val sourceName = quoteSourceName() ?: return
+        // A manually added quote arrives with no chapter label; anchor it to the open chapter so the
+        // list doesn't render a blank line.
+        val resolvedChapterName = chapterName.ifBlank { getCurrentChapter()?.chapter?.name.orEmpty() }
         val quote = Quote(
-            chapterName = chapterName,
+            chapterName = resolvedChapterName,
             content = text,
             timestamp = System.currentTimeMillis(),
             paragraphIndex = paragraphIndex,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1720,7 +1720,6 @@ class ReaderViewModel @JvmOverloads constructor(
         val manga = manga ?: return
         val sourceName = quoteSourceName() ?: return
         val quote = Quote(
-            novelName = manga.title,
             chapterName = chapterName,
             content = text,
             timestamp = System.currentTimeMillis(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/Quote.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/Quote.kt
@@ -13,16 +13,24 @@ data class Quote(
     val chapterName: String,
     val content: String,
     val timestamp: Long = System.currentTimeMillis(),
+    /** 0-based index of the paragraph the selection starts in, or null if unknown. */
+    val paragraphIndex: Int? = null,
 ) {
     companion object {
         /**
          * Create a new quote with the given parameters
          */
-        fun create(novelName: String, chapterName: String, content: String): Quote {
+        fun create(
+            novelName: String,
+            chapterName: String,
+            content: String,
+            paragraphIndex: Int? = null,
+        ): Quote {
             return Quote(
                 novelName = novelName,
                 chapterName = chapterName,
                 content = content.trim(),
+                paragraphIndex = paragraphIndex,
             )
         }
     }
@@ -33,6 +41,5 @@ data class Quote(
  */
 @Serializable
 data class NovelQuotes(
-    val novelId: Long,
     val quotes: List<Quote> = emptyList(),
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/Quote.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/Quote.kt
@@ -9,7 +9,6 @@ import java.util.UUID
 @Serializable
 data class Quote(
     val id: String = UUID.randomUUID().toString(),
-    val novelName: String,
     val chapterName: String,
     val content: String,
     val timestamp: Long = System.currentTimeMillis(),
@@ -21,13 +20,11 @@ data class Quote(
          * Create a new quote with the given parameters
          */
         fun create(
-            novelName: String,
             chapterName: String,
             content: String,
             paragraphIndex: Int? = null,
         ): Quote {
             return Quote(
-                novelName = novelName,
                 chapterName = chapterName,
                 content = content.trim(),
                 paragraphIndex = paragraphIndex,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -11,6 +11,7 @@ import tachiyomi.domain.storage.service.StorageManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Manager for handling quote storage and retrieval.
@@ -32,6 +33,15 @@ class QuoteManager(private val context: Context) {
 
     private val quotesDir: UniFile? by lazy {
         storageManager.getQuotesDirectory()
+    }
+
+    // A fresh QuoteManager is handed out per Context access, so the write lock has to be
+    // process-wide, not per-instance. Serialize load-modify-save mutators on a per-novel monitor
+    // so concurrent add/remove/update/rename can't lose each other's writes.
+    private fun <T> withNovelLock(sourceName: String, novelTitle: String, block: () -> T): T {
+        val key = "${getSourceDirName(sourceName)}/${getNovelFileName(novelTitle)}"
+        val lock = novelLocks.computeIfAbsent(key) { Any() }
+        return synchronized(lock) { block() }
     }
 
     private fun getSourceDirName(sourceName: String): String =
@@ -131,7 +141,7 @@ class QuoteManager(private val context: Context) {
     /**
      * Add a new quote for a novel
      */
-    fun addQuote(sourceName: String, novelTitle: String, quote: Quote) {
+    fun addQuote(sourceName: String, novelTitle: String, quote: Quote) = withNovelLock(sourceName, novelTitle) {
         val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         existingQuotes.add(quote)
         saveQuotes(sourceName, novelTitle, existingQuotes)
@@ -140,7 +150,7 @@ class QuoteManager(private val context: Context) {
     /**
      * Remove a quote by ID
      */
-    fun removeQuote(sourceName: String, novelTitle: String, quoteId: String) {
+    fun removeQuote(sourceName: String, novelTitle: String, quoteId: String) = withNovelLock(sourceName, novelTitle) {
         val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         existingQuotes.removeAll { it.id == quoteId }
         saveQuotes(sourceName, novelTitle, existingQuotes)
@@ -149,7 +159,11 @@ class QuoteManager(private val context: Context) {
     /**
      * Update an existing quote
      */
-    fun updateQuote(sourceName: String, novelTitle: String, updatedQuote: Quote) {
+    fun updateQuote(
+        sourceName: String,
+        novelTitle: String,
+        updatedQuote: Quote,
+    ) = withNovelLock(sourceName, novelTitle) {
         val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         val index = existingQuotes.indexOfFirst { it.id == updatedQuote.id }
         if (index >= 0) {
@@ -168,11 +182,12 @@ class QuoteManager(private val context: Context) {
     /**
      * Clear all quotes for a novel
      */
-    fun clearQuotes(sourceName: String, novelTitle: String) {
+    fun clearQuotes(sourceName: String, novelTitle: String) = withNovelLock(sourceName, novelTitle) {
         val file = getQuotesFile(sourceName, novelTitle)
         if (file?.exists() == true) {
             file.delete()
         }
+        Unit
     }
 
     /**
@@ -185,7 +200,11 @@ class QuoteManager(private val context: Context) {
     /**
      * Reorder quotes for a novel
      */
-    fun reorderQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>) {
+    fun reorderQuotes(
+        sourceName: String,
+        novelTitle: String,
+        quotes: List<Quote>,
+    ) = withNovelLock(sourceName, novelTitle) {
         saveQuotes(sourceName, novelTitle, quotes)
         logcat(LogPriority.DEBUG) { "Quotes reordered for $sourceName/$novelTitle: ${quotes.size} quotes" }
     }
@@ -231,8 +250,15 @@ class QuoteManager(private val context: Context) {
             true
         } catch (e: IOException) {
             logcat(LogPriority.ERROR) { "Failed to move quotes for $oldTitle: ${e.message}" }
+            // A partially written destination is worse than none; loadQuotes would parse a
+            // truncated file. Drop it so the source remains the single source of truth.
+            newDir.findFile(newName)?.takeIf { it.exists() }?.delete()
             false
         }
+    }
+
+    companion object {
+        private val novelLocks = ConcurrentHashMap<String, Any>()
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.reader.quote
 
 import android.content.Context
 import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.util.storage.DiskUtil
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
@@ -12,15 +13,18 @@ import uy.kohesive.injekt.api.get
 import java.io.IOException
 
 /**
- * Manager for handling quote storage and retrieval
+ * Manager for handling quote storage and retrieval.
+ *
+ * Quotes are stored in a portable, human-readable layout that mirrors downloads:
+ *   {quotes}/{source name}/{novel title}.json
+ * so they survive re-imports and can be moved between installs.
  */
 class QuoteManager(private val context: Context) {
 
-    companion object {
-        private const val QUOTES_DIR = "quotes"
+    private val jsonFormat = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
     }
-
-    private val jsonFormat = Json { prettyPrint = true }
 
     private val storageManager: StorageManager by lazy {
         Injekt.get<StorageManager>()
@@ -30,59 +34,71 @@ class QuoteManager(private val context: Context) {
         storageManager.getQuotesDirectory()
     }
 
-    /**
-     * Get the file for storing quotes for a specific novel
-     */
-    private fun getQuotesFile(novelId: Long): UniFile? {
-        return quotesDir?.findFile("novel_$novelId.json")
+    private fun getSourceDirName(sourceName: String): String = DiskUtil.buildValidFilename(sourceName)
+
+    private fun getNovelFileName(novelTitle: String): String = "${DiskUtil.buildValidFilename(novelTitle)}.json"
+
+    private fun findSourceDir(sourceName: String): UniFile? {
+        return quotesDir?.findFile(getSourceDirName(sourceName))
+    }
+
+    private fun getOrCreateSourceDir(sourceName: String): UniFile? {
+        val name = getSourceDirName(sourceName)
+        val dir = quotesDir ?: return null
+        return dir.findFile(name)?.takeIf { it.isDirectory } ?: dir.createDirectory(name)
+    }
+
+    private fun getQuotesFile(sourceName: String, novelTitle: String): UniFile? {
+        return findSourceDir(sourceName)?.findFile(getNovelFileName(novelTitle))
     }
 
     /**
      * Save quotes for a novel
      */
-    fun saveQuotes(novelId: Long, quotes: List<Quote>) {
+    fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>) {
         try {
-            val novelQuotes = NovelQuotes(novelId, quotes)
-            val json = jsonFormat.encodeToString(novelQuotes)
+            val fileName = getNovelFileName(novelTitle)
 
             // Delete existing file first to avoid duplicate files
-            val existingFile = getQuotesFile(novelId)
+            val existingFile = getQuotesFile(sourceName, novelTitle)
             if (existingFile?.exists() == true) {
                 existingFile.delete()
             }
 
-            val file = quotesDir?.createFile("novel_$novelId.json") ?: return
+            if (quotes.isEmpty()) return
+
+            val json = jsonFormat.encodeToString(NovelQuotes(quotes))
+            val file = getOrCreateSourceDir(sourceName)?.createFile(fileName) ?: return
             file.openOutputStream().use { outputStream ->
                 outputStream.write(json.toByteArray())
             }
-            logcat(LogPriority.DEBUG) { "Quotes saved for novel $novelId: ${quotes.size} quotes" }
+            logcat(LogPriority.DEBUG) { "Quotes saved for $sourceName/$novelTitle: ${quotes.size} quotes" }
         } catch (e: IOException) {
-            logcat(LogPriority.ERROR) { "Failed to save quotes for novel $novelId: ${e.message}" }
+            logcat(LogPriority.ERROR) { "Failed to save quotes for $sourceName/$novelTitle: ${e.message}" }
         } catch (e: SerializationException) {
-            logcat(LogPriority.ERROR) { "Failed to serialize quotes for novel $novelId: ${e.message}" }
+            logcat(LogPriority.ERROR) { "Failed to serialize quotes for $sourceName/$novelTitle: ${e.message}" }
         }
     }
 
     /**
      * Load quotes for a novel
      */
-    fun loadQuotes(novelId: Long): List<Quote> {
+    fun loadQuotes(sourceName: String, novelTitle: String): List<Quote> {
         return try {
-            val file = getQuotesFile(novelId)
+            val file = getQuotesFile(sourceName, novelTitle)
             if (file == null || !file.exists()) {
                 emptyList()
             } else {
                 val json = file.openInputStream().use { inputStream ->
                     String(inputStream.readBytes())
                 }
-                val novelQuotes = jsonFormat.decodeFromString<NovelQuotes>(json)
-                novelQuotes.quotes
+                jsonFormat.decodeFromString<NovelQuotes>(json).quotes
             }
         } catch (e: IOException) {
-            logcat(LogPriority.ERROR) { "Failed to load quotes for novel $novelId: ${e.message}" }
+            logcat(LogPriority.ERROR) { "Failed to load quotes for $sourceName/$novelTitle: ${e.message}" }
             emptyList()
         } catch (e: SerializationException) {
-            logcat(LogPriority.ERROR) { "Failed to deserialize quotes for novel $novelId: ${e.message}" }
+            logcat(LogPriority.ERROR) { "Failed to deserialize quotes for $sourceName/$novelTitle: ${e.message}" }
             emptyList()
         }
     }
@@ -90,45 +106,45 @@ class QuoteManager(private val context: Context) {
     /**
      * Add a new quote for a novel
      */
-    fun addQuote(novelId: Long, quote: Quote) {
-        val existingQuotes = loadQuotes(novelId).toMutableList()
+    fun addQuote(sourceName: String, novelTitle: String, quote: Quote) {
+        val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         existingQuotes.add(quote)
-        saveQuotes(novelId, existingQuotes)
+        saveQuotes(sourceName, novelTitle, existingQuotes)
     }
 
     /**
      * Remove a quote by ID
      */
-    fun removeQuote(novelId: Long, quoteId: String) {
-        val existingQuotes = loadQuotes(novelId).toMutableList()
+    fun removeQuote(sourceName: String, novelTitle: String, quoteId: String) {
+        val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         existingQuotes.removeAll { it.id == quoteId }
-        saveQuotes(novelId, existingQuotes)
+        saveQuotes(sourceName, novelTitle, existingQuotes)
     }
 
     /**
      * Update an existing quote
      */
-    fun updateQuote(novelId: Long, updatedQuote: Quote) {
-        val existingQuotes = loadQuotes(novelId).toMutableList()
+    fun updateQuote(sourceName: String, novelTitle: String, updatedQuote: Quote) {
+        val existingQuotes = loadQuotes(sourceName, novelTitle).toMutableList()
         val index = existingQuotes.indexOfFirst { it.id == updatedQuote.id }
         if (index >= 0) {
             existingQuotes[index] = updatedQuote
-            saveQuotes(novelId, existingQuotes)
+            saveQuotes(sourceName, novelTitle, existingQuotes)
         }
     }
 
     /**
      * Get all quotes for a novel, preserving the stored order
      */
-    fun getQuotes(novelId: Long): List<Quote> {
-        return loadQuotes(novelId)
+    fun getQuotes(sourceName: String, novelTitle: String): List<Quote> {
+        return loadQuotes(sourceName, novelTitle)
     }
 
     /**
      * Clear all quotes for a novel
      */
-    fun clearQuotes(novelId: Long) {
-        val file = getQuotesFile(novelId)
+    fun clearQuotes(sourceName: String, novelTitle: String) {
+        val file = getQuotesFile(sourceName, novelTitle)
         if (file?.exists() == true) {
             file.delete()
         }
@@ -137,16 +153,16 @@ class QuoteManager(private val context: Context) {
     /**
      * Get quote count for a novel
      */
-    fun getQuoteCount(novelId: Long): Int {
-        return loadQuotes(novelId).size
+    fun getQuoteCount(sourceName: String, novelTitle: String): Int {
+        return loadQuotes(sourceName, novelTitle).size
     }
 
     /**
      * Reorder quotes for a novel
      */
-    fun reorderQuotes(novelId: Long, quotes: List<Quote>) {
-        saveQuotes(novelId, quotes)
-        logcat(LogPriority.DEBUG) { "Quotes reordered for novel $novelId: ${quotes.size} quotes" }
+    fun reorderQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>) {
+        saveQuotes(sourceName, novelTitle, quotes)
+        logcat(LogPriority.DEBUG) { "Quotes reordered for $sourceName/$novelTitle: ${quotes.size} quotes" }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -55,28 +55,40 @@ class QuoteManager(private val context: Context) {
     /**
      * Save quotes for a novel
      */
-    fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>) {
+    fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>): Boolean {
         try {
             val fileName = getNovelFileName(novelTitle)
 
-            // Delete existing file first to avoid duplicate files
-            val existingFile = getQuotesFile(sourceName, novelTitle)
-            if (existingFile?.exists() == true) {
-                existingFile.delete()
+            if (quotes.isEmpty()) {
+                getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
+                return true
             }
-
-            if (quotes.isEmpty()) return
 
             val json = jsonFormat.encodeToString(NovelQuotes(quotes))
-            val file = getOrCreateSourceDir(sourceName)?.createFile(fileName) ?: return
-            file.openOutputStream().use { outputStream ->
+            val dir = getOrCreateSourceDir(sourceName) ?: return false
+
+            // Write to a temp file then swap it in, so a crash mid-write or a
+            // concurrent save can't corrupt or duplicate the destination.
+            val tmpName = "$fileName.tmp"
+            dir.findFile(tmpName)?.takeIf { it.exists() }?.delete()
+            val tmp = dir.createFile(tmpName) ?: return false
+            tmp.openOutputStream().use { outputStream ->
                 outputStream.write(json.toByteArray())
             }
+            getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
+            if (!tmp.renameTo(fileName)) {
+                tmp.delete()
+                logcat(LogPriority.ERROR) { "Failed to finalize quotes file for $sourceName/$novelTitle" }
+                return false
+            }
             logcat(LogPriority.DEBUG) { "Quotes saved for $sourceName/$novelTitle: ${quotes.size} quotes" }
+            return true
         } catch (e: IOException) {
             logcat(LogPriority.ERROR) { "Failed to save quotes for $sourceName/$novelTitle: ${e.message}" }
+            return false
         } catch (e: SerializationException) {
             logcat(LogPriority.ERROR) { "Failed to serialize quotes for $sourceName/$novelTitle: ${e.message}" }
+            return false
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -34,9 +34,11 @@ class QuoteManager(private val context: Context) {
         storageManager.getQuotesDirectory()
     }
 
-    private fun getSourceDirName(sourceName: String): String = DiskUtil.buildValidFilename(sourceName)
+    private fun getSourceDirName(sourceName: String): String =
+        DiskUtil.buildValidFilename(sourceName).ifEmpty { "source" }
 
-    private fun getNovelFileName(novelTitle: String): String = "${DiskUtil.buildValidFilename(novelTitle)}.json"
+    private fun getNovelFileName(novelTitle: String): String =
+        "${DiskUtil.buildValidFilename(novelTitle).ifEmpty { "novel" }}.json"
 
     private fun findSourceDir(sourceName: String): UniFile? {
         return quotesDir?.findFile(getSourceDirName(sourceName))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -82,6 +82,7 @@ class QuoteManager(private val context: Context) {
 
             if (quotes.isEmpty()) {
                 getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
+                deletePendingTmp(sourceName, novelTitle)
                 return true
             }
 
@@ -187,7 +188,13 @@ class QuoteManager(private val context: Context) {
         if (file?.exists() == true) {
             file.delete()
         }
+        deletePendingTmp(sourceName, novelTitle)
         Unit
+    }
+
+    private fun deletePendingTmp(sourceName: String, novelTitle: String) {
+        val dir = findSourceDir(sourceName) ?: return
+        dir.findFile("${getNovelFileName(novelTitle)}.tmp")?.takeIf { it.exists() }?.delete()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -280,7 +280,9 @@ class QuoteManager(private val context: Context) {
             val newDir = getOrCreateSourceDir(newSourceName) ?: return@withNovelLocks false
             val newName = getNovelFileName(newTitle)
             if (newDir.findFile(newName)?.exists() == true) {
-                logcat(LogPriority.WARN) { "Quotes already exist at destination for $newSourceName/$newTitle; not moving" }
+                logcat(LogPriority.WARN) {
+                    "Quotes already exist at destination for $newSourceName/$newTitle; not moving"
+                }
                 return@withNovelLocks false
             }
             try {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -38,10 +38,24 @@ class QuoteManager(private val context: Context) {
     // A fresh QuoteManager is handed out per Context access, so the write lock has to be
     // process-wide, not per-instance. Serialize load-modify-save mutators on a per-novel monitor
     // so concurrent add/remove/update/rename can't lose each other's writes.
+    private fun novelLockKey(sourceName: String, novelTitle: String): String =
+        "${getSourceDirName(sourceName)}/${getNovelFileName(novelTitle)}"
+
     private fun <T> withNovelLock(sourceName: String, novelTitle: String, block: () -> T): T {
-        val key = "${getSourceDirName(sourceName)}/${getNovelFileName(novelTitle)}"
-        val lock = novelLocks.computeIfAbsent(key) { Any() }
+        val lock = novelLocks.computeIfAbsent(novelLockKey(sourceName, novelTitle)) { Any() }
         return synchronized(lock) { block() }
+    }
+
+    // Locks every distinct key in sorted order so two concurrent calls that reference the same
+    // pair of novels (e.g. a move and its reverse) always acquire locks in the same order.
+    private fun <T> withNovelLocks(keys: List<Pair<String, String>>, block: () -> T): T {
+        val lockKeys = keys.map { (s, t) -> novelLockKey(s, t) }.distinct().sorted()
+        fun lockNext(remaining: List<String>): T {
+            if (remaining.isEmpty()) return block()
+            val lock = novelLocks.computeIfAbsent(remaining.first()) { Any() }
+            return synchronized(lock) { lockNext(remaining.drop(1)) }
+        }
+        return lockNext(lockKeys)
     }
 
     private fun getSourceDirName(sourceName: String): String =
@@ -85,52 +99,58 @@ class QuoteManager(private val context: Context) {
     /**
      * Save quotes for a novel
      */
-    fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>): Boolean {
-        try {
-            val fileName = getNovelFileName(novelTitle)
+    fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>): Boolean =
+        withNovelLock(sourceName, novelTitle) {
+            try {
+                val fileName = getNovelFileName(novelTitle)
 
-            if (quotes.isEmpty()) {
+                if (quotes.isEmpty()) {
+                    getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
+                    deletePendingTmp(sourceName, novelTitle)
+                    return@withNovelLock true
+                }
+
+                val json = jsonFormat.encodeToString(NovelQuotes(quotes))
+                val dir = getOrCreateSourceDir(sourceName) ?: return@withNovelLock false
+
+                // Write to a temp file then swap it in, so a crash mid-write or a
+                // concurrent save can't corrupt or duplicate the destination.
+                val tmpName = "$fileName.tmp"
+                dir.findFile(tmpName)?.takeIf { it.exists() }?.delete()
+                val tmp = dir.createFile(tmpName) ?: return@withNovelLock false
+                tmp.openOutputStream().use { outputStream ->
+                    outputStream.write(json.toByteArray())
+                }
                 getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
-                deletePendingTmp(sourceName, novelTitle)
-                return true
+                if (!tmp.renameTo(fileName)) {
+                    // Leave the tmp in place; loadQuotes recovers it, so a failed rename
+                    // (or a crash before this point) doesn't lose the just-written data.
+                    logcat(LogPriority.ERROR) { "Failed to finalize quotes file for $sourceName/$novelTitle" }
+                    return@withNovelLock false
+                }
+                logcat(LogPriority.DEBUG) { "Quotes saved for $sourceName/$novelTitle: ${quotes.size} quotes" }
+                true
+            } catch (e: IOException) {
+                logcat(LogPriority.ERROR) { "Failed to save quotes for $sourceName/$novelTitle: ${e.message}" }
+                false
+            } catch (e: SerializationException) {
+                logcat(LogPriority.ERROR) { "Failed to serialize quotes for $sourceName/$novelTitle: ${e.message}" }
+                false
             }
-
-            val json = jsonFormat.encodeToString(NovelQuotes(quotes))
-            val dir = getOrCreateSourceDir(sourceName) ?: return false
-
-            // Write to a temp file then swap it in, so a crash mid-write or a
-            // concurrent save can't corrupt or duplicate the destination.
-            val tmpName = "$fileName.tmp"
-            dir.findFile(tmpName)?.takeIf { it.exists() }?.delete()
-            val tmp = dir.createFile(tmpName) ?: return false
-            tmp.openOutputStream().use { outputStream ->
-                outputStream.write(json.toByteArray())
-            }
-            getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
-            if (!tmp.renameTo(fileName)) {
-                // Leave the tmp in place; loadQuotes recovers it, so a failed rename
-                // (or a crash before this point) doesn't lose the just-written data.
-                logcat(LogPriority.ERROR) { "Failed to finalize quotes file for $sourceName/$novelTitle" }
-                return false
-            }
-            logcat(LogPriority.DEBUG) { "Quotes saved for $sourceName/$novelTitle: ${quotes.size} quotes" }
-            return true
-        } catch (e: IOException) {
-            logcat(LogPriority.ERROR) { "Failed to save quotes for $sourceName/$novelTitle: ${e.message}" }
-            return false
-        } catch (e: SerializationException) {
-            logcat(LogPriority.ERROR) { "Failed to serialize quotes for $sourceName/$novelTitle: ${e.message}" }
-            return false
         }
-    }
 
     /**
      * Load quotes for a novel
      */
     fun loadQuotes(sourceName: String, novelTitle: String): List<Quote> {
         return try {
-            val file = getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }
-                ?: recoverPendingQuotes(sourceName, novelTitle)
+            // Resolving (and possibly promoting a pending ".tmp" scratch) under the same lock
+            // saveQuotes uses for its own delete+rename finalize closes the race where a
+            // concurrent read could win the promotion and make the writer's own rename fail.
+            val file = withNovelLock(sourceName, novelTitle) {
+                getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }
+                    ?: recoverPendingQuotes(sourceName, novelTitle)
+            }
             if (file == null) {
                 emptyList()
             } else {
@@ -229,16 +249,18 @@ class QuoteManager(private val context: Context) {
      * Move a novel's quotes file when its title changes (quotes are keyed by title on disk).
      */
     fun renameNovel(sourceName: String, oldTitle: String, newTitle: String): Boolean =
-        withNovelLock(sourceName, oldTitle) {
-            val dir = findSourceDir(sourceName) ?: return@withNovelLock true
+        // Lock both the old and new keys so this can't race a concurrent add/update/remove
+        // targeting either the source or destination novel.
+        withNovelLocks(listOf(sourceName to oldTitle, sourceName to newTitle)) {
+            val dir = findSourceDir(sourceName) ?: return@withNovelLocks true
             val oldName = getNovelFileName(oldTitle)
             val newName = getNovelFileName(newTitle)
-            if (oldName == newName) return@withNovelLock true
-            val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return@withNovelLock true
+            if (oldName == newName) return@withNovelLocks true
+            val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return@withNovelLocks true
             // Don't clobber existing quotes at the destination; deny rather than overwrite.
             if (dir.findFile(newName)?.exists() == true) {
                 logcat(LogPriority.WARN) { "Quotes '$newName' already exists; not overwriting on rename" }
-                return@withNovelLock false
+                return@withNovelLocks false
             }
             file.renameTo(newName).also {
                 if (!it) logcat(LogPriority.ERROR) { "Failed to rename quotes $oldName -> $newName" }
@@ -253,16 +275,16 @@ class QuoteManager(private val context: Context) {
         if (getSourceDirName(oldSourceName) == getSourceDirName(newSourceName)) {
             return renameNovel(oldSourceName, oldTitle, newTitle)
         }
-        return withNovelLock(oldSourceName, oldTitle) {
-            val oldFile = getQuotesFile(oldSourceName, oldTitle)?.takeIf { it.exists() } ?: return@withNovelLock true
-            val newDir = getOrCreateSourceDir(newSourceName) ?: return@withNovelLock false
+        return withNovelLocks(listOf(oldSourceName to oldTitle, newSourceName to newTitle)) {
+            val oldFile = getQuotesFile(oldSourceName, oldTitle)?.takeIf { it.exists() } ?: return@withNovelLocks true
+            val newDir = getOrCreateSourceDir(newSourceName) ?: return@withNovelLocks false
             val newName = getNovelFileName(newTitle)
             if (newDir.findFile(newName)?.exists() == true) {
                 logcat(LogPriority.WARN) { "Quotes already exist at destination for $newSourceName/$newTitle; not moving" }
-                return@withNovelLock false
+                return@withNovelLocks false
             }
             try {
-                val dest = newDir.createFile(newName) ?: return@withNovelLock false
+                val dest = newDir.createFile(newName) ?: return@withNovelLocks false
                 oldFile.openInputStream().use { input -> dest.openOutputStream().use { input.copyTo(it) } }
                 oldFile.delete()
                 true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -199,9 +199,39 @@ class QuoteManager(private val context: Context) {
         val newName = getNovelFileName(newTitle)
         if (oldName == newName) return true
         val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return true
-        dir.findFile(newName)?.takeIf { it.exists() }?.delete()
+        // Don't clobber existing quotes at the destination; deny rather than overwrite.
+        if (dir.findFile(newName)?.exists() == true) {
+            logcat(LogPriority.WARN) { "Quotes '$newName' already exists; not overwriting on rename" }
+            return false
+        }
         return file.renameTo(newName).also {
             if (!it) logcat(LogPriority.ERROR) { "Failed to rename quotes $oldName -> $newName" }
+        }
+    }
+
+    /**
+     * Move a novel's quotes to a different source and/or title (e.g. on migration).
+     * Denies the move if a quotes file already exists at the destination.
+     */
+    fun moveNovel(oldSourceName: String, oldTitle: String, newSourceName: String, newTitle: String): Boolean {
+        if (getSourceDirName(oldSourceName) == getSourceDirName(newSourceName)) {
+            return renameNovel(oldSourceName, oldTitle, newTitle)
+        }
+        val oldFile = getQuotesFile(oldSourceName, oldTitle)?.takeIf { it.exists() } ?: return true
+        val newDir = getOrCreateSourceDir(newSourceName) ?: return false
+        val newName = getNovelFileName(newTitle)
+        if (newDir.findFile(newName)?.exists() == true) {
+            logcat(LogPriority.WARN) { "Quotes already exist at destination for $newSourceName/$newTitle; not moving" }
+            return false
+        }
+        return try {
+            val dest = newDir.createFile(newName) ?: return false
+            oldFile.openInputStream().use { input -> dest.openOutputStream().use { input.copyTo(it) } }
+            oldFile.delete()
+            true
+        } catch (e: IOException) {
+            logcat(LogPriority.ERROR) { "Failed to move quotes for $oldTitle: ${e.message}" }
+            false
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -70,6 +70,15 @@ class QuoteManager(private val context: Context) {
         val dir = findSourceDir(sourceName) ?: return null
         val fileName = getNovelFileName(novelTitle)
         val tmp = dir.findFile("$fileName.tmp")?.takeIf { it.exists() } ?: return null
+        // Only promote a scratch that parses cleanly; a crash mid-write can leave a truncated tmp
+        // that must not be promoted and served as a complete quote set.
+        val valid = runCatching {
+            tmp.openInputStream().use { jsonFormat.decodeFromString<NovelQuotes>(String(it.readBytes())) }
+        }.isSuccess
+        if (!valid) {
+            tmp.delete()
+            return null
+        }
         return if (tmp.renameTo(fileName)) dir.findFile(fileName)?.takeIf { it.exists() } else null
     }
 
@@ -219,21 +228,22 @@ class QuoteManager(private val context: Context) {
     /**
      * Move a novel's quotes file when its title changes (quotes are keyed by title on disk).
      */
-    fun renameNovel(sourceName: String, oldTitle: String, newTitle: String): Boolean {
-        val dir = findSourceDir(sourceName) ?: return true
-        val oldName = getNovelFileName(oldTitle)
-        val newName = getNovelFileName(newTitle)
-        if (oldName == newName) return true
-        val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return true
-        // Don't clobber existing quotes at the destination; deny rather than overwrite.
-        if (dir.findFile(newName)?.exists() == true) {
-            logcat(LogPriority.WARN) { "Quotes '$newName' already exists; not overwriting on rename" }
-            return false
+    fun renameNovel(sourceName: String, oldTitle: String, newTitle: String): Boolean =
+        withNovelLock(sourceName, oldTitle) {
+            val dir = findSourceDir(sourceName) ?: return@withNovelLock true
+            val oldName = getNovelFileName(oldTitle)
+            val newName = getNovelFileName(newTitle)
+            if (oldName == newName) return@withNovelLock true
+            val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return@withNovelLock true
+            // Don't clobber existing quotes at the destination; deny rather than overwrite.
+            if (dir.findFile(newName)?.exists() == true) {
+                logcat(LogPriority.WARN) { "Quotes '$newName' already exists; not overwriting on rename" }
+                return@withNovelLock false
+            }
+            file.renameTo(newName).also {
+                if (!it) logcat(LogPriority.ERROR) { "Failed to rename quotes $oldName -> $newName" }
+            }
         }
-        return file.renameTo(newName).also {
-            if (!it) logcat(LogPriority.ERROR) { "Failed to rename quotes $oldName -> $newName" }
-        }
-    }
 
     /**
      * Move a novel's quotes to a different source and/or title (e.g. on migration).
@@ -243,24 +253,26 @@ class QuoteManager(private val context: Context) {
         if (getSourceDirName(oldSourceName) == getSourceDirName(newSourceName)) {
             return renameNovel(oldSourceName, oldTitle, newTitle)
         }
-        val oldFile = getQuotesFile(oldSourceName, oldTitle)?.takeIf { it.exists() } ?: return true
-        val newDir = getOrCreateSourceDir(newSourceName) ?: return false
-        val newName = getNovelFileName(newTitle)
-        if (newDir.findFile(newName)?.exists() == true) {
-            logcat(LogPriority.WARN) { "Quotes already exist at destination for $newSourceName/$newTitle; not moving" }
-            return false
-        }
-        return try {
-            val dest = newDir.createFile(newName) ?: return false
-            oldFile.openInputStream().use { input -> dest.openOutputStream().use { input.copyTo(it) } }
-            oldFile.delete()
-            true
-        } catch (e: IOException) {
-            logcat(LogPriority.ERROR) { "Failed to move quotes for $oldTitle: ${e.message}" }
-            // A partially written destination is worse than none; loadQuotes would parse a
-            // truncated file. Drop it so the source remains the single source of truth.
-            newDir.findFile(newName)?.takeIf { it.exists() }?.delete()
-            false
+        return withNovelLock(oldSourceName, oldTitle) {
+            val oldFile = getQuotesFile(oldSourceName, oldTitle)?.takeIf { it.exists() } ?: return@withNovelLock true
+            val newDir = getOrCreateSourceDir(newSourceName) ?: return@withNovelLock false
+            val newName = getNovelFileName(newTitle)
+            if (newDir.findFile(newName)?.exists() == true) {
+                logcat(LogPriority.WARN) { "Quotes already exist at destination for $newSourceName/$newTitle; not moving" }
+                return@withNovelLock false
+            }
+            try {
+                val dest = newDir.createFile(newName) ?: return@withNovelLock false
+                oldFile.openInputStream().use { input -> dest.openOutputStream().use { input.copyTo(it) } }
+                oldFile.delete()
+                true
+            } catch (e: IOException) {
+                logcat(LogPriority.ERROR) { "Failed to move quotes for $oldTitle: ${e.message}" }
+                // A partially written destination is worse than none; loadQuotes would parse a
+                // truncated file. Drop it so the source remains the single source of truth.
+                newDir.findFile(newName)?.takeIf { it.exists() }?.delete()
+                false
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -54,6 +54,15 @@ class QuoteManager(private val context: Context) {
         return findSourceDir(sourceName)?.findFile(getNovelFileName(novelTitle))
     }
 
+    // If a save crashed after deleting the destination but before renaming its tmp in, the
+    // just-written data survives only as "<name>.json.tmp". Promote it so no committed save is lost.
+    private fun recoverPendingQuotes(sourceName: String, novelTitle: String): UniFile? {
+        val dir = findSourceDir(sourceName) ?: return null
+        val fileName = getNovelFileName(novelTitle)
+        val tmp = dir.findFile("$fileName.tmp")?.takeIf { it.exists() } ?: return null
+        return if (tmp.renameTo(fileName)) dir.findFile(fileName)?.takeIf { it.exists() } else null
+    }
+
     /**
      * Save quotes for a novel
      */
@@ -79,7 +88,8 @@ class QuoteManager(private val context: Context) {
             }
             getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }?.delete()
             if (!tmp.renameTo(fileName)) {
-                tmp.delete()
+                // Leave the tmp in place; loadQuotes recovers it, so a failed rename
+                // (or a crash before this point) doesn't lose the just-written data.
                 logcat(LogPriority.ERROR) { "Failed to finalize quotes file for $sourceName/$novelTitle" }
                 return false
             }
@@ -99,8 +109,9 @@ class QuoteManager(private val context: Context) {
      */
     fun loadQuotes(sourceName: String, novelTitle: String): List<Quote> {
         return try {
-            val file = getQuotesFile(sourceName, novelTitle)
-            if (file == null || !file.exists()) {
+            val file = getQuotesFile(sourceName, novelTitle)?.takeIf { it.exists() }
+                ?: recoverPendingQuotes(sourceName, novelTitle)
+            if (file == null) {
                 emptyList()
             } else {
                 val json = file.openInputStream().use { inputStream ->
@@ -177,6 +188,21 @@ class QuoteManager(private val context: Context) {
     fun reorderQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>) {
         saveQuotes(sourceName, novelTitle, quotes)
         logcat(LogPriority.DEBUG) { "Quotes reordered for $sourceName/$novelTitle: ${quotes.size} quotes" }
+    }
+
+    /**
+     * Move a novel's quotes file when its title changes (quotes are keyed by title on disk).
+     */
+    fun renameNovel(sourceName: String, oldTitle: String, newTitle: String): Boolean {
+        val dir = findSourceDir(sourceName) ?: return true
+        val oldName = getNovelFileName(oldTitle)
+        val newName = getNovelFileName(newTitle)
+        if (oldName == newName) return true
+        val file = dir.findFile(oldName)?.takeIf { it.exists() } ?: return true
+        dir.findFile(newName)?.takeIf { it.exists() }?.delete()
+        return file.renameTo(newName).also {
+            if (!it) logcat(LogPriority.ERROR) { "Failed to rename quotes $oldName -> $newName" }
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
@@ -81,6 +81,32 @@ internal class ChapterTextBlock(
         return view.text.subSequence(start, end).toString()
     }
 
+    /**
+     * 0-based index of the paragraph the current selection starts in, using the same
+     * single-\n split as TTS so quote paragraph indexes align with playback positions.
+     */
+    fun selectedParagraphIndex(): Int? {
+        val chunkIndex = chunkViews.indexOfFirst { it.hasSelection() }
+        if (chunkIndex < 0) return null
+        val start = chunkViews[chunkIndex].selectionStart
+        if (start < 0) return null
+        val text = fullText ?: return null
+        val absoluteOffset = (chunkStarts.getOrNull(chunkIndex) ?: 0) + start
+
+        val paragraphLines = text.split("\n").filter { it.isNotBlank() }
+        if (paragraphLines.isEmpty()) return null
+
+        var searchFrom = 0
+        var index = -1
+        for ((i, line) in paragraphLines.withIndex()) {
+            val idx = text.indexOf(line, searchFrom)
+            val offset = if (idx >= 0) idx else searchFrom
+            if (offset <= absoluteOffset) index = i else break
+            searchFrom = if (idx >= 0) idx + line.length else searchFrom
+        }
+        return index.takeIf { it >= 0 }
+    }
+
     fun clearSelections() {
         chunkViews.forEach { NovelTextRenderer.clearTextViewSelection(it) }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/ChapterTextBlock.kt
@@ -91,20 +91,17 @@ internal class ChapterTextBlock(
         val start = chunkViews[chunkIndex].selectionStart
         if (start < 0) return null
         val text = fullText ?: return null
-        val absoluteOffset = (chunkStarts.getOrNull(chunkIndex) ?: 0) + start
+        if (text.isBlank()) return null
+        val absoluteOffset = ((chunkStarts.getOrNull(chunkIndex) ?: 0) + start)
+            .coerceIn(0, text.length)
 
-        val paragraphLines = text.split("\n").filter { it.isNotBlank() }
-        if (paragraphLines.isEmpty()) return null
-
-        var searchFrom = 0
-        var index = -1
-        for ((i, line) in paragraphLines.withIndex()) {
-            val idx = text.indexOf(line, searchFrom)
-            val offset = if (idx >= 0) idx else searchFrom
-            if (offset <= absoluteOffset) index = i else break
-            searchFrom = if (idx >= 0) idx + line.length else searchFrom
-        }
-        return index.takeIf { it >= 0 }
+        // Count the non-blank lines that end before the selection, mirroring the WebView
+        // plain-text path (setEnd at the selection, split on \n, count non-blank lines
+        // excluding the partial current line) so quote indexes align across viewers.
+        return text.substring(0, absoluteOffset)
+            .split("\n")
+            .dropLast(1)
+            .count { it.isNotBlank() }
     }
 
     fun clearSelections() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -2024,6 +2024,11 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         return loaded.block.selectedText()
     }
 
+    fun getSelectedParagraphIndex(): Int? {
+        val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return null
+        return loaded.block.selectedParagraphIndex()
+    }
+
     fun getCurrentChapterName(): String? {
         val loaded = loadedChapters.getOrNull(currentChapterIndex) ?: return null
         return loaded.chapter.chapter.name

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -549,7 +549,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             "NovelViewer: loadNext starting from anchor=${anchor.chapter.id}/${anchor.chapter.name}"
         }
 
-        val retry = { lastNextLoadFailedAt = 0L; loadNextChapterIfAvailable() }
+        val retry = {
+            lastNextLoadFailedAt = 0L
+            loadNextChapterIfAvailable()
+        }
         var loadFailed = false
 
         scope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -148,13 +148,15 @@ internal class NovelWebViewStyler(
         val format = if (isOtf) "opentype" else "truetype"
         // Version by the uri so switching fonts busts the WebView's cached face for the same URL.
         val url = "$FONT_URL_PREFIX?v=${fontFamily.hashCode()}"
-        val declaration = "@font-face { font-family: 'CustomFont'; src: url('$url') format('$format'); font-display: swap; }"
+        val declaration =
+            "@font-face { font-family: 'CustomFont'; src: url('$url') format('$format'); font-display: swap; }"
         return declaration to "'CustomFont', sans-serif"
     }
 
     // Written on the UI thread (style injection), read on the WebView worker thread (interceptFont);
     // @Volatile so the worker sees the latest value instead of a stale cached one.
     @Volatile private var fontUriString: String? = null
+
     @Volatile private var cachedFontBytes: Pair<String, ByteArray>? = null
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1710,7 +1710,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     if (handoffState.isIdle) {
                         scope.launch { preFetchNextChapterForTts() }
                     }
-                } else if (System.currentTimeMillis() - lastNextLoadFailedAt < NovelProgress.NEXT_LOAD_RETRY_COOLDOWN_MS) {
+                } else if (System.currentTimeMillis() - lastNextLoadFailedAt <
+                    NovelProgress.NEXT_LOAD_RETRY_COOLDOWN_MS
+                ) {
                     // Keep the JS load latch held (JS set it before this call) so it stops re-firing
                     // loadNextChapter every scroll frame during the cooldown; schedule a single
                     // release for when the cooldown expires so it can't become permanent.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -216,6 +216,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     var pendingSelectedText: String? = null
+    var pendingParagraphIndex: Int? = null
 
     private val gestureDetector = GestureDetector(
         activity,
@@ -2343,20 +2344,59 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         evaluateJavascriptSafe(
             """
         (function() {
-            var selection = window.getSelection();
-            if (selection && selection.toString().trim()) {
-                return selection.toString().trim();
+            var sel = window.getSelection();
+            if (!sel || sel.rangeCount === 0) return null;
+            var text = sel.toString().trim();
+            if (!text) return null;
+            var range = sel.getRangeAt(0);
+            var node = range.startContainer;
+            if (node && node.nodeType === 3) node = node.parentNode;
+            var para = -1;
+            try {
+                var chapterEl = (node && node.closest) ? node.closest('tsundoku-chapter') : null;
+                if (chapterEl) {
+                    var plain = chapterEl.querySelector('[data-tsundoku-plain-text]');
+                    if (plain) {
+                        var pre = document.createRange();
+                        pre.selectNodeContents(plain);
+                        pre.setEnd(range.startContainer, range.startOffset);
+                        var lines = pre.toString().split('\n');
+                        var count = 0;
+                        for (var i = 0; i < lines.length - 1; i++) {
+                            if (lines[i].trim().length > 0) count++;
+                        }
+                        para = count;
+                    } else {
+                        var blocks = chapterEl.querySelectorAll('p, li, blockquote, h1, h2, h3, h4, h5, h6, pre');
+                        for (var j = 0; j < blocks.length; j++) {
+                            if (blocks[j].contains(node)) { para = j; break; }
+                        }
+                    }
+                }
+            } catch (e) {
+                para = -1;
             }
-            return null;
+            return para + '\n' + text;
         })();
             """.trimIndent(),
         ) { result ->
             activity.runOnUiThread {
                 actionMode?.finish() // finish AFTER JS has read the selection
-                val selectedText = if (result != "null") unescapeJsResult(result).ifEmpty { null } else null
+                val raw = if (result != "null") unescapeJsResult(result) else null
+                val newlineIdx = raw?.indexOf('\n') ?: -1
+                val paragraphIndex = raw?.takeIf { newlineIdx >= 0 }
+                    ?.substring(0, newlineIdx)
+                    ?.toIntOrNull()
+                    ?.takeIf { it >= 0 }
+                val selectedText = when {
+                    raw == null -> null
+                    newlineIdx >= 0 -> raw.substring(newlineIdx + 1).trim().ifEmpty { null }
+                    else -> raw.trim().ifEmpty { null }
+                }
 
                 if (!selectedText.isNullOrBlank()) {
                     pendingSelectedText = selectedText
+                    pendingParagraphIndex = paragraphIndex
                     activity.onRememberSelectedText()
                     clearTextSelection()
                 } else {

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -103,6 +103,8 @@ class MangaRepositoryImpl(
         }.awaitAsOne()
     }
 
+    override suspend fun getMangaByIdOrNull(id: Long): Manga? = getMangasByIds(listOf(id)).firstOrNull()
+
     override suspend fun getMangasByIds(ids: List<Long>): List<Manga> {
         if (ids.isEmpty()) return emptyList()
         return ids.chunked(SQLITE_VARIABLE_LIMIT).flatMap { chunk ->

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -110,11 +110,14 @@ class TranslatedChapterRepositoryImpl(
 
     // ── Path helpers ──────────────────────────────────────────────────
 
-    private fun sourceDirName(sourceName: String): String = DiskUtil.buildValidFilename(sourceName)
+    private fun sourceDirName(sourceName: String): String =
+        DiskUtil.buildValidFilename(sourceName).ifEmpty { "source" }
 
-    private fun novelDirName(novelTitle: String): String = DiskUtil.buildValidFilename(novelTitle)
+    private fun novelDirName(novelTitle: String): String =
+        DiskUtil.buildValidFilename(novelTitle).ifEmpty { "novel" }
 
-    private fun langDirName(targetLanguage: String): String = DiskUtil.buildValidFilename(targetLanguage)
+    private fun langDirName(targetLanguage: String): String =
+        DiskUtil.buildValidFilename(targetLanguage).ifEmpty { "unknown" }
 
     private fun chapterFileBase(chapterName: String, chapterUrl: String): String {
         // Reserve bytes for the longest suffix we append: "_<hash>" + ".html.tmp".
@@ -268,10 +271,19 @@ class TranslatedChapterRepositoryImpl(
             val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
             val content = (meta + translatedChapter.translatedContent).toByteArray()
 
-            dir.findFile(name)?.delete()
-            val file = dir.createFile(name)
+            // Write to a scratch file then swap it in so a crash mid-write can't leave a
+            // truncated translation. ".saving" is not read back (reads require ".html").
+            val savingName = "$name.saving"
+            dir.findFile(savingName)?.delete()
+            val scratch = dir.createFile(savingName)
                 ?: throw IllegalStateException("Failed to create translation file: $name")
-            file.openOutputStream().use { it.write(content) }
+            scratch.openOutputStream().use { it.write(content) }
+
+            dir.findFile(name)?.delete()
+            if (!scratch.renameTo(name)) {
+                scratch.delete()
+                throw IllegalStateException("Failed to finalize translation file: $name")
+            }
 
             dir.findFile(tmpFileName(locator))?.delete()
             Unit

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -49,6 +49,12 @@ class TranslatedChapterRepositoryImpl(
         migrateFromLegacyDir()
     }
 
+    private companion object {
+        // Hex chars of the url MD5 appended to disambiguate chapters whose sanitized
+        // names collide. 8 chars (~4.3B values) keeps per-novel collisions negligible.
+        const val HASH_LENGTH = 8
+    }
+
     /**
      * Move translation files from old app-internal dir to the shared storage dir.
      * Safe to call multiple times – it only moves files that still exist in the legacy dir.
@@ -108,10 +114,16 @@ class TranslatedChapterRepositoryImpl(
 
     private fun novelDirName(novelTitle: String): String = DiskUtil.buildValidFilename(novelTitle)
 
+    private fun langDirName(targetLanguage: String): String = DiskUtil.buildValidFilename(targetLanguage)
+
     private fun chapterFileBase(chapterName: String, chapterUrl: String): String {
-        // Reserve bytes for the longest suffix we append: "_<6 hex>" + ".html.tmp".
-        val base = DiskUtil.buildValidFilename(chapterName, DiskUtil.MAX_FILE_NAME_BYTES - 16)
-        return base + "_" + Hash.md5(chapterUrl).take(6)
+        // Reserve bytes for the longest suffix we append: "_<hash>" + ".html.tmp".
+        val reserved = 1 + HASH_LENGTH + ".html.tmp".length
+        val sanitized = DiskUtil.buildValidFilename(chapterName, DiskUtil.MAX_FILE_NAME_BYTES - reserved)
+        // buildValidFilename can yield an empty string; keep a stable prefix so the
+        // filename still carries a chapter marker before the url hash.
+        val base = sanitized.ifEmpty { "chapter" }
+        return base + "_" + Hash.md5(chapterUrl).take(HASH_LENGTH)
     }
 
     private fun fileName(locator: TranslationLocator): String =
@@ -124,13 +136,13 @@ class TranslatedChapterRepositoryImpl(
         translationsDir.findFile(sourceDirName(sourceName))?.findFile(novelDirName(novelTitle))
 
     private fun findLangDir(locator: TranslationLocator, targetLanguage: String): UniFile? =
-        findNovelDir(locator.sourceName, locator.novelTitle)?.findFile(targetLanguage)
+        findNovelDir(locator.sourceName, locator.novelTitle)?.findFile(langDirName(targetLanguage))
 
     private fun getOrCreateLangDir(locator: TranslationLocator, targetLanguage: String): UniFile? {
         val root = translationsDir
         val src = root.findChildDir(sourceDirName(locator.sourceName)) ?: return null
         val novel = src.findChildDir(novelDirName(locator.novelTitle)) ?: return null
-        return novel.findChildDir(targetLanguage)
+        return novel.findChildDir(langDirName(targetLanguage))
     }
 
     private fun UniFile.findChildDir(name: String): UniFile? {
@@ -234,7 +246,7 @@ class TranslatedChapterRepositoryImpl(
         chapters: Collection<ChapterRef>,
     ): Set<Long> = withContext(Dispatchers.IO) {
         if (chapters.isEmpty()) return@withContext emptySet()
-        val langDir = findNovelDir(sourceName, novelTitle)?.findFile(targetLanguage) ?: return@withContext emptySet()
+        val langDir = findNovelDir(sourceName, novelTitle)?.findFile(langDirName(targetLanguage)) ?: return@withContext emptySet()
         val present = langDir.listFiles()
             ?.mapNotNull { it.name }
             ?.filterTo(HashSet()) { it.endsWith(".html") && !it.endsWith(".html.tmp") }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -326,12 +326,14 @@ class TranslatedChapterRepositoryImpl(
         toTranslatedChapter(meta, targetLanguage)
     }
 
-    // ── Delete operations ─────────────────────────────────────────────
+    // Delete operations
 
     override suspend fun deleteTranslation(locator: TranslationLocator, targetLanguage: String) =
         withContext(Dispatchers.IO) {
             findLangDir(locator, targetLanguage)?.let { dir ->
-                dir.findFile(fileName(locator))?.delete()
+                val name = fileName(locator)
+                dir.findFile(name)?.delete()
+                dir.findFile("$name.saving")?.delete()
                 dir.findFile(tmpFileName(locator))?.delete()
             }
             Unit
@@ -345,6 +347,7 @@ class TranslatedChapterRepositoryImpl(
             ?.filter { it.isDirectory }
             ?.forEach { langDir ->
                 langDir.findFile(target)?.delete()
+                langDir.findFile("$target.saving")?.delete()
                 langDir.findFile(tmp)?.delete()
             }
         Unit
@@ -359,7 +362,7 @@ class TranslatedChapterRepositoryImpl(
         val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withContext
         val wanted = chapters.flatMapTo(HashSet()) {
             val base = chapterFileBase(it.name, it.url)
-            listOf("$base.html", "$base.html.tmp")
+            listOf("$base.html", "$base.html.saving", "$base.html.tmp")
         }
         novelDir.listFiles()
             ?.filter { it.isDirectory }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -2,32 +2,32 @@ package tachiyomi.data.translation
 
 import android.content.Context
 import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.util.lang.Hash
+import eu.kanade.tachiyomi.util.storage.DiskUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
-import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.storage.service.StorageManager
+import tachiyomi.domain.translation.model.ChapterRef
 import tachiyomi.domain.translation.model.TranslatedChapter
+import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import java.io.File
-import java.security.MessageDigest
 
 /**
  * Filesystem-only implementation of [TranslatedChapterRepository].
  *
- * Storage layout (shared storage via SAF / UniFile):
- *   {baseDir}/translations/{chapterId}_{targetLanguage}.html
+ * Portable storage layout (shared storage via SAF / UniFile), mirroring downloads:
+ *   {baseDir}/translations/{source name}/{novel title}/{language}/{chapter name}_{urlHash}.html
  *
- * Falls back to app-internal storage if shared storage is unavailable:
- *   filesDir/translations/{chapterId}_{targetLanguage}.html
+ * Falls back to app-internal storage if shared storage is unavailable.
  *
  * Engine and date metadata are embedded as an HTML comment on the first line:
  *   <!-- tsundoku-meta:engineId:dateTranslated -->
  *
  * NOTE: This implementation uses [UniFile] throughout (same as the download system)
- * to avoid converting SAF URIs to file paths, which causes crashes on some devices/ROMs
- * when [android.content.Context.getExternalCacheDirs] fails.
+ * to avoid converting SAF URIs to file paths, which crashes on some devices/ROMs.
  */
 class TranslatedChapterRepositoryImpl(
     private val context: Context,
@@ -37,22 +37,15 @@ class TranslatedChapterRepositoryImpl(
     /** Legacy (app-internal) directory – used for fallback and migration. */
     private val legacyDir = File(context.filesDir, "translations")
 
-    /**
-     * Resolve the translations directory via SAF, falling back to app-internal.
-     * Returns a [UniFile] that can be used for all I/O operations without needing
-     * to convert to a filesystem path.
-     */
     private val translationsDir: UniFile
         get() {
             val shared = storageManager.getTranslationsDirectory()
             if (shared != null && shared.exists()) return shared
-            // Fallback to app-internal wrapped as UniFile
             legacyDir.mkdirs()
             return UniFile.fromFile(legacyDir)!!
         }
 
     init {
-        // Migrate existing translations from legacy location to shared storage on first access
         migrateFromLegacyDir()
     }
 
@@ -67,7 +60,6 @@ class TranslatedChapterRepositoryImpl(
             if (files.isEmpty()) return
 
             val targetDir = storageManager.getTranslationsDirectory() ?: return
-            // Don't migrate if target is effectively the same as legacy (both are app-internal)
             val targetPath = try {
                 targetDir.filePath
             } catch (_: Exception) {
@@ -78,13 +70,11 @@ class TranslatedChapterRepositoryImpl(
             var migrated = 0
             for (file in files) {
                 val name = file.name
-                // Check if already exists in target
                 if (targetDir.findFile(name) != null) {
                     file.delete()
                     migrated++
                     continue
                 }
-                // Copy file content via SAF
                 val dest = targetDir.createFile(name) ?: continue
                 try {
                     file.inputStream().use { input ->
@@ -100,7 +90,6 @@ class TranslatedChapterRepositoryImpl(
                 }
             }
 
-            // Clean up empty legacy dir
             if (legacyDir.listFiles()?.isEmpty() == true) {
                 legacyDir.delete()
             }
@@ -113,17 +102,52 @@ class TranslatedChapterRepositoryImpl(
         }
     }
 
-    private fun getTranslationFileName(chapterId: Long, targetLanguage: String): String {
-        return "${chapterId}_$targetLanguage.html"
+    // ── Path helpers ──────────────────────────────────────────────────
+
+    private fun sourceDirName(sourceName: String): String = DiskUtil.buildValidFilename(sourceName)
+
+    private fun novelDirName(novelTitle: String): String = DiskUtil.buildValidFilename(novelTitle)
+
+    private fun chapterFileBase(chapterName: String, chapterUrl: String): String {
+        // Subtract 11 bytes to leave room for the "_<6 hex>" suffix.
+        val base = DiskUtil.buildValidFilename(chapterName, DiskUtil.MAX_FILE_NAME_BYTES - 11)
+        return base + "_" + Hash.md5(chapterUrl).take(6)
     }
 
-    private fun getTmpTranslationFileName(chapterId: Long, targetLanguage: String): String {
-        return "${chapterId}_$targetLanguage.html.tmp"
+    private fun fileName(locator: TranslationLocator): String =
+        chapterFileBase(locator.chapterName, locator.chapterUrl) + ".html"
+
+    private fun tmpFileName(locator: TranslationLocator): String =
+        chapterFileBase(locator.chapterName, locator.chapterUrl) + ".html.tmp"
+
+    private fun findNovelDir(sourceName: String, novelTitle: String): UniFile? =
+        translationsDir.findFile(sourceDirName(sourceName))?.findFile(novelDirName(novelTitle))
+
+    private fun findLangDir(locator: TranslationLocator, targetLanguage: String): UniFile? =
+        findNovelDir(locator.sourceName, locator.novelTitle)?.findFile(targetLanguage)
+
+    private fun getOrCreateLangDir(locator: TranslationLocator, targetLanguage: String): UniFile? {
+        val root = translationsDir
+        val src = root.findChildDir(sourceDirName(locator.sourceName)) ?: return null
+        val novel = src.findChildDir(novelDirName(locator.novelTitle)) ?: return null
+        return novel.findChildDir(targetLanguage)
     }
 
-    private fun findTranslationFile(chapterId: Long, targetLanguage: String): UniFile? {
-        val name = getTranslationFileName(chapterId, targetLanguage)
-        return translationsDir.findFile(name)
+    private fun UniFile.findChildDir(name: String): UniFile? {
+        val existing = findFile(name)
+        if (existing != null) return existing.takeIf { it.isDirectory }
+        return createDirectory(name)
+    }
+
+    private fun allFilesRecursive(dir: UniFile): Sequence<UniFile> = sequence {
+        dir.listFiles()?.forEach { f ->
+            if (f.isDirectory) yieldAll(allFilesRecursive(f)) else yield(f)
+        }
+    }
+
+    private fun deleteRecursive(file: UniFile) {
+        if (file.isDirectory) file.listFiles()?.forEach { deleteRecursive(it) }
+        file.delete()
     }
 
     // ── Metadata helpers ──────────────────────────────────────────────
@@ -132,25 +156,16 @@ class TranslatedChapterRepositoryImpl(
     private val metaSuffix = " -->"
     private val metaRegex = Regex("^<!-- tsundoku-meta:(.+?):(-?\\d+)(?::([a-f0-9]{64}))? -->\\n?")
 
-    private fun buildMetaComment(engineId: String, dateTranslated: Long, sourceContentHash: String? = null): String {
-        val hashPart = if (!sourceContentHash.isNullOrEmpty()) ":$sourceContentHash" else ""
-        return "$metaPrefix$engineId:$dateTranslated$hashPart$metaSuffix\n"
-    }
-
-    private fun computeSourceHash(content: String): String {
-        val digest = MessageDigest.getInstance("SHA-256")
-        val hashBytes = digest.digest(content.toByteArray(Charsets.UTF_8))
-        return hashBytes.joinToString("") { "%02x".format(it) }
+    private fun buildMetaComment(engineId: String, dateTranslated: Long): String {
+        return "$metaPrefix$engineId:$dateTranslated$metaSuffix\n"
     }
 
     private data class FileMeta(
         val engineId: String,
         val dateTranslated: Long,
-        val sourceHash: String?,
         val content: String,
     )
 
-    /** Read a translation file, parsing the optional metadata comment from the first line. */
     private fun parseUniFile(file: UniFile): FileMeta? {
         if (!file.exists()) return null
         val raw = try {
@@ -164,145 +179,97 @@ class TranslatedChapterRepositoryImpl(
             FileMeta(
                 engineId = match.groupValues[1],
                 dateTranslated = match.groupValues[2].toLong(),
-                sourceHash = match.groupValues[3].takeIf { it.isNotEmpty() },
                 content = raw.removeRange(match.range).trimStart('\n'),
             )
         } else {
-            FileMeta(engineId = "unknown", dateTranslated = 0L, sourceHash = null, content = raw)
+            FileMeta(engineId = "unknown", dateTranslated = 0L, content = raw)
         }
     }
 
+    private fun toTranslatedChapter(meta: FileMeta, targetLanguage: String): TranslatedChapter =
+        TranslatedChapter(
+            chapterId = 0,
+            mangaId = 0,
+            targetLanguage = targetLanguage,
+            engineId = meta.engineId,
+            translatedContent = meta.content,
+            dateTranslated = meta.dateTranslated,
+        )
+
     // ── Read operations ───────────────────────────────────────────────
 
-    override suspend fun getTranslatedChapter(chapterId: Long, targetLanguage: String): TranslatedChapter? =
-        withContext(Dispatchers.IO) {
-            val file = findTranslationFile(chapterId, targetLanguage) ?: return@withContext null
-            val meta = parseUniFile(file) ?: return@withContext null
-            TranslatedChapter(
-                chapterId = chapterId,
-                mangaId = 0,
-                targetLanguage = targetLanguage,
-                engineId = meta.engineId,
-                translatedContent = meta.content,
-                dateTranslated = meta.dateTranslated,
-            )
-        }
+    override suspend fun getTranslatedChapter(
+        locator: TranslationLocator,
+        targetLanguage: String,
+    ): TranslatedChapter? = withContext(Dispatchers.IO) {
+        val file = findLangDir(locator, targetLanguage)?.findFile(fileName(locator)) ?: return@withContext null
+        val meta = parseUniFile(file) ?: return@withContext null
+        toTranslatedChapter(meta, targetLanguage)
+    }
 
-    override suspend fun getAllTranslationsForChapter(chapterId: Long): List<TranslatedChapter> =
+    override suspend fun getAllTranslationsForChapter(locator: TranslationLocator): List<TranslatedChapter> =
         withContext(Dispatchers.IO) {
-            val prefix = "${chapterId}_"
-            val dir = translationsDir
-            dir.listFiles()
-                ?.filter { it.name?.startsWith(prefix) == true && it.name?.endsWith(".html") == true }
-                ?.mapNotNull { file ->
-                    val nameWithoutExt = file.nameWithoutExtension ?: return@mapNotNull null
-                    val lang = nameWithoutExt.removePrefix(prefix)
+            val novelDir = findNovelDir(locator.sourceName, locator.novelTitle) ?: return@withContext emptyList()
+            val target = fileName(locator)
+            novelDir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.mapNotNull { langDir ->
+                    val lang = langDir.name ?: return@mapNotNull null
+                    val file = langDir.findFile(target) ?: return@mapNotNull null
                     val meta = parseUniFile(file) ?: return@mapNotNull null
-                    TranslatedChapter(
-                        chapterId = chapterId,
-                        mangaId = 0,
-                        targetLanguage = lang,
-                        engineId = meta.engineId,
-                        translatedContent = meta.content,
-                        dateTranslated = meta.dateTranslated,
-                    )
+                    toTranslatedChapter(meta, lang)
                 }
                 .orEmpty()
         }
 
-    override suspend fun hasTranslation(chapterId: Long, targetLanguage: String): Boolean =
+    override suspend fun hasTranslation(locator: TranslationLocator, targetLanguage: String): Boolean =
         withContext(Dispatchers.IO) {
-            findTranslationFile(chapterId, targetLanguage) != null
+            findLangDir(locator, targetLanguage)?.findFile(fileName(locator)) != null
         }
 
-    /**
-     * Check if a partial (tmp) translation exists for a chapter.
-     */
-    override suspend fun hasTmpTranslation(chapterId: Long, targetLanguage: String): Boolean =
-        withContext(Dispatchers.IO) {
-            val name = getTmpTranslationFileName(chapterId, targetLanguage)
-            translationsDir.findFile(name) != null
-        }
-
-    override suspend fun getTranslatedChapterIds(chapterIds: Collection<Long>): Set<Long> =
-        withContext(Dispatchers.IO) {
-            if (chapterIds.isEmpty()) return@withContext emptySet()
-            val dir = translationsDir
-            val allFiles = dir.listFiles() ?: return@withContext emptySet()
-            val wantedIds = chapterIds.toHashSet()
-            allFiles.asSequence()
-                .filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
-                .mapNotNull { it.nameWithoutExtension?.substringBefore('_')?.toLongOrNull() }
-                .filter { it in wantedIds }
-                .toSet()
-        }
-
-    override suspend fun getTranslatedLanguagesForChapters(chapterIds: Collection<Long>): List<String> =
-        withContext(Dispatchers.IO) {
-            if (chapterIds.isEmpty()) return@withContext emptyList()
-            val dir = translationsDir
-            val allFiles = dir.listFiles() ?: return@withContext emptyList()
-            val wantedIds = chapterIds.toHashSet()
-            allFiles.asSequence()
-                .filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
-                .filter { it.nameWithoutExtension?.substringBefore('_')?.toLongOrNull() in wantedIds }
-                .mapNotNull { it.nameWithoutExtension?.substringAfter('_') }
-                .distinct()
-                .toList()
-        }
-
-    override suspend fun getAll(): List<TranslatedChapter> = withContext(Dispatchers.IO) {
-        val dir = translationsDir
-        dir.listFiles()
-            ?.filter { it.name?.endsWith(".html") == true && it.name?.endsWith(".html.tmp") != true }
-            ?.mapNotNull { file ->
-                val nameWithoutExt = file.nameWithoutExtension ?: return@mapNotNull null
-                val parts = nameWithoutExt.split('_', limit = 2)
-                if (parts.size != 2) return@mapNotNull null
-                val chapterId = parts[0].toLongOrNull() ?: return@mapNotNull null
-                val lang = parts[1]
-                val meta = parseUniFile(file) ?: return@mapNotNull null
-                TranslatedChapter(
-                    chapterId = chapterId,
-                    mangaId = 0,
-                    targetLanguage = lang,
-                    engineId = meta.engineId,
-                    translatedContent = meta.content,
-                    dateTranslated = meta.dateTranslated,
-                )
-            }
-            .orEmpty()
+    override suspend fun filterTranslatedChapters(
+        sourceName: String,
+        novelTitle: String,
+        targetLanguage: String,
+        chapters: Collection<ChapterRef>,
+    ): Set<Long> = withContext(Dispatchers.IO) {
+        if (chapters.isEmpty()) return@withContext emptySet()
+        val langDir = findNovelDir(sourceName, novelTitle)?.findFile(targetLanguage) ?: return@withContext emptySet()
+        val present = langDir.listFiles()
+            ?.mapNotNull { it.name }
+            ?.filterTo(HashSet()) { it.endsWith(".html") && !it.endsWith(".html.tmp") }
+            ?: return@withContext emptySet()
+        if (present.isEmpty()) return@withContext emptySet()
+        chapters.asSequence()
+            .filter { (chapterFileBase(it.name, it.url) + ".html") in present }
+            .map { it.id }
+            .toSet()
     }
 
     // ── Write operations ──────────────────────────────────────────────
 
-    override suspend fun upsertTranslation(translatedChapter: TranslatedChapter) =
+    override suspend fun upsertTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter) =
         withContext(Dispatchers.IO) {
-            val dir = translationsDir
-            val name = getTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
+            val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
+                ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
+            val name = fileName(locator)
             val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
             val content = (meta + translatedChapter.translatedContent).toByteArray()
 
-            // Delete existing file first (createFile may fail if it already exists on some backends)
             dir.findFile(name)?.delete()
             val file = dir.createFile(name)
                 ?: throw IllegalStateException("Failed to create translation file: $name")
             file.openOutputStream().use { it.write(content) }
 
-            // Remove any tmp file for this chapter+language
-            val tmpName = getTmpTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
-            dir.findFile(tmpName)?.delete()
+            dir.findFile(tmpFileName(locator))?.delete()
             Unit
         }
 
-    /**
-     * Save a partial (in-progress) translation with .tmp extension.
-     * This allows resuming incomplete translations.
-     */
-    override suspend fun upsertTmpTranslation(translatedChapter: TranslatedChapter) =
+    override suspend fun upsertTmpTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter) =
         withContext(Dispatchers.IO) {
-            val dir = translationsDir
-            val name = getTmpTranslationFileName(translatedChapter.chapterId, translatedChapter.targetLanguage)
+            val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
+                ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
+            val name = tmpFileName(locator)
             val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
             val content = (meta + translatedChapter.translatedContent).toByteArray()
 
@@ -312,114 +279,75 @@ class TranslatedChapterRepositoryImpl(
             file.openOutputStream().use { it.write(content) }
         }
 
-    /**
-     * Read a partial (in-progress) translation.
-     */
-    override suspend fun getTmpTranslation(chapterId: Long, targetLanguage: String): TranslatedChapter? =
-        withContext(Dispatchers.IO) {
-            val name = getTmpTranslationFileName(chapterId, targetLanguage)
-            val file = translationsDir.findFile(name) ?: return@withContext null
-            val meta = parseUniFile(file) ?: return@withContext null
-            TranslatedChapter(
-                chapterId = chapterId,
-                mangaId = 0,
-                targetLanguage = targetLanguage,
-                engineId = meta.engineId,
-                translatedContent = meta.content,
-                dateTranslated = meta.dateTranslated,
-            )
-        }
-
-    /**
-     * Promote a tmp translation to a final one (remove .tmp extension).
-     */
-    suspend fun promoteTmpTranslation(chapterId: Long, targetLanguage: String): Boolean =
-        withContext(Dispatchers.IO) {
-            val tmpName = getTmpTranslationFileName(chapterId, targetLanguage)
-            val tmpFile = translationsDir.findFile(tmpName) ?: return@withContext false
-            val meta = parseUniFile(tmpFile) ?: return@withContext false
-
-            // Write final file
-            val dir = translationsDir
-            val finalName = getTranslationFileName(chapterId, targetLanguage)
-            dir.findFile(finalName)?.delete()
-            val finalFile = dir.createFile(finalName) ?: return@withContext false
-            val metaComment = buildMetaComment(meta.engineId, meta.dateTranslated)
-            finalFile.openOutputStream().use { it.write((metaComment + meta.content).toByteArray()) }
-
-            // Delete tmp
-            tmpFile.delete()
-            true
-        }
+    override suspend fun getTmpTranslation(
+        locator: TranslationLocator,
+        targetLanguage: String,
+    ): TranslatedChapter? = withContext(Dispatchers.IO) {
+        val file = findLangDir(locator, targetLanguage)?.findFile(tmpFileName(locator)) ?: return@withContext null
+        val meta = parseUniFile(file) ?: return@withContext null
+        toTranslatedChapter(meta, targetLanguage)
+    }
 
     // ── Delete operations ─────────────────────────────────────────────
 
-    override suspend fun deleteTranslation(chapterId: Long, targetLanguage: String) =
+    override suspend fun deleteTranslation(locator: TranslationLocator, targetLanguage: String) =
         withContext(Dispatchers.IO) {
-            findTranslationFile(chapterId, targetLanguage)?.delete()
-            // Also delete any tmp file
-            val tmpName = getTmpTranslationFileName(chapterId, targetLanguage)
-            translationsDir.findFile(tmpName)?.delete()
+            findLangDir(locator, targetLanguage)?.let { dir ->
+                dir.findFile(fileName(locator))?.delete()
+                dir.findFile(tmpFileName(locator))?.delete()
+            }
             Unit
         }
 
-    override suspend fun deleteAllForChapter(chapterId: Long) = withContext(Dispatchers.IO) {
-        val prefix = "${chapterId}_"
-        val dir = translationsDir
-        dir.listFiles()
-            ?.filter { it.name?.startsWith(prefix) == true }
-            ?.forEach { it.delete() }
+    override suspend fun deleteAllForChapter(locator: TranslationLocator) = withContext(Dispatchers.IO) {
+        val novelDir = findNovelDir(locator.sourceName, locator.novelTitle) ?: return@withContext
+        val target = fileName(locator)
+        val tmp = tmpFileName(locator)
+        novelDir.listFiles()
+            ?.filter { it.isDirectory }
+            ?.forEach { langDir ->
+                langDir.findFile(target)?.delete()
+                langDir.findFile(tmp)?.delete()
+            }
         Unit
     }
 
-    override suspend fun deleteAllForChapters(chapterIds: Collection<Long>) = withContext(Dispatchers.IO) {
-        if (chapterIds.isEmpty()) return@withContext
-        val wantedIds = chapterIds.toHashSet()
-        val dir = translationsDir
-        dir.listFiles()
-            ?.filter {
-                val name = it.name ?: return@filter false
-                name.endsWith(".html") || name.endsWith(".html.tmp")
+    override suspend fun deleteAllForChapters(
+        sourceName: String,
+        novelTitle: String,
+        chapters: Collection<ChapterRef>,
+    ) = withContext(Dispatchers.IO) {
+        if (chapters.isEmpty()) return@withContext
+        val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withContext
+        val wanted = chapters.flatMapTo(HashSet()) {
+            val base = chapterFileBase(it.name, it.url)
+            listOf("$base.html", "$base.html.tmp")
+        }
+        novelDir.listFiles()
+            ?.filter { it.isDirectory }
+            ?.forEach { langDir ->
+                langDir.listFiles()
+                    ?.filter { it.name in wanted }
+                    ?.forEach { it.delete() }
             }
-            ?.filter {
-                val nameNoExt = it.name?.substringBefore('_') ?: return@filter false
-                nameNoExt.toLongOrNull() in wantedIds
-            }
-            ?.forEach { it.delete() }
+        Unit
+    }
+
+    override suspend fun deleteAllForManga(sourceName: String, novelTitle: String) = withContext(Dispatchers.IO) {
+        findNovelDir(sourceName, novelTitle)?.let { deleteRecursive(it) }
         Unit
     }
 
     override suspend fun deleteAll() = withContext(Dispatchers.IO) {
-        val dir = translationsDir
-        dir.listFiles()?.forEach { it.delete() }
-        Unit
-    }
-
-    // ── Cache management ──────────────────────────────────────────────
-
-    override suspend fun getCacheSize(): Long = withContext(Dispatchers.IO) {
-        val dir = translationsDir
-        dir.listFiles()
-            ?.filter { it.isFile }
-            ?.sumOf { it.length() }
-            ?: 0L
-    }
-
-    override suspend fun clearOldCache(olderThan: Long) = withContext(Dispatchers.IO) {
-        val dir = translationsDir
-        dir.listFiles()
-            ?.filter { it.name?.endsWith(".html") == true || it.name?.endsWith(".html.tmp") == true }
-            ?.filter { it.lastModified() < olderThan }
-            ?.forEach { it.delete() }
+        translationsDir.listFiles()?.forEach { deleteRecursive(it) }
         Unit
     }
 
     override suspend fun clearTmpFiles(): Long = withContext(Dispatchers.IO) {
-        val dir = translationsDir
         var freed = 0L
-        dir.listFiles()
-            ?.filter { it.name?.endsWith(".html.tmp") == true }
-            ?.forEach {
+        allFilesRecursive(translationsDir)
+            .filter { it.name?.endsWith(".html.tmp") == true }
+            .forEach {
                 freed += it.length()
                 it.delete()
             }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -14,6 +14,7 @@ import tachiyomi.domain.translation.model.TranslatedChapter
 import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import java.io.File
+import java.io.IOException
 
 /**
  * Filesystem-only implementation of [TranslatedChapterRepository].
@@ -260,7 +261,8 @@ class TranslatedChapterRepositoryImpl(
         chapters: Collection<ChapterRef>,
     ): Set<Long> = withContext(Dispatchers.IO) {
         if (chapters.isEmpty()) return@withContext emptySet()
-        val langDir = findNovelDir(sourceName, novelTitle)?.findFile(langDirName(targetLanguage)) ?: return@withContext emptySet()
+        val langDir =
+            findNovelDir(sourceName, novelTitle)?.findFile(langDirName(targetLanguage)) ?: return@withContext emptySet()
         val present = langDir.listFiles()
             ?.mapNotNull { it.name }
             ?.filterTo(HashSet()) { it.endsWith(".html") && !it.endsWith(".html.tmp") }
@@ -385,7 +387,9 @@ class TranslatedChapterRepositoryImpl(
             if (existing != null) {
                 // Deny if a non-empty dir already holds translations; only reclaim an empty one.
                 if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
-                    logcat(LogPriority.WARN) { "Translation dir '$newName' exists and is not empty; not renaming '$oldName'" }
+                    logcat(LogPriority.WARN) {
+                        "Translation dir '$newName' exists and is not empty; not renaming '$oldName'"
+                    }
                     return@withContext
                 }
                 existing.delete()
@@ -415,7 +419,9 @@ class TranslatedChapterRepositoryImpl(
         val existing = newSrcDir.findFile(newNovel)
         if (existing != null) {
             if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
-                logcat(LogPriority.WARN) { "Translation dir '$newSrcName/$newNovel' exists and is not empty; not moving" }
+                logcat(LogPriority.WARN) {
+                    "Translation dir '$newSrcName/$newNovel' exists and is not empty; not moving"
+                }
                 return@withContext
             }
             existing.delete()
@@ -430,22 +436,47 @@ class TranslatedChapterRepositoryImpl(
         }
 
         val destDir = newSrcDir.createDirectory(newNovel) ?: return@withContext
-        copyContentsRecursive(oldDir, destDir)
-        deleteRecursive(oldDir)
+        if (copyContentsRecursive(oldDir, destDir)) {
+            deleteRecursive(oldDir)
+        } else {
+            // Deleting the source after a partial copy would lose the un-copied translations.
+            // Keep it so the move can be retried; the half-written dest is denied on retry by the
+            // non-empty-existing guard above (or reclaimed once empty).
+            logcat(LogPriority.ERROR) {
+                "Copy incomplete moving '$oldSrcName/$oldNovel' -> '$newSrcName/$newNovel'; keeping source"
+            }
+        }
         Unit
     }
 
     // SAF renameTo only renames within the same parent, so a cross-source move is copy-then-delete.
-    private fun copyContentsRecursive(src: UniFile, dest: UniFile) {
+    // Returns true only if every child copied; a false result must prevent deleting the source.
+    private fun copyContentsRecursive(src: UniFile, dest: UniFile): Boolean {
+        var ok = true
         src.listFiles()?.forEach { child ->
-            val name = child.name ?: return@forEach
+            val name = child.name
+            if (name == null) {
+                ok = false
+                return@forEach
+            }
             if (child.isDirectory) {
-                dest.findChildDir(name)?.let { copyContentsRecursive(child, it) }
+                val destChild = dest.findChildDir(name)
+                if (destChild == null || !copyContentsRecursive(child, destChild)) ok = false
             } else {
-                val out = dest.createFile(name) ?: return@forEach
-                child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+                val out = dest.createFile(name)
+                if (out == null) {
+                    ok = false
+                } else {
+                    try {
+                        child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+                    } catch (e: IOException) {
+                        logcat(LogPriority.ERROR) { "Failed to copy translation '$name': ${e.message}" }
+                        ok = false
+                    }
+                }
             }
         }
+        return ok
     }
 
     override suspend fun deleteAll() = withContext(Dispatchers.IO) {

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -271,6 +271,16 @@ class TranslatedChapterRepositoryImpl(
         return if (scratch.renameTo(name)) langDir.findFile(name)?.takeIf { it.exists() } else null
     }
 
+    // A ".saving" scratch only counts as a real translation once it holds content: a crash right
+    // after createFile (before the write) leaves an empty/header-only scratch that recovery discards,
+    // so the badge/skip-translated predicates must not treat it as translated either. Read-only: it
+    // never promotes or deletes, unlike recoverPendingTranslation.
+    private fun savingHasContent(scratch: UniFile?): Boolean {
+        val file = scratch?.takeIf { it.exists() } ?: return false
+        val meta = parseUniFile(file)
+        return meta != null && meta.content.isNotBlank()
+    }
+
     override suspend fun getAllTranslationsForChapter(locator: TranslationLocator): List<TranslatedChapter> =
         withContext(Dispatchers.IO) {
             val novelDir = findNovelDir(locator.sourceName, locator.novelTitle) ?: return@withContext emptyList()
@@ -286,13 +296,45 @@ class TranslatedChapterRepositoryImpl(
                 .orEmpty()
         }
 
+    override suspend fun getAllTranslationsForNovel(
+        sourceName: String,
+        novelTitle: String,
+        chapters: Collection<ChapterRef>,
+    ): Map<Long, List<TranslatedChapter>> = withContext(Dispatchers.IO) {
+        if (chapters.isEmpty()) return@withContext emptyMap()
+        val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withContext emptyMap()
+        // List each language dir once up front (name -> file) so the per-chapter lookup below is an
+        // in-memory map hit rather than a SAF findFile call.
+        val langFiles = novelDir.listFiles()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { langDir ->
+                val lang = langDir.name ?: return@mapNotNull null
+                val files = langDir.listFiles()?.mapNotNull { f -> f.name?.let { it to f } }?.toMap().orEmpty()
+                lang to files
+            }
+            .orEmpty()
+        if (langFiles.isEmpty()) return@withContext emptyMap()
+        val result = HashMap<Long, List<TranslatedChapter>>()
+        chapters.forEach { ref ->
+            val target = "${chapterFileBase(ref.name, ref.url)}.html"
+            val translations = langFiles.mapNotNull { (lang, files) ->
+                val file = files[target] ?: return@mapNotNull null
+                val meta = parseUniFile(file) ?: return@mapNotNull null
+                toTranslatedChapter(meta, lang)
+            }
+            if (translations.isNotEmpty()) result[ref.id] = translations
+        }
+        result
+    }
+
     override suspend fun hasTranslation(locator: TranslationLocator, targetLanguage: String): Boolean =
         withContext(Dispatchers.IO) {
             val langDir = findLangDir(locator, targetLanguage) ?: return@withContext false
             val name = fileName(locator)
             // A recoverable ".saving" scratch counts as translated so a crash before the final rename
-            // doesn't make the badge/skip-translated logic re-translate over the recovered write.
-            langDir.findFile(name) != null || langDir.findFile("$name.saving")?.exists() == true
+            // doesn't make the badge/skip-translated logic re-translate over the recovered write; an
+            // empty scratch (crash before the write) does not, matching recoverPendingTranslation.
+            langDir.findFile(name) != null || savingHasContent(langDir.findFile("$name.saving"))
         }
 
     override suspend fun filterTranslatedChapters(
@@ -304,13 +346,15 @@ class TranslatedChapterRepositoryImpl(
         if (chapters.isEmpty()) return@withContext emptySet()
         val langDir =
             findNovelDir(sourceName, novelTitle)?.findFile(langDirName(targetLanguage)) ?: return@withContext emptySet()
-        val names = langDir.listFiles()?.mapNotNull { it.name } ?: return@withContext emptySet()
+        val files = langDir.listFiles() ?: return@withContext emptySet()
         // Count a recoverable ".saving" scratch as its committed ".html" so a crashed-but-recoverable
-        // write isn't reported as untranslated.
+        // write isn't reported as untranslated, but only when it holds content (an empty scratch is
+        // discarded on the read path, so reporting it translated would wrongly skip re-translation).
         val present = HashSet<String>()
-        names.forEach { n ->
+        files.forEach { file ->
+            val n = file.name ?: return@forEach
             when {
-                n.endsWith(".html.saving") -> present.add(n.removeSuffix(".saving"))
+                n.endsWith(".html.saving") -> if (savingHasContent(file)) present.add(n.removeSuffix(".saving"))
                 n.endsWith(".html") -> present.add(n)
             }
         }
@@ -538,12 +582,12 @@ class TranslatedChapterRepositoryImpl(
             if (copyContentsRecursive(oldDir, destDir)) {
                 deleteRecursive(oldDir)
             } else {
-                // Deleting the source after a partial copy would lose the un-copied translations.
-                // Keep it so the move can be retried; the half-written dest is denied on retry by
-                // the non-empty-existing guard above (or reclaimed once empty).
+                // Keep the source (it still holds every translation) but drop the half-copied dest,
+                // otherwise the non-empty-existing guard above would block every future retry.
                 logcat(LogPriority.ERROR) {
-                    "Copy incomplete moving '$oldSrcName/$oldNovel' -> '$newSrcName/$newNovel'; keeping source"
+                    "Copy incomplete moving '$oldSrcName/$oldNovel' -> '$newSrcName/$newNovel'; reverting"
                 }
+                deleteRecursive(destDir)
             }
         }
         Unit
@@ -580,18 +624,50 @@ class TranslatedChapterRepositoryImpl(
     }
 
     override suspend fun deleteAll() = withContext(Dispatchers.IO) {
-        translationsDir.listFiles()?.forEach { deleteRecursive(it) }
+        // Delete each novel dir under its own lock so this can't race an in-flight upsert/rename for
+        // that novel. The on-disk dir names equal the sanitized lock-key components, so the key
+        // built here matches the one writers use (see novelLockKey).
+        translationsDir.listFiles()?.forEach { srcDir ->
+            val srcName = srcDir.name
+            if (srcName == null || !srcDir.isDirectory) {
+                srcDir.delete()
+                return@forEach
+            }
+            srcDir.listFiles()?.forEach { novelDir ->
+                val novelName = novelDir.name
+                if (novelName == null || !novelDir.isDirectory) {
+                    novelDir.delete()
+                    return@forEach
+                }
+                val lock = novelLocks.computeIfAbsent("$srcName/$novelName") { Any() }
+                synchronized(lock) { deleteRecursive(novelDir) }
+            }
+            srcDir.delete()
+        }
         Unit
     }
 
     override suspend fun clearTmpFiles(): Long = withContext(Dispatchers.IO) {
         var freed = 0L
-        allFilesRecursive(translationsDir)
-            .filter { it.name?.endsWith(".html.tmp") == true }
-            .forEach {
-                freed += it.length()
-                it.delete()
+        // Same per-novel locking as deleteAll: a tmp sweep must not race the writer creating/renaming
+        // scratch files for the novel it is scanning.
+        translationsDir.listFiles()?.forEach { srcDir ->
+            val srcName = srcDir.name ?: return@forEach
+            if (!srcDir.isDirectory) return@forEach
+            srcDir.listFiles()?.forEach { novelDir ->
+                val novelName = novelDir.name ?: return@forEach
+                if (!novelDir.isDirectory) return@forEach
+                val lock = novelLocks.computeIfAbsent("$srcName/$novelName") { Any() }
+                synchronized(lock) {
+                    allFilesRecursive(novelDir)
+                        .filter { it.name?.endsWith(".html.tmp") == true }
+                        .forEach {
+                            freed += it.length()
+                            it.delete()
+                        }
+                }
             }
+        }
         freed
     }
 }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -15,6 +15,7 @@ import tachiyomi.domain.translation.model.TranslationLocator
 import tachiyomi.domain.translation.repository.TranslatedChapterRepository
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Filesystem-only implementation of [TranslatedChapterRepository].
@@ -54,6 +55,31 @@ class TranslatedChapterRepositoryImpl(
         // Hex chars of the url MD5 appended to disambiguate chapters whose sanitized
         // names collide. 8 chars (~4.3B values) keeps per-novel collisions negligible.
         const val HASH_LENGTH = 8
+
+        // Process-wide per-novel monitors, mirroring QuoteManager's withNovelLock: serializes
+        // writes/relocations for the same novel so a rename/move can't race an in-flight upsert,
+        // and closes the read-side recovery race (see getTranslatedChapter).
+        val novelLocks = ConcurrentHashMap<String, Any>()
+    }
+
+    private fun novelLockKey(sourceName: String, novelTitle: String): String =
+        "${sourceDirName(sourceName)}/${novelDirName(novelTitle)}"
+
+    private fun <T> withNovelLock(sourceName: String, novelTitle: String, block: () -> T): T {
+        val lock = novelLocks.computeIfAbsent(novelLockKey(sourceName, novelTitle)) { Any() }
+        return synchronized(lock) { block() }
+    }
+
+    // Locks every distinct key in sorted order so two concurrent calls that reference the same
+    // pair of novels (e.g. a move and its reverse) always acquire locks in the same order.
+    private fun <T> withNovelLocks(keys: List<Pair<String, String>>, block: () -> T): T {
+        val lockKeys = keys.map { (s, t) -> novelLockKey(s, t) }.distinct().sorted()
+        fun lockNext(remaining: List<String>): T {
+            if (remaining.isEmpty()) return block()
+            val lock = novelLocks.computeIfAbsent(remaining.first()) { Any() }
+            return synchronized(lock) { lockNext(remaining.drop(1)) }
+        }
+        return lockNext(lockKeys)
     }
 
     /**
@@ -220,9 +246,13 @@ class TranslatedChapterRepositoryImpl(
     ): TranslatedChapter? = withContext(Dispatchers.IO) {
         val langDir = findLangDir(locator, targetLanguage) ?: return@withContext null
         val name = fileName(locator)
-        val file = langDir.findFile(name)?.takeIf { it.exists() }
-            ?: recoverPendingTranslation(langDir, name)
-            ?: return@withContext null
+        // Resolving (and possibly promoting a pending ".saving" scratch) under the same lock
+        // upsertTranslation uses for its own delete+rename finalize closes the race where a
+        // concurrent read could win the promotion and make the writer's own rename fail.
+        val file = withNovelLock(locator.sourceName, locator.novelTitle) {
+            langDir.findFile(name)?.takeIf { it.exists() }
+                ?: recoverPendingTranslation(langDir, name)
+        } ?: return@withContext null
         val meta = parseUniFile(file) ?: return@withContext null
         toTranslatedChapter(meta, targetLanguage)
     }
@@ -295,43 +325,47 @@ class TranslatedChapterRepositoryImpl(
 
     override suspend fun upsertTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter) =
         withContext(Dispatchers.IO) {
-            val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
-                ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
-            val name = fileName(locator)
-            val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
-            val content = (meta + translatedChapter.translatedContent).toByteArray()
+            withNovelLock(locator.sourceName, locator.novelTitle) {
+                val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
+                    ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
+                val name = fileName(locator)
+                val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
+                val content = (meta + translatedChapter.translatedContent).toByteArray()
 
-            // Write to a scratch file then swap it in so a crash mid-write can't leave a
-            // truncated translation. ".saving" is not read back (reads require ".html").
-            val savingName = "$name.saving"
-            dir.findFile(savingName)?.delete()
-            val scratch = dir.createFile(savingName)
-                ?: throw IllegalStateException("Failed to create translation file: $name")
-            scratch.openOutputStream().use { it.write(content) }
+                // Write to a scratch file then swap it in so a crash mid-write can't leave a
+                // truncated translation. ".saving" is not read back (reads require ".html").
+                val savingName = "$name.saving"
+                dir.findFile(savingName)?.delete()
+                val scratch = dir.createFile(savingName)
+                    ?: throw IllegalStateException("Failed to create translation file: $name")
+                scratch.openOutputStream().use { it.write(content) }
 
-            dir.findFile(name)?.delete()
-            if (!scratch.renameTo(name)) {
-                // Leave the scratch; getTranslatedChapter recovers it, so a failed rename
-                // (or a crash before this point) doesn't lose the just-written translation.
-                throw IllegalStateException("Failed to finalize translation file: $name")
+                dir.findFile(name)?.delete()
+                if (!scratch.renameTo(name)) {
+                    // Leave the scratch; getTranslatedChapter recovers it, so a failed rename
+                    // (or a crash before this point) doesn't lose the just-written translation.
+                    throw IllegalStateException("Failed to finalize translation file: $name")
+                }
+
+                dir.findFile(tmpFileName(locator))?.delete()
+                Unit
             }
-
-            dir.findFile(tmpFileName(locator))?.delete()
-            Unit
         }
 
     override suspend fun upsertTmpTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter) =
         withContext(Dispatchers.IO) {
-            val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
-                ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
-            val name = tmpFileName(locator)
-            val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
-            val content = (meta + translatedChapter.translatedContent).toByteArray()
+            withNovelLock(locator.sourceName, locator.novelTitle) {
+                val dir = getOrCreateLangDir(locator, translatedChapter.targetLanguage)
+                    ?: throw IllegalStateException("Failed to create translation dir for ${locator.novelTitle}")
+                val name = tmpFileName(locator)
+                val meta = buildMetaComment(translatedChapter.engineId, translatedChapter.dateTranslated)
+                val content = (meta + translatedChapter.translatedContent).toByteArray()
 
-            dir.findFile(name)?.delete()
-            val file = dir.createFile(name)
-                ?: throw IllegalStateException("Failed to create tmp translation file: $name")
-            file.openOutputStream().use { it.write(content) }
+                dir.findFile(name)?.delete()
+                val file = dir.createFile(name)
+                    ?: throw IllegalStateException("Failed to create tmp translation file: $name")
+                file.openOutputStream().use { it.write(content) }
+            }
         }
 
     override suspend fun getTmpTranslation(
@@ -347,26 +381,30 @@ class TranslatedChapterRepositoryImpl(
 
     override suspend fun deleteTranslation(locator: TranslationLocator, targetLanguage: String) =
         withContext(Dispatchers.IO) {
-            findLangDir(locator, targetLanguage)?.let { dir ->
-                val name = fileName(locator)
-                dir.findFile(name)?.delete()
-                dir.findFile("$name.saving")?.delete()
-                dir.findFile(tmpFileName(locator))?.delete()
+            withNovelLock(locator.sourceName, locator.novelTitle) {
+                findLangDir(locator, targetLanguage)?.let { dir ->
+                    val name = fileName(locator)
+                    dir.findFile(name)?.delete()
+                    dir.findFile("$name.saving")?.delete()
+                    dir.findFile(tmpFileName(locator))?.delete()
+                }
             }
             Unit
         }
 
     override suspend fun deleteAllForChapter(locator: TranslationLocator) = withContext(Dispatchers.IO) {
-        val novelDir = findNovelDir(locator.sourceName, locator.novelTitle) ?: return@withContext
-        val target = fileName(locator)
-        val tmp = tmpFileName(locator)
-        novelDir.listFiles()
-            ?.filter { it.isDirectory }
-            ?.forEach { langDir ->
-                langDir.findFile(target)?.delete()
-                langDir.findFile("$target.saving")?.delete()
-                langDir.findFile(tmp)?.delete()
-            }
+        withNovelLock(locator.sourceName, locator.novelTitle) {
+            val novelDir = findNovelDir(locator.sourceName, locator.novelTitle) ?: return@withNovelLock
+            val target = fileName(locator)
+            val tmp = tmpFileName(locator)
+            novelDir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.forEach { langDir ->
+                    langDir.findFile(target)?.delete()
+                    langDir.findFile("$target.saving")?.delete()
+                    langDir.findFile(tmp)?.delete()
+                }
+        }
         Unit
     }
 
@@ -376,46 +414,86 @@ class TranslatedChapterRepositoryImpl(
         chapters: Collection<ChapterRef>,
     ) = withContext(Dispatchers.IO) {
         if (chapters.isEmpty()) return@withContext
-        val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withContext
-        val wanted = chapters.flatMapTo(HashSet()) {
-            val base = chapterFileBase(it.name, it.url)
-            listOf("$base.html", "$base.html.saving", "$base.html.tmp")
-        }
-        novelDir.listFiles()
-            ?.filter { it.isDirectory }
-            ?.forEach { langDir ->
-                langDir.listFiles()
-                    ?.filter { it.name in wanted }
-                    ?.forEach { it.delete() }
+        withNovelLock(sourceName, novelTitle) {
+            val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withNovelLock
+            val wanted = chapters.flatMapTo(HashSet()) {
+                val base = chapterFileBase(it.name, it.url)
+                listOf("$base.html", "$base.html.saving", "$base.html.tmp")
             }
+            novelDir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.forEach { langDir ->
+                    langDir.listFiles()
+                        ?.filter { it.name in wanted }
+                        ?.forEach { it.delete() }
+                }
+        }
         Unit
     }
 
     override suspend fun deleteAllForManga(sourceName: String, novelTitle: String) = withContext(Dispatchers.IO) {
-        findNovelDir(sourceName, novelTitle)?.let { deleteRecursive(it) }
+        withNovelLock(sourceName, novelTitle) {
+            findNovelDir(sourceName, novelTitle)?.let { deleteRecursive(it) }
+        }
+        Unit
+    }
+
+    override suspend fun renameChapter(
+        sourceName: String,
+        novelTitle: String,
+        oldChapterName: String,
+        newChapterName: String,
+        chapterUrl: String,
+    ) = withContext(Dispatchers.IO) {
+        withNovelLock(sourceName, novelTitle) {
+            val oldBase = chapterFileBase(oldChapterName, chapterUrl)
+            val newBase = chapterFileBase(newChapterName, chapterUrl)
+            if (oldBase == newBase) return@withNovelLock
+            val novelDir = findNovelDir(sourceName, novelTitle) ?: return@withNovelLock
+            novelDir.listFiles()
+                ?.filter { it.isDirectory }
+                ?.forEach { langDir ->
+                    listOf(".html", ".html.saving", ".html.tmp").forEach { suffix ->
+                        val oldFile = langDir.findFile("$oldBase$suffix") ?: return@forEach
+                        val newName = "$newBase$suffix"
+                        if (langDir.findFile(newName) == null) {
+                            if (!oldFile.renameTo(newName)) {
+                                logcat(LogPriority.ERROR) {
+                                    "Failed to rename translation file '$oldBase$suffix' -> '$newName'"
+                                }
+                            }
+                        }
+                    }
+                }
+        }
         Unit
     }
 
     override suspend fun renameNovel(sourceName: String, oldTitle: String, newTitle: String) =
         withContext(Dispatchers.IO) {
-            val oldName = novelDirName(oldTitle)
-            val newName = novelDirName(newTitle)
-            if (oldName == newName) return@withContext
-            val srcDir = translationsDir.findFile(sourceDirName(sourceName)) ?: return@withContext
-            val oldDir = srcDir.findFile(oldName)?.takeIf { it.isDirectory && it.exists() } ?: return@withContext
-            val existing = srcDir.findFile(newName)
-            if (existing != null) {
-                // Deny if a non-empty dir already holds translations; only reclaim an empty one.
-                if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
-                    logcat(LogPriority.WARN) {
-                        "Translation dir '$newName' exists and is not empty; not renaming '$oldName'"
+            // Lock both the old and new keys so this can't race a concurrent upsert/delete
+            // targeting either the source or destination novel.
+            withNovelLocks(listOf(sourceName to oldTitle, sourceName to newTitle)) {
+                val oldName = novelDirName(oldTitle)
+                val newName = novelDirName(newTitle)
+                if (oldName == newName) return@withNovelLocks
+                val srcDir = translationsDir.findFile(sourceDirName(sourceName)) ?: return@withNovelLocks
+                val oldDir = srcDir.findFile(oldName)?.takeIf { it.isDirectory && it.exists() }
+                    ?: return@withNovelLocks
+                val existing = srcDir.findFile(newName)
+                if (existing != null) {
+                    // Deny if a non-empty dir already holds translations; only reclaim an empty one.
+                    if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
+                        logcat(LogPriority.WARN) {
+                            "Translation dir '$newName' exists and is not empty; not renaming '$oldName'"
+                        }
+                        return@withNovelLocks
                     }
-                    return@withContext
+                    existing.delete()
                 }
-                existing.delete()
-            }
-            if (!oldDir.renameTo(newName)) {
-                logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldName' -> '$newName'" }
+                if (!oldDir.renameTo(newName)) {
+                    logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldName' -> '$newName'" }
+                }
             }
             Unit
         }
@@ -426,44 +504,46 @@ class TranslatedChapterRepositoryImpl(
         newSourceName: String,
         newTitle: String,
     ) = withContext(Dispatchers.IO) {
-        val oldSrcName = sourceDirName(oldSourceName)
-        val newSrcName = sourceDirName(newSourceName)
-        val oldNovel = novelDirName(oldTitle)
-        val newNovel = novelDirName(newTitle)
-        if (oldSrcName == newSrcName && oldNovel == newNovel) return@withContext
+        withNovelLocks(listOf(oldSourceName to oldTitle, newSourceName to newTitle)) {
+            val oldSrcName = sourceDirName(oldSourceName)
+            val newSrcName = sourceDirName(newSourceName)
+            val oldNovel = novelDirName(oldTitle)
+            val newNovel = novelDirName(newTitle)
+            if (oldSrcName == newSrcName && oldNovel == newNovel) return@withNovelLocks
 
-        val oldDir = translationsDir.findFile(oldSrcName)?.findFile(oldNovel)
-            ?.takeIf { it.isDirectory && it.exists() } ?: return@withContext
-        val newSrcDir = translationsDir.findChildDir(newSrcName) ?: return@withContext
+            val oldDir = translationsDir.findFile(oldSrcName)?.findFile(oldNovel)
+                ?.takeIf { it.isDirectory && it.exists() } ?: return@withNovelLocks
+            val newSrcDir = translationsDir.findChildDir(newSrcName) ?: return@withNovelLocks
 
-        val existing = newSrcDir.findFile(newNovel)
-        if (existing != null) {
-            if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
-                logcat(LogPriority.WARN) {
-                    "Translation dir '$newSrcName/$newNovel' exists and is not empty; not moving"
+            val existing = newSrcDir.findFile(newNovel)
+            if (existing != null) {
+                if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
+                    logcat(LogPriority.WARN) {
+                        "Translation dir '$newSrcName/$newNovel' exists and is not empty; not moving"
+                    }
+                    return@withNovelLocks
                 }
-                return@withContext
+                existing.delete()
             }
-            existing.delete()
-        }
 
-        if (oldSrcName == newSrcName) {
-            // Same parent: a rename suffices (no cross-directory copy needed).
-            if (!oldDir.renameTo(newNovel)) {
-                logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldNovel' -> '$newNovel'" }
+            if (oldSrcName == newSrcName) {
+                // Same parent: a rename suffices (no cross-directory copy needed).
+                if (!oldDir.renameTo(newNovel)) {
+                    logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldNovel' -> '$newNovel'" }
+                }
+                return@withNovelLocks
             }
-            return@withContext
-        }
 
-        val destDir = newSrcDir.createDirectory(newNovel) ?: return@withContext
-        if (copyContentsRecursive(oldDir, destDir)) {
-            deleteRecursive(oldDir)
-        } else {
-            // Deleting the source after a partial copy would lose the un-copied translations.
-            // Keep it so the move can be retried; the half-written dest is denied on retry by the
-            // non-empty-existing guard above (or reclaimed once empty).
-            logcat(LogPriority.ERROR) {
-                "Copy incomplete moving '$oldSrcName/$oldNovel' -> '$newSrcName/$newNovel'; keeping source"
+            val destDir = newSrcDir.createDirectory(newNovel) ?: return@withNovelLocks
+            if (copyContentsRecursive(oldDir, destDir)) {
+                deleteRecursive(oldDir)
+            } else {
+                // Deleting the source after a partial copy would lose the un-copied translations.
+                // Keep it so the move can be retried; the half-written dest is denied on retry by
+                // the non-empty-existing guard above (or reclaimed once empty).
+                logcat(LogPriority.ERROR) {
+                    "Copy incomplete moving '$oldSrcName/$oldNovel' -> '$newSrcName/$newNovel'; keeping source"
+                }
             }
         }
         Unit

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -109,8 +109,8 @@ class TranslatedChapterRepositoryImpl(
     private fun novelDirName(novelTitle: String): String = DiskUtil.buildValidFilename(novelTitle)
 
     private fun chapterFileBase(chapterName: String, chapterUrl: String): String {
-        // Subtract 11 bytes to leave room for the "_<6 hex>" suffix.
-        val base = DiskUtil.buildValidFilename(chapterName, DiskUtil.MAX_FILE_NAME_BYTES - 11)
+        // Reserve bytes for the longest suffix we append: "_<6 hex>" + ".html.tmp".
+        val base = DiskUtil.buildValidFilename(chapterName, DiskUtil.MAX_FILE_NAME_BYTES - 16)
         return base + "_" + Hash.md5(chapterUrl).take(6)
     }
 

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -381,16 +381,72 @@ class TranslatedChapterRepositoryImpl(
             if (oldName == newName) return@withContext
             val srcDir = translationsDir.findFile(sourceDirName(sourceName)) ?: return@withContext
             val oldDir = srcDir.findFile(oldName)?.takeIf { it.isDirectory && it.exists() } ?: return@withContext
-            if (srcDir.findFile(newName) != null) {
-                // Destination already exists; renaming would clobber it. Leave both in place.
-                logcat(LogPriority.WARN) { "Translation dir '$newName' already exists; not renaming '$oldName'" }
-                return@withContext
+            val existing = srcDir.findFile(newName)
+            if (existing != null) {
+                // Deny if a non-empty dir already holds translations; only reclaim an empty one.
+                if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
+                    logcat(LogPriority.WARN) { "Translation dir '$newName' exists and is not empty; not renaming '$oldName'" }
+                    return@withContext
+                }
+                existing.delete()
             }
             if (!oldDir.renameTo(newName)) {
                 logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldName' -> '$newName'" }
             }
             Unit
         }
+
+    override suspend fun moveNovel(
+        oldSourceName: String,
+        oldTitle: String,
+        newSourceName: String,
+        newTitle: String,
+    ) = withContext(Dispatchers.IO) {
+        val oldSrcName = sourceDirName(oldSourceName)
+        val newSrcName = sourceDirName(newSourceName)
+        val oldNovel = novelDirName(oldTitle)
+        val newNovel = novelDirName(newTitle)
+        if (oldSrcName == newSrcName && oldNovel == newNovel) return@withContext
+
+        val oldDir = translationsDir.findFile(oldSrcName)?.findFile(oldNovel)
+            ?.takeIf { it.isDirectory && it.exists() } ?: return@withContext
+        val newSrcDir = translationsDir.findChildDir(newSrcName) ?: return@withContext
+
+        val existing = newSrcDir.findFile(newNovel)
+        if (existing != null) {
+            if (!existing.isDirectory || !existing.listFiles().isNullOrEmpty()) {
+                logcat(LogPriority.WARN) { "Translation dir '$newSrcName/$newNovel' exists and is not empty; not moving" }
+                return@withContext
+            }
+            existing.delete()
+        }
+
+        if (oldSrcName == newSrcName) {
+            // Same parent: a rename suffices (no cross-directory copy needed).
+            if (!oldDir.renameTo(newNovel)) {
+                logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldNovel' -> '$newNovel'" }
+            }
+            return@withContext
+        }
+
+        val destDir = newSrcDir.createDirectory(newNovel) ?: return@withContext
+        copyContentsRecursive(oldDir, destDir)
+        deleteRecursive(oldDir)
+        Unit
+    }
+
+    // SAF renameTo only renames within the same parent, so a cross-source move is copy-then-delete.
+    private fun copyContentsRecursive(src: UniFile, dest: UniFile) {
+        src.listFiles()?.forEach { child ->
+            val name = child.name ?: return@forEach
+            if (child.isDirectory) {
+                dest.findChildDir(name)?.let { copyContentsRecursive(child, it) }
+            } else {
+                val out = dest.createFile(name) ?: return@forEach
+                child.openInputStream().use { input -> out.openOutputStream().use { input.copyTo(it) } }
+            }
+        }
+    }
 
     override suspend fun deleteAll() = withContext(Dispatchers.IO) {
         translationsDir.listFiles()?.forEach { deleteRecursive(it) }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -217,9 +217,20 @@ class TranslatedChapterRepositoryImpl(
         locator: TranslationLocator,
         targetLanguage: String,
     ): TranslatedChapter? = withContext(Dispatchers.IO) {
-        val file = findLangDir(locator, targetLanguage)?.findFile(fileName(locator)) ?: return@withContext null
+        val langDir = findLangDir(locator, targetLanguage) ?: return@withContext null
+        val name = fileName(locator)
+        val file = langDir.findFile(name)?.takeIf { it.exists() }
+            ?: recoverPendingTranslation(langDir, name)
+            ?: return@withContext null
         val meta = parseUniFile(file) ?: return@withContext null
         toTranslatedChapter(meta, targetLanguage)
+    }
+
+    // If upsertTranslation crashed after deleting the destination but before renaming its scratch
+    // in, the data survives only as "<name>.saving". Promote it so no committed write is lost.
+    private fun recoverPendingTranslation(langDir: UniFile, name: String): UniFile? {
+        val scratch = langDir.findFile("$name.saving")?.takeIf { it.exists() } ?: return null
+        return if (scratch.renameTo(name)) langDir.findFile(name)?.takeIf { it.exists() } else null
     }
 
     override suspend fun getAllTranslationsForChapter(locator: TranslationLocator): List<TranslatedChapter> =
@@ -281,7 +292,8 @@ class TranslatedChapterRepositoryImpl(
 
             dir.findFile(name)?.delete()
             if (!scratch.renameTo(name)) {
-                scratch.delete()
+                // Leave the scratch; getTranslatedChapter recovers it, so a failed rename
+                // (or a crash before this point) doesn't lose the just-written translation.
                 throw IllegalStateException("Failed to finalize translation file: $name")
             }
 
@@ -361,6 +373,24 @@ class TranslatedChapterRepositoryImpl(
         findNovelDir(sourceName, novelTitle)?.let { deleteRecursive(it) }
         Unit
     }
+
+    override suspend fun renameNovel(sourceName: String, oldTitle: String, newTitle: String) =
+        withContext(Dispatchers.IO) {
+            val oldName = novelDirName(oldTitle)
+            val newName = novelDirName(newTitle)
+            if (oldName == newName) return@withContext
+            val srcDir = translationsDir.findFile(sourceDirName(sourceName)) ?: return@withContext
+            val oldDir = srcDir.findFile(oldName)?.takeIf { it.isDirectory && it.exists() } ?: return@withContext
+            if (srcDir.findFile(newName) != null) {
+                // Destination already exists; renaming would clobber it. Leave both in place.
+                logcat(LogPriority.WARN) { "Translation dir '$newName' already exists; not renaming '$oldName'" }
+                return@withContext
+            }
+            if (!oldDir.renameTo(newName)) {
+                logcat(LogPriority.ERROR) { "Failed to rename translation dir '$oldName' -> '$newName'" }
+            }
+            Unit
+        }
 
     override suspend fun deleteAll() = withContext(Dispatchers.IO) {
         translationsDir.listFiles()?.forEach { deleteRecursive(it) }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -109,7 +109,7 @@ class TranslatedChapterRepositoryImpl(
         }
     }
 
-    // ── Path helpers ──────────────────────────────────────────────────
+    // Path helpers
 
     private fun sourceDirName(sourceName: String): String =
         DiskUtil.buildValidFilename(sourceName).ifEmpty { "source" }
@@ -166,7 +166,7 @@ class TranslatedChapterRepositoryImpl(
         file.delete()
     }
 
-    // ── Metadata helpers ──────────────────────────────────────────────
+    // Metadata helpers
 
     private val metaPrefix = "<!-- tsundoku-meta:"
     private val metaSuffix = " -->"
@@ -212,7 +212,7 @@ class TranslatedChapterRepositoryImpl(
             dateTranslated = meta.dateTranslated,
         )
 
-    // ── Read operations ───────────────────────────────────────────────
+    // Read operations
 
     override suspend fun getTranslatedChapter(
         locator: TranslationLocator,
@@ -228,9 +228,16 @@ class TranslatedChapterRepositoryImpl(
     }
 
     // If upsertTranslation crashed after deleting the destination but before renaming its scratch
-    // in, the data survives only as "<name>.saving". Promote it so no committed write is lost.
+    // in, the data survives only as "<name>.saving". Promote it so no committed write is lost, but
+    // only when it holds content: a crash right after createFile leaves an empty/header-only scratch
+    // that must not be promoted and served as a complete translation.
     private fun recoverPendingTranslation(langDir: UniFile, name: String): UniFile? {
         val scratch = langDir.findFile("$name.saving")?.takeIf { it.exists() } ?: return null
+        val meta = parseUniFile(scratch)
+        if (meta == null || meta.content.isBlank()) {
+            scratch.delete()
+            return null
+        }
         return if (scratch.renameTo(name)) langDir.findFile(name)?.takeIf { it.exists() } else null
     }
 
@@ -251,7 +258,11 @@ class TranslatedChapterRepositoryImpl(
 
     override suspend fun hasTranslation(locator: TranslationLocator, targetLanguage: String): Boolean =
         withContext(Dispatchers.IO) {
-            findLangDir(locator, targetLanguage)?.findFile(fileName(locator)) != null
+            val langDir = findLangDir(locator, targetLanguage) ?: return@withContext false
+            val name = fileName(locator)
+            // A recoverable ".saving" scratch counts as translated so a crash before the final rename
+            // doesn't make the badge/skip-translated logic re-translate over the recovered write.
+            langDir.findFile(name) != null || langDir.findFile("$name.saving")?.exists() == true
         }
 
     override suspend fun filterTranslatedChapters(
@@ -263,10 +274,16 @@ class TranslatedChapterRepositoryImpl(
         if (chapters.isEmpty()) return@withContext emptySet()
         val langDir =
             findNovelDir(sourceName, novelTitle)?.findFile(langDirName(targetLanguage)) ?: return@withContext emptySet()
-        val present = langDir.listFiles()
-            ?.mapNotNull { it.name }
-            ?.filterTo(HashSet()) { it.endsWith(".html") && !it.endsWith(".html.tmp") }
-            ?: return@withContext emptySet()
+        val names = langDir.listFiles()?.mapNotNull { it.name } ?: return@withContext emptySet()
+        // Count a recoverable ".saving" scratch as its committed ".html" so a crashed-but-recoverable
+        // write isn't reported as untranslated.
+        val present = HashSet<String>()
+        names.forEach { n ->
+            when {
+                n.endsWith(".html.saving") -> present.add(n.removeSuffix(".saving"))
+                n.endsWith(".html") -> present.add(n)
+            }
+        }
         if (present.isEmpty()) return@withContext emptySet()
         chapters.asSequence()
             .filter { (chapterFileBase(it.name, it.url) + ".html") in present }
@@ -274,7 +291,7 @@ class TranslatedChapterRepositoryImpl(
             .toSet()
     }
 
-    // ── Write operations ──────────────────────────────────────────────
+    // Write operations
 
     override suspend fun upsertTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter) =
         withContext(Dispatchers.IO) {

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
@@ -149,7 +149,12 @@ class FindDuplicateNovels(
 
         val result = LinkedHashMap<String, List<MangaWithChapterCount>>()
         groupsByRoot.values.forEach { members ->
-            val key = members.first().manga.title.trim().lowercase().ifBlank { members.first().manga.id.toString() }
+            val representativeId = members.first().manga.id
+            val baseKey = members.first().manga.title.trim().lowercase().ifBlank { representativeId.toString() }
+            // Two distinct groups can share a base key (e.g. one group's blank-title fallback
+            // equals another group's literal title); disambiguate rather than silently
+            // overwriting and losing a whole duplicate group from the result.
+            val key = if (result.containsKey(baseKey)) "$baseKey#$representativeId" else baseKey
             result[key] = members.sortedByDescending { it.chapterCount }
         }
         return result

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -33,6 +33,8 @@ interface MangaRepository {
 
     suspend fun getMangaById(id: Long): Manga
 
+    suspend fun getMangaByIdOrNull(id: Long): Manga?
+
     suspend fun getMangasByIds(ids: List<Long>): List<Manga>
 
     suspend fun getMangaByIdAsFlow(id: Long): Flow<Manga>

--- a/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
@@ -37,33 +37,28 @@ class StubSource(
     override suspend fun getPageList(chapter: SChapter): List<Page> =
         throw SourceNotInstalledException()
 
-    // Must match JsSource.toString() so quotes/translations resolve to the same on-disk directory
-    // whether a source is currently loaded (JsSource) or stubbed (plugin not yet loaded). Novel
-    // sources are JS plugins here, which render as "Name (LANG) (JS)".
+    // Must match the loaded source's toString() so quotes/translations resolve to the same on-disk
+    // directory whether the source is currently loaded or only stubbed (plugin not yet loaded).
+    // Installed novel sources are JS plugins, rendering as "Name (LANG) (JS)"; the built-in local
+    // sources (ids 0/1) override toString() to their bare name with no lang/marker.
     override fun toString(): String = when {
         isInvalid -> id.toString()
+        id == LOCAL_SOURCE_ID || id == LOCAL_NOVEL_SOURCE_ID -> name
         isNovelSource -> "$name (${lang.uppercase()}) (JS)"
         else -> "$name (${lang.uppercase()})"
     }
 
     companion object {
+        // Kept in sync with LocalSource.ID (0) / LocalNovelSource.ID (1) in :source-local, which
+        // :domain cannot depend on. Their toString() is the bare name, unlike installed sources.
+        private const val LOCAL_SOURCE_ID = 0L
+        private const val LOCAL_NOVEL_SOURCE_ID = 1L
+
         fun from(source: Source): StubSource {
             return StubSource(
                 id = source.id,
                 lang = source.lang,
                 name = source.name,
-                isNovelSource = source.isNovelSource(),
-            )
-        }
-
-        /**
-         * Create a StubSource that preserves the full display name (including markers like "(JS)")
-         */
-        fun fromWithDisplayName(source: Source, displayName: String): StubSource {
-            return StubSource(
-                id = source.id,
-                lang = source.lang,
-                name = displayName,
                 isNovelSource = source.isNovelSource(),
             )
         }

--- a/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
@@ -37,8 +37,14 @@ class StubSource(
     override suspend fun getPageList(chapter: SChapter): List<Page> =
         throw SourceNotInstalledException()
 
-    override fun toString(): String =
-        if (!isInvalid) "$name (${lang.uppercase()})" else id.toString()
+    // Must match JsSource.toString() so quotes/translations resolve to the same on-disk directory
+    // whether a source is currently loaded (JsSource) or stubbed (plugin not yet loaded). Novel
+    // sources are JS plugins here, which render as "Name (LANG) (JS)".
+    override fun toString(): String = when {
+        isInvalid -> id.toString()
+        isNovelSource -> "$name (${lang.uppercase()}) (JS)"
+        else -> "$name (${lang.uppercase()})"
+    }
 
     companion object {
         fun from(source: Source): StubSource {

--- a/domain/src/main/java/tachiyomi/domain/translation/model/TranslationModels.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/model/TranslationModels.kt
@@ -1,6 +1,28 @@
 package tachiyomi.domain.translation.model
 
 /**
+ * Locates a translated chapter on disk using portable, human-readable identifiers
+ * (mirrors the download layout: source name / novel title / language / chapter).
+ * This is what makes translation files moveable between installs.
+ */
+data class TranslationLocator(
+    val sourceName: String,
+    val novelTitle: String,
+    val chapterName: String,
+    val chapterUrl: String,
+)
+
+/**
+ * Minimal chapter identity used for bulk translation lookups/deletes without pulling
+ * the full [tachiyomi.domain.chapter.model.Chapter].
+ */
+data class ChapterRef(
+    val id: Long,
+    val name: String,
+    val url: String,
+)
+
+/**
  * Represents a translated chapter stored on the filesystem.
  */
 data class TranslatedChapter(

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -1,47 +1,72 @@
 package tachiyomi.domain.translation.repository
 
+import tachiyomi.domain.translation.model.ChapterRef
 import tachiyomi.domain.translation.model.TranslatedChapter
+import tachiyomi.domain.translation.model.TranslationLocator
 
 /**
  * Repository interface for managing translated chapters.
- * All storage is filesystem-based (no database table).
+ *
+ * All storage is filesystem-based (no database table), keyed by a portable
+ * [TranslationLocator] (source name / novel title / chapter) plus a language code,
+ * so translation files can be moved between installs.
  */
 interface TranslatedChapterRepository {
 
     /**
-     * Get a translated chapter by chapter ID and target language.
+     * Get a translated chapter for a locator and target language.
      */
-    suspend fun getTranslatedChapter(chapterId: Long, targetLanguage: String): TranslatedChapter?
+    suspend fun getTranslatedChapter(locator: TranslationLocator, targetLanguage: String): TranslatedChapter?
 
     /**
-     * Get all translations for a chapter.
+     * Get all translations (every language) for a chapter locator.
      */
-    suspend fun getAllTranslationsForChapter(chapterId: Long): List<TranslatedChapter>
+    suspend fun getAllTranslationsForChapter(locator: TranslationLocator): List<TranslatedChapter>
 
     /**
      * Check if a chapter has a translation for a specific language.
      */
-    suspend fun hasTranslation(chapterId: Long, targetLanguage: String): Boolean
+    suspend fun hasTranslation(locator: TranslationLocator, targetLanguage: String): Boolean
 
     /**
-     * Get set of chapter IDs that have any translation, from the given candidate IDs.
+     * From the given candidate chapters (of one manga), return the ids that have a
+     * translation for [targetLanguage].
      */
-    suspend fun getTranslatedChapterIds(chapterIds: Collection<Long>): Set<Long>
-
-    /**
-     * Get all distinct languages across the given chapter IDs.
-     */
-    suspend fun getTranslatedLanguagesForChapters(chapterIds: Collection<Long>): List<String>
+    suspend fun filterTranslatedChapters(
+        sourceName: String,
+        novelTitle: String,
+        targetLanguage: String,
+        chapters: Collection<ChapterRef>,
+    ): Set<Long>
 
     /**
      * Insert or update a translated chapter.
      */
-    suspend fun upsertTranslation(translatedChapter: TranslatedChapter)
+    suspend fun upsertTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter)
 
     /**
-     * Delete a translation.
+     * Delete a translation for a specific language.
      */
-    suspend fun deleteTranslation(chapterId: Long, targetLanguage: String)
+    suspend fun deleteTranslation(locator: TranslationLocator, targetLanguage: String)
+
+    /**
+     * Delete all translations (every language) for a single chapter.
+     */
+    suspend fun deleteAllForChapter(locator: TranslationLocator)
+
+    /**
+     * Delete all translations for the given chapters of a manga.
+     */
+    suspend fun deleteAllForChapters(
+        sourceName: String,
+        novelTitle: String,
+        chapters: Collection<ChapterRef>,
+    )
+
+    /**
+     * Delete every translation for a whole manga (all chapters, all languages).
+     */
+    suspend fun deleteAllForManga(sourceName: String, novelTitle: String)
 
     /**
      * Delete all translations.
@@ -49,48 +74,17 @@ interface TranslatedChapterRepository {
     suspend fun deleteAll()
 
     /**
-     * Get all translations.
-     */
-    suspend fun getAll(): List<TranslatedChapter>
-
-    /**
-     * Delete all translations for a chapter.
-     */
-    suspend fun deleteAllForChapter(chapterId: Long)
-
-    /**
-     * Delete all translations for chapters belonging to a manga.
-     */
-    suspend fun deleteAllForChapters(chapterIds: Collection<Long>)
-
-    /**
-     * Get the total cache size in bytes.
-     */
-    suspend fun getCacheSize(): Long
-
-    /**
-     * Clear old cached translations.
-     */
-    suspend fun clearOldCache(olderThan: Long)
-
-    /**
-     * Clear temporary (.tmp) translation files.
-     * Returns the number of bytes freed.
+     * Clear temporary (.tmp) translation files. Returns the number of bytes freed.
      */
     suspend fun clearTmpFiles(): Long
 
     /**
      * Insert or update a partial (.tmp) translation (for resume support).
      */
-    suspend fun upsertTmpTranslation(translatedChapter: TranslatedChapter)
+    suspend fun upsertTmpTranslation(locator: TranslationLocator, translatedChapter: TranslatedChapter)
 
     /**
      * Get a partial (.tmp) translation if one exists.
      */
-    suspend fun getTmpTranslation(chapterId: Long, targetLanguage: String): TranslatedChapter?
-
-    /**
-     * Check if a partial (.tmp) translation exists.
-     */
-    suspend fun hasTmpTranslation(chapterId: Long, targetLanguage: String): Boolean
+    suspend fun getTmpTranslation(locator: TranslationLocator, targetLanguage: String): TranslatedChapter?
 }

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -24,6 +24,18 @@ interface TranslatedChapterRepository {
     suspend fun getAllTranslationsForChapter(locator: TranslationLocator): List<TranslatedChapter>
 
     /**
+     * Batched form of [getAllTranslationsForChapter] for a whole novel: resolves the novel
+     * directory and lists each language dir once, then maps every candidate chapter to its
+     * translations (all languages) keyed by [ChapterRef.id]. Avoids the per-chapter directory
+     * scan of calling [getAllTranslationsForChapter] in a loop.
+     */
+    suspend fun getAllTranslationsForNovel(
+        sourceName: String,
+        novelTitle: String,
+        chapters: Collection<ChapterRef>,
+    ): Map<Long, List<TranslatedChapter>>
+
+    /**
      * Check if a chapter has a translation for a specific language.
      */
     suspend fun hasTranslation(locator: TranslationLocator, targetLanguage: String): Boolean

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -69,6 +69,11 @@ interface TranslatedChapterRepository {
     suspend fun deleteAllForManga(sourceName: String, novelTitle: String)
 
     /**
+     * Move a novel's translations when its title changes (translations are keyed by title on disk).
+     */
+    suspend fun renameNovel(sourceName: String, oldTitle: String, newTitle: String)
+
+    /**
      * Delete all translations.
      */
     suspend fun deleteAll()

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -74,6 +74,18 @@ interface TranslatedChapterRepository {
     suspend fun renameNovel(sourceName: String, oldTitle: String, newTitle: String)
 
     /**
+     * Move a chapter's translation files (every language) when a source renames the chapter,
+     * mirroring DownloadManager.renameChapter for downloads.
+     */
+    suspend fun renameChapter(
+        sourceName: String,
+        novelTitle: String,
+        oldChapterName: String,
+        newChapterName: String,
+        chapterUrl: String,
+    )
+
+    /**
      * Move a novel's translations to a different source and/or title (e.g. on migration).
      * Denies the move if a non-empty destination already exists.
      */

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -74,6 +74,12 @@ interface TranslatedChapterRepository {
     suspend fun renameNovel(sourceName: String, oldTitle: String, newTitle: String)
 
     /**
+     * Move a novel's translations to a different source and/or title (e.g. on migration).
+     * Denies the move if a non-empty destination already exists.
+     */
+    suspend fun moveNovel(oldSourceName: String, oldTitle: String, newSourceName: String, newTitle: String)
+
+    /**
      * Delete all translations.
      */
     suspend fun deleteAll()

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1211,6 +1211,12 @@
     <string name="pref_delete_all_translations_subtitle">Deletes all downloaded translations</string>
     <string name="pref_delete_all_translations_confirm">Are you sure you want to delete all downloaded translations? This cannot be undone.</string>
     <string name="pref_all_translations_deleted">All translations deleted</string>
+    <string name="pref_migrate_quotes_portable">Migrate quotes to portable storage</string>
+    <string name="pref_migrate_quotes_portable_subtitle">Move id-based quote files to the source/title layout</string>
+    <string name="pref_migrate_translations_portable">Migrate translations to portable storage</string>
+    <string name="pref_migrate_translations_portable_subtitle">Move id-based translation files to the source/novel/language layout</string>
+    <string name="pref_portable_migration_done">Migrated %d file(s)</string>
+    <string name="pref_portable_migration_error">Migration failed</string>
     <string name="pref_clear_temp_files">Clear temp files</string>
     <string name="pref_clear_temp_files_subtitle">Clears temporary files from app cache (epub exports, network cache, etc.)</string>
     <string name="pref_temp_files_cleared">Cleared %s of temp files</string>


### PR DESCRIPTION


**Translations** — was `translations/{chapterId}_{lang}.html`, now:
```
translations/<source>/<novel>/<lang>/<chapterName>_<md5(url)>.html
```


**Quotes** — was `quotes/novel_<id>.json` (with a redundant `novelId`), now:
```
quotes/<source>/<title>.json
```
Badging is now **target-language-specific** via `filterTranslatedChapters(...)`: switching target language changes which chapters show a translated badge.


### Quotes
- `novelId` removed from `NovelQuotes`; `Quote` gains a 0-based `paragraphIndex` captured at "remember" time in both viewers.
- Saves use a temp-file-then-rename swap to avoid corruption/duplication.
- Paragraph number surfaced in the QuotesSheet header (`¶N`).
- Redundant `novelName` dropped from the `Quote` model.

### Migration
- `QuotesPortableMigrator` / `TranslationsPortableMigrator` convert legacy layouts to the new one, found in Advanced settings.

