### PR TITLE
Feat/library alt titles

### DIFF
--- a/.github/workflows/lint-translations.yml
+++ b/.github/workflows/lint-translations.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Install xmllint
+        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+
       - name: xmllint locale resources
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - A ton of Arabic translations [@OtakuArab](https://github.com/OtakuArab) [#327](https://github.com/tsundoku-otaku/tsundoku/pull/327)
+- Alt titles are now searchable [@mrissaoussama](https://github.com/mrissaoussama) [#337](https://github.com/tsundoku-otaku/tsundoku/pull/337)
 - Novel download queue improvements to prevent errors [@mrissaoussama](https://github.com/mrissaoussama) [#284](https://github.com/tsundoku-otaku/tsundoku/pull/284)
 - Reader status bar reordering + more [@mrissaoussama](https://github.com/mrissaoussama) [#318](https://github.com/tsundoku-otaku/tsundoku/pull/318)
 - Some great improvements to custom sources, including {novelUrl} [@mrissaoussama](https://github.com/mrissaoussama) [#296](https://github.com/tsundoku-otaku/tsundoku/pull/296)

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -256,6 +256,10 @@ private fun ColumnScope.FilterPage(
         pref = screenModel.libraryPreferences.searchChapterContent,
     )
     CheckboxItem(
+        label = "Search alternative titles",
+        pref = screenModel.libraryPreferences.searchAlternativeTitles,
+    )
+    CheckboxItem(
         label = "Search by URL",
         pref = screenModel.libraryPreferences.searchByUrl,
     )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -152,6 +152,11 @@ fun EditMangaDialog(
                         onAltTitlesChange = { altTitles = it },
                         onSwapMainTitle = onSwapMainTitle?.let { swap ->
                             { newMain, updatedAlts ->
+                                // Title/alt-titles are persisted by swap() itself; other tabs'
+                                // edits are not, so save them explicitly before the guard below
+                                // skips the normal onDismissRequest save path.
+                                onSaveUrl(url)
+                                onSaveInfo(description, tags, author, artist, status)
                                 didSwapMainTitle = true
                                 swap(newMain, updatedAlts)
                                 onDismissRequest()

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -385,8 +385,10 @@ private fun EditAltTitlesTab(
     // Reject a new alt title that duplicates the main title or an existing alt (case-insensitive),
     // matching the lower(trim(...)) comparison used by duplicate detection.
     val isDuplicate = trimmedNew.isNotEmpty() &&
-        (mainTitle.trim().equals(trimmedNew, ignoreCase = true) ||
-            altTitles.any { it.trim().equals(trimmedNew, ignoreCase = true) })
+        (
+            mainTitle.trim().equals(trimmedNew, ignoreCase = true) ||
+                altTitles.any { it.trim().equals(trimmedNew, ignoreCase = true) }
+            )
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -30,6 +32,7 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,6 +40,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.TabTitle
@@ -364,6 +369,8 @@ private fun EditAltTitlesTab(
     onSwapMainTitle: ((String, List<String>) -> Unit)? = null,
 ) {
     var newTitle by remember { mutableStateOf("") }
+    var pendingDelete by remember { mutableStateOf<Int?>(null) }
+    val clipboardManager = LocalClipboardManager.current
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
@@ -410,6 +417,14 @@ private fun EditAltTitlesTab(
                         modifier = Modifier.weight(1f),
                         style = MaterialTheme.typography.bodyMedium,
                     )
+                    IconButton(
+                        onClick = { clipboardManager.setText(AnnotatedString(title)) },
+                    ) {
+                        Icon(
+                            Icons.Outlined.ContentCopy,
+                            contentDescription = stringResource(MR.strings.action_copy_to_clipboard),
+                        )
+                    }
                     if (onSwapMainTitle != null && mainTitle.isNotEmpty()) {
                         IconButton(
                             onClick = {
@@ -428,9 +443,7 @@ private fun EditAltTitlesTab(
                         }
                     }
                     IconButton(
-                        onClick = {
-                            onAltTitlesChange(altTitles.toMutableList().apply { removeAt(index) })
-                        },
+                        onClick = { pendingDelete = index },
                     ) {
                         Icon(
                             Icons.Outlined.Delete,
@@ -441,5 +454,33 @@ private fun EditAltTitlesTab(
                 }
             }
         }
+    }
+
+    pendingDelete?.let { index ->
+        val title = altTitles.getOrNull(index)
+        if (title == null) {
+            pendingDelete = null
+            return@let
+        }
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text(stringResource(MR.strings.action_delete)) },
+            text = { Text(title) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onAltTitlesChange(altTitles.toMutableList().apply { removeAt(index) })
+                        pendingDelete = null
+                    },
+                ) {
+                    Text(stringResource(MR.strings.action_ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text(stringResource(MR.strings.action_cancel))
+                }
+            },
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -80,6 +80,7 @@ fun EditMangaDialog(
     var author by remember { mutableStateOf(manga.author.orEmpty()) }
     var artist by remember { mutableStateOf(manga.artist.orEmpty()) }
     var status by remember { mutableStateOf(manga.status) }
+    var didSwapMainTitle by remember { mutableStateOf(false) }
 
     val tabTitles = listOf(
         TabTitle.Text(stringResource(MR.strings.pref_category_general)),
@@ -88,10 +89,12 @@ fun EditMangaDialog(
 
     TabbedDialog(
         onDismissRequest = {
-            onSaveTitle(title)
-            onSaveUrl(url)
-            onSaveAltTitles(altTitles)
-            onSaveInfo(description, tags, author, artist, status)
+            if (!didSwapMainTitle) {
+                onSaveTitle(title)
+                onSaveUrl(url)
+                onSaveAltTitles(altTitles)
+                onSaveInfo(description, tags, author, artist, status)
+            }
             onDismissRequest()
         },
         tabTitles = tabTitles,
@@ -144,11 +147,12 @@ fun EditMangaDialog(
                         onTagsChange = { tags = it },
                     )
                     EditAltTitlesTab(
-                        mainTitle = manga.title,
+                        mainTitle = title,
                         altTitles = altTitles,
                         onAltTitlesChange = { altTitles = it },
                         onSwapMainTitle = onSwapMainTitle?.let { swap ->
                             { newMain, updatedAlts ->
+                                didSwapMainTitle = true
                                 swap(newMain, updatedAlts)
                                 onDismissRequest()
                             }
@@ -372,6 +376,13 @@ private fun EditAltTitlesTab(
     var pendingDelete by remember { mutableStateOf<Int?>(null) }
     val clipboardManager = LocalClipboardManager.current
 
+    val trimmedNew = newTitle.trim()
+    // Reject a new alt title that duplicates the main title or an existing alt (case-insensitive),
+    // matching the lower(trim(...)) comparison used by duplicate detection.
+    val isDuplicate = trimmedNew.isNotEmpty() &&
+        (mainTitle.trim().equals(trimmedNew, ignoreCase = true) ||
+            altTitles.any { it.trim().equals(trimmedNew, ignoreCase = true) })
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -383,15 +394,21 @@ private fun EditAltTitlesTab(
                 modifier = Modifier.weight(1f),
                 label = { Text("New title") },
                 singleLine = true,
+                isError = isDuplicate,
+                supportingText = if (isDuplicate) {
+                    { Text("Title already exists") }
+                } else {
+                    null
+                },
             )
             IconButton(
                 onClick = {
-                    if (newTitle.isNotBlank()) {
-                        onAltTitlesChange(altTitles + newTitle.trim())
+                    if (trimmedNew.isNotEmpty() && !isDuplicate) {
+                        onAltTitlesChange(altTitles + trimmedNew)
                         newTitle = ""
                     }
                 },
-                enabled = newTitle.isNotBlank(),
+                enabled = trimmedNew.isNotEmpty() && !isDuplicate,
             ) {
                 Icon(Icons.Outlined.Add, contentDescription = "Add")
             }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -369,7 +369,7 @@ private fun EditAltTitlesTab(
     onSwapMainTitle: ((String, List<String>) -> Unit)? = null,
 ) {
     var newTitle by remember { mutableStateOf("") }
-    var pendingDelete by remember { mutableStateOf<String?>(null) }
+    var pendingDelete by remember { mutableStateOf<Int?>(null) }
     val clipboardManager = LocalClipboardManager.current
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -443,7 +443,7 @@ private fun EditAltTitlesTab(
                         }
                     }
                     IconButton(
-                        onClick = { pendingDelete = title },
+                        onClick = { pendingDelete = index },
                     ) {
                         Icon(
                             Icons.Outlined.Delete,
@@ -456,9 +456,9 @@ private fun EditAltTitlesTab(
         }
     }
 
-    pendingDelete?.let { title ->
-        val index = altTitles.indexOf(title)
-        if (index < 0) {
+    pendingDelete?.let { index ->
+        val title = altTitles.getOrNull(index)
+        if (title == null) {
             pendingDelete = null
             return@let
         }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/EditMangaDialog.kt
@@ -369,7 +369,7 @@ private fun EditAltTitlesTab(
     onSwapMainTitle: ((String, List<String>) -> Unit)? = null,
 ) {
     var newTitle by remember { mutableStateOf("") }
-    var pendingDelete by remember { mutableStateOf<Int?>(null) }
+    var pendingDelete by remember { mutableStateOf<String?>(null) }
     val clipboardManager = LocalClipboardManager.current
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -443,7 +443,7 @@ private fun EditAltTitlesTab(
                         }
                     }
                     IconButton(
-                        onClick = { pendingDelete = index },
+                        onClick = { pendingDelete = title },
                     ) {
                         Icon(
                             Icons.Outlined.Delete,
@@ -456,9 +456,9 @@ private fun EditAltTitlesTab(
         }
     }
 
-    pendingDelete?.let { index ->
-        val title = altTitles.getOrNull(index)
-        if (title == null) {
+    pendingDelete?.let { title ->
+        val index = altTitles.indexOf(title)
+        if (index < 0) {
             pendingDelete = null
             return@let
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -115,6 +115,7 @@ private fun Manga.toBackupManga() =
         author = this.author,
         description = this.description,
         genre = this.genre.orEmpty(),
+        alternativeTitles = this.alternativeTitles,
         status = this.status.toInt(),
         thumbnailUrl = this.thumbnailUrl,
         favorite = this.favorite,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -48,6 +48,7 @@ class BackupManga(
     @ProtoNumber(112) var memo: ByteArray = JsonObjectEmptyBytes,
     // Fork fields use a reserved 8000+ ProtoNumber block so they never collide with new upstream fields.
     @ProtoNumber(8000) var isNovel: Boolean = false,
+    @ProtoNumber(8001) var alternativeTitles: List<String> = emptyList(),
 ) {
     fun getMangaImpl(): Manga {
         return Manga.create().copy(
@@ -57,6 +58,7 @@ class BackupManga(
             author = this@BackupManga.author,
             description = this@BackupManga.description,
             genre = this@BackupManga.genre,
+            alternativeTitles = this@BackupManga.alternativeTitles,
             status = this@BackupManga.status.toLong(),
             thumbnailUrl = this@BackupManga.thumbnailUrl,
             favorite = this@BackupManga.favorite,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupTracking
 import tachiyomi.data.Database
 import tachiyomi.data.MemoColumnAdapter
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.domain.category.interactor.GetCategories
@@ -155,7 +156,7 @@ class MangaRestorer(
             notes = manga.notes,
             alternativeTitles = manga.alternativeTitles.takeIf {
                 it.isNotEmpty()
-            }?.let { StringListColumnAdapter.encode(it) },
+            }?.let { AlternativeTitlesColumnAdapter.encode(it) },
             isNovel = manga.isNovel,
             memo = manga.memo.let(MemoColumnAdapter::encode),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -8,10 +8,9 @@ import eu.kanade.tachiyomi.data.backup.models.BackupChapter
 import eu.kanade.tachiyomi.data.backup.models.BackupHistory
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupTracking
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.Database
 import tachiyomi.data.MemoColumnAdapter
-import tachiyomi.data.AlternativeTitlesColumnAdapter
-import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -39,6 +39,7 @@ import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import tachiyomi.core.common.storage.AndroidStorageFolderProvider
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.Chapters
 import tachiyomi.data.Database
 import tachiyomi.data.DatabaseMaintenance
@@ -46,7 +47,6 @@ import tachiyomi.data.DateColumnAdapter
 import tachiyomi.data.History
 import tachiyomi.data.Mangas
 import tachiyomi.data.MemoColumnAdapter
-import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.domain.source.service.SourceManager

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -46,6 +46,7 @@ import tachiyomi.data.DateColumnAdapter
 import tachiyomi.data.History
 import tachiyomi.data.Mangas
 import tachiyomi.data.MemoColumnAdapter
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.domain.source.service.SourceManager
@@ -96,7 +97,7 @@ class AppModule(val app: Application) : InjektModule {
                 mangasAdapter = Mangas.Adapter(
                     genreAdapter = StringListColumnAdapter,
                     update_strategyAdapter = UpdateStrategyColumnAdapter,
-                    alternative_titlesAdapter = StringListColumnAdapter,
+                    alternative_titlesAdapter = AlternativeTitlesColumnAdapter,
                     memoAdapter = MemoColumnAdapter,
                 ),
                 chaptersAdapter = Chapters.Adapter(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -103,10 +103,11 @@ data class LibraryItem(
         }
         if (inMemoryMatch) return true
 
-        // Author/artist/description/chapter live in the DB; their id-sets cover the whole query.
+        // Author/artist/description/alt-title/chapter live in the DB; their id-sets cover the whole query.
         return metadataMatchIds.author.contains(id) ||
             metadataMatchIds.artist.contains(id) ||
             metadataMatchIds.description.contains(id) ||
+            metadataMatchIds.altTitle.contains(id) ||
             chapterMatchIds.contains(id)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -199,7 +199,8 @@ class LibraryScreenModel(
                 searchQueryFlow,
                 libraryPreferences.searchChapterContent.changes(),
                 libraryPreferences.useRegexSearch.changes(),
-            ) { query, searchContent, useRegex ->
+                libraryPreferences.searchAlternativeTitles.changes(),
+            ) { query, searchContent, useRegex, searchAltTitles ->
                 if (query.isNullOrEmpty()) {
                     MetadataMatchIds()
                 } else {
@@ -208,6 +209,7 @@ class LibraryScreenModel(
                         author: Boolean = false,
                         artist: Boolean = false,
                         description: Boolean = false,
+                        altTitle: Boolean = false,
                     ): MetadataMatchIds {
                         val matches = withIOContext {
                             searchMangaMetadata.await(
@@ -216,12 +218,14 @@ class LibraryScreenModel(
                                 searchAuthor = author,
                                 searchArtist = artist,
                                 searchDescription = description,
+                                searchAltTitle = altTitle,
                             )
                         }
                         return MetadataMatchIds(
                             author = matches.author,
                             artist = matches.artist,
                             description = matches.description,
+                            altTitle = matches.altTitle,
                         )
                     }
                     when (parsed.field) {
@@ -232,7 +236,7 @@ class LibraryScreenModel(
                         // default (non-prefixed) search, where it adds an expensive full-text scan.
                         LibrarySearchSpec.Field.DESCRIPTION -> ids(description = true)
                         LibrarySearchSpec.Field.DEFAULT ->
-                            ids(author = true, artist = true, description = searchContent)
+                            ids(author = true, artist = true, description = searchContent, altTitle = searchAltTitles)
                         else -> MetadataMatchIds()
                     }
                 }
@@ -1247,6 +1251,7 @@ class LibraryScreenModel(
             filterChapterCountThreshold = prefs.filterChapterCountThreshold,
             excludedSourceIds = prefs.excludedExtensions.mapNotNull { it.toLongOrNull() },
             searchTerm = term,
+            searchAlternativeTitles = libraryPreferences.searchAlternativeTitles.get(),
             includedTagsCsv = includedTagsCsvFor(prefs),
         )
         val map = HashMap<Pair<Long, Boolean>, LibraryPageSpec>()
@@ -2071,6 +2076,7 @@ class LibraryScreenModel(
         val author: Set<Long> = emptySet(),
         val artist: Set<Long> = emptySet(),
         val description: Set<Long> = emptySet(),
+        val altTitle: Set<Long> = emptySet(),
     )
 
     @Immutable

--- a/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
+++ b/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
@@ -48,6 +48,37 @@ object StringListColumnAdapter : ColumnAdapter<List<String>, String> {
     )
 }
 
+// Alternative titles frequently contain ", " (e.g. "Vol. 1, Part 2"), which the
+// legacy ", " separator would wrongly split into multiple entries. Use the
+// non-printable unit separator so any punctuation inside a title is preserved.
+private const val ALT_TITLES_SEPARATOR = ""
+object AlternativeTitlesColumnAdapter : ColumnAdapter<List<String>, String> {
+    override fun decode(databaseValue: String): List<String> {
+        if (databaseValue.isEmpty()) return emptyList()
+
+        if (databaseValue.length > MAX_DECODED_STRING_LIST_LENGTH) {
+            logcat(LogPriority.WARN) {
+                "AlternativeTitlesColumnAdapter: dropping oversized value (len=${databaseValue.length}) to avoid OOM"
+            }
+            return emptyList()
+        }
+
+        val values = databaseValue
+            .splitToSequence(ALT_TITLES_SEPARATOR)
+            .filter { it.isNotBlank() }
+            .take(MAX_DECODED_STRING_LIST_ITEMS + 1)
+            .toList()
+
+        return if (values.size > MAX_DECODED_STRING_LIST_ITEMS) {
+            values.take(MAX_DECODED_STRING_LIST_ITEMS)
+        } else {
+            values
+        }
+    }
+
+    override fun encode(value: List<String>) = value.joinToString(separator = ALT_TITLES_SEPARATOR)
+}
+
 object UpdateStrategyColumnAdapter : ColumnAdapter<UpdateStrategy, Long> {
     override fun decode(databaseValue: Long): UpdateStrategy =
         UpdateStrategy.entries.getOrElse(databaseValue.toInt()) { UpdateStrategy.ALWAYS_UPDATE }

--- a/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
+++ b/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
@@ -77,7 +77,12 @@ object AlternativeTitlesColumnAdapter : ColumnAdapter<List<String>, String> {
         }
     }
 
-    override fun encode(value: List<String>) = value.joinToString(separator = ALT_TITLES_SEPARATOR)
+    // Trim + drop blanks symmetrically with decode so stored entries have exact char(31) boundaries;
+    // the duplicate-detection SQL (instr on char(31)-wrapped values) fails to match otherwise.
+    override fun encode(value: List<String>) = value
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .joinToString(separator = ALT_TITLES_SEPARATOR)
 }
 
 object UpdateStrategyColumnAdapter : ColumnAdapter<UpdateStrategy, Long> {

--- a/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
+++ b/data/src/main/java/tachiyomi/data/DatabaseAdapter.kt
@@ -65,7 +65,8 @@ object AlternativeTitlesColumnAdapter : ColumnAdapter<List<String>, String> {
 
         val values = databaseValue
             .splitToSequence(ALT_TITLES_SEPARATOR)
-            .filter { it.isNotBlank() }
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
             .take(MAX_DECODED_STRING_LIST_ITEMS + 1)
             .toList()
 

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -15,6 +15,7 @@ import mihon.core.common.extensions.EMPTY
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.data.Database
 import tachiyomi.data.MemoColumnAdapter
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.data.subscribeToList
@@ -29,6 +30,7 @@ import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.repository.DuplicateGroup
 import tachiyomi.domain.manga.repository.DuplicatePair
+import tachiyomi.domain.manga.repository.FavoriteMetadataMatches
 import tachiyomi.domain.manga.repository.MangaRepository
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -820,6 +822,7 @@ class MangaRepositoryImpl(
             chapterCountThreshold = spec.filterChapterCountThreshold.toLong(),
             excludedSourceIds = excluded,
             searchTerm = spec.searchTerm,
+            searchAltTitles = if (spec.searchAlternativeTitles) 1L else 0L,
             includedTagsCsv = spec.includedTagsCsv,
             sortType = spec.sortType.toLong(),
             sortAscending = if (spec.sortAscending) 1L else 0L,
@@ -1225,8 +1228,13 @@ class MangaRepositoryImpl(
         }.subscribeToList()
     }
 
-    override suspend fun getDuplicateLibraryManga(id: Long, title: String): List<MangaWithChapterCount> {
-        return database.mangasQueries.getDuplicateLibraryManga(id, title) {
+    override suspend fun getDuplicateLibraryManga(
+        id: Long,
+        title: String,
+        altTitles: List<String>,
+    ): List<MangaWithChapterCount> {
+        val altTitlesEncoded = altTitles.takeIf { it.isNotEmpty() }?.let(AlternativeTitlesColumnAdapter::encode).orEmpty()
+        return database.mangasQueries.getDuplicateLibraryManga(id, title, altTitlesEncoded) {
                 id,
                 source,
                 url,
@@ -1318,20 +1326,25 @@ class MangaRepositoryImpl(
         matchAuthor: ((String) -> Boolean)?,
         matchArtist: ((String) -> Boolean)?,
         matchDescription: ((String) -> Boolean)?,
-    ): Triple<Set<Long>, Set<Long>, Set<Long>> {
+        matchAltTitle: ((List<String>) -> Boolean)?,
+    ): FavoriteMetadataMatches {
         val authorIds = HashSet<Long>()
         val artistIds = HashSet<Long>()
         val descriptionIds = HashSet<Long>()
+        val altTitleIds = HashSet<Long>()
         // Side-effecting mapper: each row's strings are matched and discarded as the cursor
         // streams, so the full favorite metadata is never held in memory at once.
-        database.mangasQueries.getFavoriteMetadataForSearch { id, author, artist, description ->
+        database.mangasQueries.getFavoriteMetadataForSearch { id, author, artist, description, altTitles ->
             if (matchAuthor != null && author != null && matchAuthor(author)) authorIds.add(id)
             if (matchArtist != null && artist != null && matchArtist(artist)) artistIds.add(id)
             if (matchDescription != null && description != null && matchDescription(description)) {
                 descriptionIds.add(id)
             }
+            if (matchAltTitle != null && !altTitles.isNullOrEmpty() && matchAltTitle(altTitles)) {
+                altTitleIds.add(id)
+            }
         }.awaitAsList()
-        return Triple(authorIds, artistIds, descriptionIds)
+        return FavoriteMetadataMatches(authorIds, artistIds, descriptionIds, altTitleIds)
     }
 
     override suspend fun getFavoriteIdAndTitle(): List<Pair<Long, String>> {
@@ -1765,7 +1778,7 @@ class MangaRepositoryImpl(
                     description = value.description,
                     genre = genre?.let(StringListColumnAdapter::encode),
                     title = value.title,
-                    alternativeTitles = value.alternativeTitles?.let(StringListColumnAdapter::encode),
+                    alternativeTitles = value.alternativeTitles?.let(AlternativeTitlesColumnAdapter::encode),
                     status = value.status,
                     thumbnailUrl = value.thumbnailUrl,
                     favorite = value.favorite,

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -13,9 +13,9 @@ import kotlinx.serialization.json.JsonObject
 import logcat.LogPriority
 import mihon.core.common.extensions.EMPTY
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.Database
 import tachiyomi.data.MemoColumnAdapter
-import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.StringListColumnAdapter
 import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.data.subscribeToList

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1233,7 +1233,9 @@ class MangaRepositoryImpl(
         title: String,
         altTitles: List<String>,
     ): List<MangaWithChapterCount> {
-        val altTitlesEncoded = altTitles.takeIf { it.isNotEmpty() }?.let(AlternativeTitlesColumnAdapter::encode).orEmpty()
+        val altTitlesEncoded = altTitles.takeIf {
+            it.isNotEmpty()
+        }?.let(AlternativeTitlesColumnAdapter::encode).orEmpty()
         return database.mangasQueries.getDuplicateLibraryManga(id, title, altTitlesEncoded) {
                 id,
                 source,

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1336,16 +1336,26 @@ class MangaRepositoryImpl(
         val altTitleIds = HashSet<Long>()
         // Side-effecting mapper: each row's strings are matched and discarded as the cursor
         // streams, so the full favorite metadata is never held in memory at once.
-        database.mangasQueries.getFavoriteMetadataForSearch { id, author, artist, description, altTitles ->
-            if (matchAuthor != null && author != null && matchAuthor(author)) authorIds.add(id)
-            if (matchArtist != null && artist != null && matchArtist(artist)) artistIds.add(id)
-            if (matchDescription != null && description != null && matchDescription(description)) {
-                descriptionIds.add(id)
-            }
-            if (matchAltTitle != null && !altTitles.isNullOrEmpty() && matchAltTitle(altTitles)) {
-                altTitleIds.add(id)
-            }
-        }.awaitAsList()
+        if (matchAltTitle != null) {
+            database.mangasQueries.getFavoriteMetadataForSearch { id, author, artist, description, altTitles ->
+                if (matchAuthor != null && author != null && matchAuthor(author)) authorIds.add(id)
+                if (matchArtist != null && artist != null && matchArtist(artist)) artistIds.add(id)
+                if (matchDescription != null && description != null && matchDescription(description)) {
+                    descriptionIds.add(id)
+                }
+                if (!altTitles.isNullOrEmpty() && matchAltTitle(altTitles)) altTitleIds.add(id)
+            }.awaitAsList()
+        } else {
+            // Skips the alternative_titles column entirely so its adapter never decodes when
+            // alt-title matching wasn't requested (pref disabled or a field-scoped search).
+            database.mangasQueries.getFavoriteMetadataForSearchBasic { id, author, artist, description ->
+                if (matchAuthor != null && author != null && matchAuthor(author)) authorIds.add(id)
+                if (matchArtist != null && artist != null && matchArtist(artist)) artistIds.add(id)
+                if (matchDescription != null && description != null && matchDescription(description)) {
+                    descriptionIds.add(id)
+                }
+            }.awaitAsList()
+        }
         return FavoriteMetadataMatches(authorIds, artistIds, descriptionIds, altTitleIds)
     }
 

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -278,7 +278,15 @@ SELECT M._id, M.source, M.url, M.artist, M.author, M.description, M.genre, M.tit
 FROM mangas M
 WHERE M.favorite = 1
 AND M._id != :id
-AND lower(trim(M.title)) = lower(trim(:title))
+AND (
+    lower(trim(M.title)) = lower(trim(:title))
+    -- :title is a full alt-title entry of the candidate (entries are U+001F-joined)
+    OR (M.alternative_titles IS NOT NULL AND M.alternative_titles != ''
+        AND instr(char(31) || lower(M.alternative_titles) || char(31), char(31) || lower(trim(:title)) || char(31)) > 0)
+    -- candidate's title is a full alt-title entry of the incoming manga
+    OR (:altTitles != ''
+        AND instr(char(31) || lower(:altTitles) || char(31), char(31) || lower(trim(M.title)) || char(31)) > 0)
+)
 LIMIT 10;
 
 -- Find all duplicate groups with exact title match (case-insensitive, trimmed)
@@ -298,7 +306,7 @@ ORDER BY duplicate_count DESC;
 -- this cursor and matches in Kotlin (one scan covers all three fields, supports regex, and
 -- avoids LIKE wildcard/escaping pitfalls).
 getFavoriteMetadataForSearch:
-SELECT _id, author, artist, description
+SELECT _id, author, artist, description, alternative_titles
 FROM mangas
 WHERE favorite = 1;
 
@@ -359,7 +367,7 @@ ORDER BY totalCount DESC;
 -- Uses same columns to keep SQLDelight column adapters working
 getMangaWithCountsLight:
 SELECT
-    M._id, M.source, M.url, M.artist, M.author, NULL AS description, NULL AS genre, M.title, NULL AS alternative_titles, M.status, M.thumbnail_url, M.favorite, M.last_update, M.next_update, M.initialized, M.viewer, M.chapter_flags, M.cover_last_modified, M.date_added, M.update_strategy, M.calculate_interval, M.last_modified_at, M.favorite_modified_at, M.version, M.is_syncing, '' AS notes, M.is_novel,
+    M._id, M.source, M.url, M.artist, M.author, NULL AS description, NULL AS genre, M.title, M.alternative_titles, M.status, M.thumbnail_url, M.favorite, M.last_update, M.next_update, M.initialized, M.viewer, M.chapter_flags, M.cover_last_modified, M.date_added, M.update_strategy, M.calculate_interval, M.last_modified_at, M.favorite_modified_at, M.version, M.is_syncing, '' AS notes, M.is_novel,
     COALESCE(CC.totalCount, 0) AS totalCount,
     COALESCE(CC.readCount, 0) AS readCount
 FROM mangas M
@@ -677,6 +685,7 @@ WHERE M.favorite = 1
     OR M.title LIKE '%' || :searchTerm || '%' ESCAPE '\'
     OR M.url LIKE '%' || :searchTerm || '%' ESCAPE '\'
     OR coalesce(M.genre, '') LIKE '%' || :searchTerm || '%' ESCAPE '\'
+    OR (:searchAltTitles = 1 AND coalesce(M.alternative_titles, '') LIKE '%' || :searchTerm || '%' ESCAPE '\')
   )
   -- Included-tag prefilter (superset of the exact in-memory match): keep rows whose genre
   -- contains ANY of the U+001F-joined lowercased tags. The CTE splits the param into rows so an

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -286,6 +286,19 @@ AND (
     -- candidate's title is a full alt-title entry of the incoming manga
     OR (:altTitles != ''
         AND instr(char(31) || lower(:altTitles) || char(31), char(31) || lower(trim(M.title)) || char(31)) > 0)
+    -- any alt-title entry is shared between the incoming manga and the candidate
+    OR (:altTitles != '' AND M.alternative_titles IS NOT NULL AND M.alternative_titles != ''
+        AND EXISTS (
+            WITH RECURSIVE alt(entry, rest) AS (
+                SELECT NULL, :altTitles || char(31)
+                UNION ALL
+                SELECT substr(rest, 1, instr(rest, char(31)) - 1), substr(rest, instr(rest, char(31)) + 1)
+                FROM alt WHERE rest <> ''
+            )
+            SELECT 1 FROM alt
+            WHERE alt.entry IS NOT NULL AND alt.entry <> ''
+                AND instr(char(31) || lower(M.alternative_titles) || char(31), char(31) || lower(alt.entry) || char(31)) > 0
+        ))
 )
 LIMIT 10;
 

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -323,6 +323,13 @@ SELECT _id, author, artist, description, alternative_titles
 FROM mangas
 WHERE favorite = 1;
 
+-- Same as getFavoriteMetadataForSearch but skips alternative_titles: avoids decoding the
+-- U+001F-joined column adapter on every favorite row when alt-title matching isn't requested.
+getFavoriteMetadataForSearchBasic:
+SELECT _id, author, artist, description
+FROM mangas
+WHERE favorite = 1;
+
 -- Find all duplicate groups with contains match (one title contains another)
 -- Optimized: use substr index and smaller comparisons to avoid full table scans
 findDuplicatesContains:

--- a/data/src/main/sqldelight/tachiyomi/migrations/31.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/31.sqm
@@ -1,0 +1,6 @@
+-- Alternative titles previously used ", " as the list separator, which split any
+-- title that legitimately contained a comma. Re-encode existing rows to use the
+-- unit separator (char(31)) so future decodes preserve commas.
+UPDATE mangas
+SET alternative_titles = REPLACE(alternative_titles, ', ', char(31))
+WHERE alternative_titles IS NOT NULL AND alternative_titles != '';

--- a/data/src/main/sqldelight/tachiyomi/migrations/31.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/31.sqm
@@ -2,5 +2,5 @@
 -- title that legitimately contained a comma. Re-encode existing rows to use the
 -- unit separator (char(31)) so future decodes preserve commas.
 UPDATE mangas
-SET alternative_titles = REPLACE(alternative_titles, ', ', char(31))
+SET alternative_titles = replace(alternative_titles, ', ', char(31))
 WHERE alternative_titles IS NOT NULL AND alternative_titles != '';

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibraryPageSpec.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibraryPageSpec.kt
@@ -26,6 +26,8 @@ data class LibraryPageSpec(
     val excludedSourceIds: List<Long> = emptyList(),
     // Default-field search term applied as a title/genre/url LIKE. Blank = no search.
     val searchTerm: String = "",
+    // When true, the search term also matches against the alternative_titles column.
+    val searchAlternativeTitles: Boolean = true,
     // Included-tag prefilter: U+001F-joined, lowercased ASCII tags. DB keeps rows whose genre
     // contains ANY of them (case-insensitive substring), a superset of the exact in-memory match,
     // so it only narrows and never drops a row. Blank = skip. Populated only when every tag is

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -186,6 +186,8 @@ class LibraryPreferences(
     val searchChapterNames: Preference<Boolean> = preferenceStore.getBoolean("pref_search_chapter_names", false)
     val searchChapterContent: Preference<Boolean> = preferenceStore.getBoolean("pref_search_chapter_content", false)
     val searchByUrl: Preference<Boolean> = preferenceStore.getBoolean("pref_search_by_url", false)
+    val searchAlternativeTitles: Preference<Boolean> =
+        preferenceStore.getBoolean("pref_search_alternative_titles", true)
     val useRegexSearch: Preference<Boolean> = preferenceStore.getBoolean("pref_use_regex_search", false)
 
     fun filterChapterCount() = preferenceStore.getEnum(

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
@@ -108,12 +108,51 @@ class FindDuplicateNovels(
     suspend fun findGroupedByIds(ids: List<Long>): Map<String, List<MangaWithChapterCount>> {
         if (ids.isEmpty()) return emptyMap()
 
-        val grouped = LinkedHashMap<String, MutableList<MangaWithChapterCount>>()
-        getMangaWithCountsLight(ids).forEach { item ->
-            val key = item.manga.title.trim().lowercase().ifBlank { item.manga.id.toString() }
-            grouped.getOrPut(key) { mutableListOf() }.add(item)
+        val items = getMangaWithCountsLight(ids)
+        if (items.isEmpty()) return emptyMap()
+
+        // A manga's match keys are its normalized title plus each normalized alternative title.
+        // Two manga that share ANY key are duplicates, so union them (title-A == alt-title-B counts).
+        val keyToItems = HashMap<String, MutableList<Int>>()
+        items.forEachIndexed { idx, item ->
+            val keys = buildSet {
+                item.manga.title.trim().lowercase().takeIf { it.isNotBlank() }?.let { add(it) }
+                item.manga.alternativeTitles.forEach { alt ->
+                    alt.trim().lowercase().takeIf { it.isNotBlank() }?.let { add(it) }
+                }
+            }
+            keys.forEach { keyToItems.getOrPut(it) { mutableListOf() }.add(idx) }
         }
-        return grouped.mapValues { (_, list) -> list.sortedByDescending { it.chapterCount } }
+
+        val parent = IntArray(items.size) { it }
+        fun find(x: Int): Int {
+            var root = x
+            while (parent[root] != root) root = parent[root]
+            var cur = x
+            while (parent[cur] != cur) {
+                val next = parent[cur]
+                parent[cur] = root
+                cur = next
+            }
+            return root
+        }
+        keyToItems.values.forEach { shared ->
+            for (k in 1 until shared.size) {
+                val ra = find(shared[0])
+                val rb = find(shared[k])
+                if (ra != rb) parent[ra] = rb
+            }
+        }
+
+        val groupsByRoot = LinkedHashMap<Int, MutableList<MangaWithChapterCount>>()
+        items.indices.forEach { i -> groupsByRoot.getOrPut(find(i)) { mutableListOf() }.add(items[i]) }
+
+        val result = LinkedHashMap<String, List<MangaWithChapterCount>>()
+        groupsByRoot.values.forEach { members ->
+            val key = members.first().manga.title.trim().lowercase().ifBlank { members.first().manga.id.toString() }
+            result[key] = members.sortedByDescending { it.chapterCount }
+        }
+        return result
     }
 
     /**

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
@@ -9,6 +9,6 @@ class GetDuplicateLibraryManga(
 ) {
 
     suspend operator fun invoke(manga: Manga): List<MangaWithChapterCount> {
-        return mangaRepository.getDuplicateLibraryManga(manga.id, manga.title.lowercase())
+        return mangaRepository.getDuplicateLibraryManga(manga.id, manga.title.lowercase(), manga.alternativeTitles)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/SearchMangaMetadata.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/SearchMangaMetadata.kt
@@ -18,6 +18,7 @@ class SearchMangaMetadata(
         val author: Set<Long> = emptySet(),
         val artist: Set<Long> = emptySet(),
         val description: Set<Long> = emptySet(),
+        val altTitle: Set<Long> = emptySet(),
     )
 
     /**
@@ -30,9 +31,10 @@ class SearchMangaMetadata(
         searchAuthor: Boolean,
         searchArtist: Boolean,
         searchDescription: Boolean,
+        searchAltTitle: Boolean = false,
     ): MatchIds {
         if (regex == null && term.isBlank()) return MatchIds()
-        if (!searchAuthor && !searchArtist && !searchDescription) return MatchIds()
+        if (!searchAuthor && !searchArtist && !searchDescription && !searchAltTitle) return MatchIds()
 
         val predicate: (String) -> Boolean = if (regex != null) {
             { regex.containsMatchIn(it) }
@@ -40,11 +42,17 @@ class SearchMangaMetadata(
             { it.contains(term, ignoreCase = true) }
         }
 
-        val (author, artist, description) = mangaRepository.findFavoriteIdsMatchingMetadata(
+        val matches = mangaRepository.findFavoriteIdsMatchingMetadata(
             matchAuthor = predicate.takeIf { searchAuthor },
             matchArtist = predicate.takeIf { searchArtist },
             matchDescription = predicate.takeIf { searchDescription },
+            matchAltTitle = ({ titles: List<String> -> titles.any(predicate) }).takeIf { searchAltTitle },
         )
-        return MatchIds(author = author, artist = artist, description = description)
+        return MatchIds(
+            author = matches.author,
+            artist = matches.artist,
+            description = matches.description,
+            altTitle = matches.altTitle,
+        )
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -9,6 +9,13 @@ import tachiyomi.domain.manga.model.MangaSelectionMetric
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 
+data class FavoriteMetadataMatches(
+    val author: Set<Long> = emptySet(),
+    val artist: Set<Long> = emptySet(),
+    val description: Set<Long> = emptySet(),
+    val altTitle: Set<Long> = emptySet(),
+)
+
 data class DuplicateGroup(
     val normalizedTitle: String,
     val ids: List<Long>,
@@ -112,7 +119,11 @@ interface MangaRepository {
 
     fun getFavoritesBySourceId(sourceId: Long): Flow<List<Manga>>
 
-    suspend fun getDuplicateLibraryManga(id: Long, title: String): List<MangaWithChapterCount>
+    suspend fun getDuplicateLibraryManga(
+        id: Long,
+        title: String,
+        altTitles: List<String> = emptyList(),
+    ): List<MangaWithChapterCount>
 
     suspend fun findDuplicatesExact(): List<DuplicateGroup>
 
@@ -129,7 +140,8 @@ interface MangaRepository {
         matchAuthor: ((String) -> Boolean)?,
         matchArtist: ((String) -> Boolean)?,
         matchDescription: ((String) -> Boolean)?,
-    ): Triple<Set<Long>, Set<Long>, Set<Long>>
+        matchAltTitle: ((List<String>) -> Boolean)? = null,
+    ): FavoriteMetadataMatches
 
     /**
      * Get ID + title pairs for all favorites.


### PR DESCRIPTION


Makes a manga's alternative titles first-class in the library: they are now searchable, included in duplicate detection, are editable per-title in the Edit dialog, and are included in backup/restore. Also fixes a storage bug where alt titles containing `", "` were fragmented on every save.

## Changes

- The shared `StringListColumnAdapter` joins/splits on `", "`, so any alt title containing `", "` was split into fragments on every save (visibly triggered by the "make main title" action).
- Dedicated `AlternativeTitlesColumnAdapter` in `DatabaseAdapter.kt` uses the unit separator (`0x1F`) instead.
- Migration `31.sqm` rewrites existing rows: `REPLACE(alternative_titles, ', ', char(31))`.

- Library search now matches alternative titles, gated by `LibraryPreferences.searchAlternativeTitles` (default on, toggle in `LibrarySettingsDialog`).

### Duplicate detection
- Add-time `getDuplicateLibraryManga` matches alt titles in both directions via `instr(char(31)||…||char(31))` boundary membership.
- Duplicate finder (`FindDuplicateNovels.findGroupedByIds`) uses union-find over title + alt-title keys.

### Edit dialog
- Per-title copy-to-clipboard icon and a delete action with confirmation.
- Delete resolves the row by index (not by value), so deleting a duplicate alt title removes the tapped entry rather than the first match.

### Backup
- Alt titles now round-trip via `BackupManga @ProtoNumber(8001) alternativeTitles`. (The legacy CSV column was never backed up.)
