### PR TITLE
Reader lifecycle, leak, and novel-reader UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 
 ### Improved
+- Reader Lifecycle and UX fixes [@mrissaoussama](https://github.com/mrissaoussama) [#338](https://github.com/tsundoku-otaku/tsundoku/pull/338)
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - Translations and quotes more organized/portable [@mrissaoussama](https://github.com/mrissaoussama) [#336](https://github.com/tsundoku-otaku/tsundoku/pull/336)
 - A ton of Arabic translations [@OtakuArab](https://github.com/OtakuArab) [#327](https://github.com/tsundoku-otaku/tsundoku/pull/327)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -87,5 +87,5 @@
 -keepclassmembers class * {
     @android.webkit.JavascriptInterface <methods>;
 }
--keep class eu.kanade.tachiyomi.ui.reader.viewer.text.NovelWebViewViewer$WebViewInterface { *; }
+-keep class eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewViewer$WebViewInterface { *; }
 -keep class eu.kanade.tachiyomi.ui.customsource.ElementSelectorJSInterface { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -232,6 +232,7 @@
         <activity
             android:name=".ui.reader.ReaderActivity"
             android:exported="false"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="com.samsung.android.support.REMOTE_ACTION" />

--- a/app/src/main/assets/novel-reader/next-chapter-button.js
+++ b/app/src/main/assets/novel-reader/next-chapter-button.js
@@ -1,7 +1,8 @@
 // Inject a "Next Chapter →" button at the bottom of the WebView content.
 //
 // Replaces:
-//   __BTN_CONTAINER_ID__ — DOM id of the wrapping div
+//   __BTN_CONTAINER_ID__ - DOM id of the wrapping div
+//   __SAFE_BOTTOM_VAR__  - safe-area bottom CSS custom property name
 
 (function () {
     var existing = document.getElementById('__BTN_CONTAINER_ID__');
@@ -9,7 +10,8 @@
 
     var container = document.createElement('div');
     container.id = '__BTN_CONTAINER_ID__';
-    container.style.cssText = 'padding: 32px 16px; text-align: center;';
+    // Bottom padding clears the reader menu / nav bar so the button isn't hidden at chapter end.
+    container.style.cssText = 'padding: 32px 16px calc(32px + var(__SAFE_BOTTOM_VAR__, 0px)); text-align: center;';
 
     var bg = getComputedStyle(document.body).backgroundColor || 'transparent';
     var fg = getComputedStyle(document.body).color || '#000000';

--- a/app/src/main/assets/novel-reader/reader-chrome.js
+++ b/app/src/main/assets/novel-reader/reader-chrome.js
@@ -1,0 +1,26 @@
+// Push reader-chrome state into the page: safe-area CSS vars + reader-menu visibility.
+//
+// Replaces:
+//   __SAFE_TOP_VAR__ / __SAFE_BOTTOM_VAR__ - CSS custom property names
+//   __SAFE_TOP__ / __SAFE_BOTTOM__         - px values (numbers)
+//   __OBJECT__                             - global object name (Tsundoku)
+//   __MENU_KEY__                           - runtime menu-visible key
+//   __MENU_VISIBLE__                       - true / false
+//   __EVENT__                              - menu-visibility CustomEvent name
+//
+// Writes the vars only when they change: setting a custom property invalidates style for its whole
+// subtree, an avoidable recalc on a long document during menu toggles.
+(function () {
+    var s = document.documentElement.style;
+    var top = '__SAFE_TOP__px', bottom = '__SAFE_BOTTOM__px';
+    if (s.getPropertyValue('__SAFE_TOP_VAR__') !== top) s.setProperty('__SAFE_TOP_VAR__', top);
+    if (s.getPropertyValue('__SAFE_BOTTOM_VAR__') !== bottom) s.setProperty('__SAFE_BOTTOM_VAR__', bottom);
+
+    window.__OBJECT__ = window.__OBJECT__ || {};
+    window.__OBJECT__.runtime = window.__OBJECT__.runtime || {};
+    var was = window.__OBJECT__.runtime.__MENU_KEY__;
+    window.__OBJECT__.runtime.__MENU_KEY__ = __MENU_VISIBLE__;
+    if (was !== __MENU_VISIBLE__) {
+        window.dispatchEvent(new CustomEvent('__EVENT__', { detail: { visible: __MENU_VISIBLE__ } }));
+    }
+})();

--- a/app/src/main/assets/novel-reader/scroll-tracking.js
+++ b/app/src/main/assets/novel-reader/scroll-tracking.js
@@ -1,13 +1,18 @@
 // Page-side scroll listener for the novel WebView reader.
 // Installed once per load via NovelWebViewStyler.injectScrollTracking(), which substitutes the
 // __TSUNDOKU_OBJECT_NAME__ / __CHAPTER_DIVIDER_CLASS__ / __CHAPTER_ID_ATTR__ /
-// __INFINITE_SCROLL_ENABLED__ / __LOAD_THRESHOLD__ / __DONE_THRESHOLD__ tokens.
+// __INFINITE_SCROLL_ENABLED__ / __LOAD_THRESHOLD__ / __DONE_THRESHOLD__ / __PROGRESS_EVENT__ tokens.
 //
 // Reports to the Android JS interface:
 //   onChapterScrollUpdate(chapterId, progress)  visible chapter changed
 //   onScrollUpdate(progress)                     live slider position
 //   onScrollProgress(progress)                   persist point (scroll settled / 100%)
 //   loadNextChapter()
+//
+// Publishes for snippets/plugins:
+//   runtime.progress / runtime.chapterProgress / runtime.currentChapterId  (updated every frame)
+//   window event __PROGRESS_EVENT__  { progress, chapterProgress, chapterId, isLast }
+//     dispatched JS-side (no Kotlin bridge hop), throttled with the slider bridge.
 
 (function () {
     window.__TSUNDOKU_OBJECT_NAME__ = window.__TSUNDOKU_OBJECT_NAME__ || {};
@@ -84,11 +89,35 @@
         return { progress: progress, chapterProgress: chapterProgress, idx: idx, chapterId: chapterId, isLast: isLast };
     }
 
+    var PROGRESS_EVENT = '__PROGRESS_EVENT__';
+    // Dispatched page-side (no Kotlin bridge). Constructing + dispatching a CustomEvent with no
+    // listeners is cheap, so gating on subscriber count isn't worth the bookkeeping; the 50ms/0.01
+    // slider throttle already bounds how often this fires.
+    function dispatchProgress(s) {
+        try {
+            window.dispatchEvent(new CustomEvent(PROGRESS_EVENT, {
+                detail: {
+                    progress: s.progress,
+                    chapterProgress: s.chapterProgress,
+                    chapterId: s.chapterId,
+                    isLast: s.isLast,
+                },
+            }));
+        } catch (e) {}
+    }
+
+    function publishProgress(s) {
+        runtime.progress = s.progress;
+        runtime.chapterProgress = s.chapterProgress;
+        runtime.currentChapterId = s.chapterId;
+    }
+
     var framePending = false;
 
     function onFrame() {
         framePending = false;
         var s = computeState();
+        publishProgress(s);
 
         if (infiniteScrollEnabled && s.idx !== runtime.lastChapterIdxSeen && s.chapterId != null) {
             runtime.lastChapterIdxSeen = s.idx;
@@ -102,6 +131,7 @@
                 lastScrollUpdateTime = now;
                 lastSliderProgress = s.chapterProgress;
                 Android.onScrollUpdate(s.chapterProgress);
+                dispatchProgress(s);
             }
         }
         // Only the last chapter flashes to 100% and self-persists; a middle chapter momentarily
@@ -111,6 +141,7 @@
             lastSliderProgress = 1.0;
             Android.onScrollUpdate(1.0);
             Android.onScrollProgress(1.0);
+            dispatchProgress(s);
         }
 
         if (!runtime.loadingNext && infiniteScrollEnabled && !runtime.noMoreChapters) {
@@ -220,5 +251,8 @@
 
     requestAnimationFrame(function () {
         if (typeof window.updateChapterBoundaries === 'function') window.updateChapterBoundaries();
+        var s0 = computeState();
+        publishProgress(s0);
+        dispatchProgress(s0);
     });
 })();

--- a/app/src/main/assets/novel-reader/scroll-tracking.js
+++ b/app/src/main/assets/novel-reader/scroll-tracking.js
@@ -23,6 +23,10 @@
     var loadThreshold = __LOAD_THRESHOLD__;
     var lastSliderProgress = -1;
     var lastScrollUpdateTime = 0;
+    // Late reflow (images/fonts) triggers scroll anchoring that fires scrollend off a
+    // still-settling docHeight; persistCurrent waits this out before saving.
+    var lastBodyResizeAt = 0;
+    var SETTLE_MS = 400;
 
     runtime.loadingNext = runtime.loadingNext || false;
     runtime.setLoadingNext = function (v) { runtime.loadingNext = !!v; };
@@ -132,17 +136,30 @@
     window.addEventListener('scroll', onScroll, { passive: true });
 
     // computeState() is re-read here so a chapter switch mid-scroll can't persist a stale value.
-    function persistCurrent() {
+    function persistCurrent(retriesLeft) {
+        if (retriesLeft === undefined) retriesLeft = 3;
+        if (retriesLeft > 0 && Date.now() - lastBodyResizeAt < SETTLE_MS) {
+            setTimeout(function () { persistCurrent(retriesLeft - 1); }, SETTLE_MS);
+            return;
+        }
         Android.onScrollProgress(computeState().chapterProgress);
     }
     if ('onscrollend' in window) {
-        window.addEventListener('scrollend', persistCurrent, { passive: true });
+        window.addEventListener('scrollend', function () { persistCurrent(); }, { passive: true });
     } else {
         var settleTimer = null;
         window.addEventListener('scroll', function () {
             clearTimeout(settleTimer);
             settleTimer = setTimeout(persistCurrent, 250);
         }, { passive: true });
+    }
+
+    // Marks in-flight reflow so persistCurrent can wait it out before saving.
+    if (typeof ResizeObserver === 'function' && document.body) {
+        var bodyResizeObserver = new ResizeObserver(function () {
+            lastBodyResizeAt = Date.now();
+        });
+        bodyResizeObserver.observe(document.body);
     }
 
     window.addChapterBoundary = function (chapterId, startOffset, height) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -85,6 +85,7 @@ import eu.kanade.tachiyomi.network.PREF_DOH_QUAD101
 import eu.kanade.tachiyomi.network.PREF_DOH_QUAD9
 import eu.kanade.tachiyomi.network.PREF_DOH_SHECAN
 import eu.kanade.tachiyomi.ui.more.OnboardingScreen
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.system.GLUtil
 import eu.kanade.tachiyomi.util.system.copyToClipboard
@@ -206,6 +207,7 @@ object SettingsAdvancedScreen : SearchableSettings {
             getNetworkGroup(networkPreferences = networkPreferences),
             getLibraryGroup(libraryPreferences = libraryPreferences),
             getReaderGroup(basePreferences = basePreferences),
+            getNovelReaderGroup(),
             getExtensionsGroup(basePreferences = basePreferences),
             getMassImportGroup(novelDownloadPreferences = novelDownloadPreferences),
         )
@@ -227,6 +229,29 @@ object SettingsAdvancedScreen : SearchableSettings {
                     preference = novelDownloadPreferences.massImportSplitByDomain(),
                     title = stringResource(TDMR.strings.pref_mass_import_split_by_domain),
                     subtitle = stringResource(TDMR.strings.pref_mass_import_split_by_domain_summary),
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getNovelReaderGroup(): Preference.PreferenceGroup {
+        val readerPreferences = remember { Injekt.get<ReaderPreferences>() }
+        val devToolsEnabled by readerPreferences.novelWebViewDevTools.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(TDMR.strings.pref_category_novel_webview),
+            preferenceItems = listOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.novelWebViewDevTools,
+                    title = stringResource(TDMR.strings.pref_novel_webview_devtools),
+                    subtitle = stringResource(TDMR.strings.pref_novel_webview_devtools_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.novelConsoleErrorToast,
+                    title = stringResource(TDMR.strings.pref_novel_console_error_toast),
+                    subtitle = stringResource(TDMR.strings.pref_novel_console_error_toast_summary),
+                    enabled = devToolsEnabled,
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -280,9 +280,10 @@ object SettingsNovelReaderScreen : SearchableSettings {
             preferenceItems = listOf(
                 Preference.PreferenceItem.SliderPreference(
                     value = autoScrollSpeed,
-                    valueRange = 5..120,
+                    // Pref is half-steps (x2); 2..20 shows as speed 1.0..10.0 in 0.5 increments.
+                    valueRange = 2..20,
                     title = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
-                    valueString = "${autoScrollSpeed}s per screen",
+                    valueString = "${autoScrollSpeed / 2f}",
                     onValueChanged = {
                         readerPreferences.novelAutoScrollSpeed.set(it)
                     },

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -280,7 +280,6 @@ object SettingsNovelReaderScreen : SearchableSettings {
             preferenceItems = listOf(
                 Preference.PreferenceItem.SliderPreference(
                     value = autoScrollSpeed,
-                    // Pref is half-steps (x2). 2..20 shows as speed 1.0..10.0 in 0.5 increments.
                     valueRange = 2..20,
                     title = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
                     valueString = "${autoScrollSpeed / 2f}",

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -280,7 +280,7 @@ object SettingsNovelReaderScreen : SearchableSettings {
             preferenceItems = listOf(
                 Preference.PreferenceItem.SliderPreference(
                     value = autoScrollSpeed,
-                    // Pref is half-steps (x2); 2..20 shows as speed 1.0..10.0 in 0.5 increments.
+                    // Pref is half-steps (x2). 2..20 shows as speed 1.0..10.0 in 0.5 increments.
                     valueRange = 2..20,
                     title = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
                     valueString = "${autoScrollSpeed / 2f}",

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -153,10 +153,24 @@ fun NovelReaderAppBars(
 
     // Extra bottom offset for the floating TTS overlay so it clears the status bar
     ttsOverlayBottomPadding: Dp = 0.dp,
+
+    // Measured bar heights in px (0 while hidden), so the page can inset fixed elements clear of the
+    // transient reader menu bars.
+    onTopBarHeight: (Int) -> Unit = {},
+    onBottomBarHeight: (Int) -> Unit = {},
 ) {
     val backgroundColor = MaterialTheme.colorScheme
         .surfaceColorAtElevation(3.dp)
         .copy(alpha = if (isSystemInDarkTheme()) 0.9f else 0.95f)
+
+    // onSizeChanged doesn't fire a final 0 when AnimatedVisibility removes the bars, so clear the
+    // reported heights here when the menu hides.
+    LaunchedEffect(visible) {
+        if (!visible) {
+            onTopBarHeight(0)
+            onBottomBarHeight(0)
+        }
+    }
 
     Box(modifier = Modifier.fillMaxHeight()) {
         Column(modifier = Modifier.fillMaxHeight()) {
@@ -169,6 +183,7 @@ fun NovelReaderAppBars(
             ) {
                 NovelReaderTopBar(
                     modifier = Modifier
+                        .onSizeChanged { onTopBarHeight(it.height) }
                         .background(backgroundColor)
                         .clickable(onClick = onClickTopAppBar),
                     novelTitle = novelTitle,
@@ -243,6 +258,7 @@ fun NovelReaderAppBars(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .onSizeChanged { onBottomBarHeight(it.height) }
                         .background(backgroundColor)
                         .windowInsetsPadding(WindowInsets.navigationBars),
                 ) {

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -533,11 +533,12 @@ internal fun ColumnScope.NovelAppearanceTab(screenModel: ReaderSettingsScreenMod
 internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel, renderingMode: String) {
     val autoScrollSpeed by screenModel.preferences.novelAutoScrollSpeed.collectAsState()
 
-    // Auto Scroll Speed
+    // Auto Scroll Speed - pref is half-steps (x2), so 2..20 shows as 1.0..10.0 in 0.5 increments.
     SliderItem(
         label = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
         value = autoScrollSpeed,
-        valueRange = 1..10,
+        valueRange = 2..20,
+        valueString = "${autoScrollSpeed / 2f}",
         onChange = { screenModel.preferences.novelAutoScrollSpeed.set(it) },
     )
 

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.FormatAlignLeft
 import androidx.compose.material.icons.automirrored.outlined.FormatAlignRight
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
@@ -65,6 +68,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.data.font.FontManager
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
@@ -88,6 +92,8 @@ data class CodeSnippet(
     val title: String,
     val code: String,
     val enabled: Boolean = true,
+    // JS only. Default off so one-shot snippets don't re-run on every infinite-scroll append.
+    val runOnAppend: Boolean = false,
 )
 
 @Serializable
@@ -858,6 +864,14 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             }
             screenModel.preferences.novelCustomCssSnippets.set(Json.encodeToString(updated))
         },
+        onMove = { from, to ->
+            val updated = cssSnippets.toMutableList().apply { add(to, removeAt(from)) }
+            screenModel.preferences.novelCustomCssSnippets.set(Json.encodeToString(updated))
+        },
+        onSortEnabledFirst = {
+            val updated = cssSnippets.sortedByDescending { it.enabled }
+            screenModel.preferences.novelCustomCssSnippets.set(Json.encodeToString(updated))
+        },
     )
 
     // JS Snippets Section
@@ -876,6 +890,14 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             }
             screenModel.preferences.novelCustomJsSnippets.set(Json.encodeToString(updated))
         },
+        onMove = { from, to ->
+            val updated = jsSnippets.toMutableList().apply { add(to, removeAt(from)) }
+            screenModel.preferences.novelCustomJsSnippets.set(Json.encodeToString(updated))
+        },
+        onSortEnabledFirst = {
+            val updated = jsSnippets.sortedByDescending { it.enabled }
+            screenModel.preferences.novelCustomJsSnippets.set(Json.encodeToString(updated))
+        },
     )
 
     // CSS Add/Edit Dialog
@@ -888,6 +910,7 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             },
             initialSnippet = editingCssSnippet?.second,
             focusCodeFieldByDefault = editingCssSnippet != null,
+            showRunOnAppend = false,
             onDismiss = {
                 showCssDialog = false
                 editingCssSnippet = null
@@ -916,6 +939,7 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             },
             initialSnippet = editingJsSnippet?.second,
             focusCodeFieldByDefault = editingJsSnippet != null,
+            showRunOnAppend = true,
             onDismiss = {
                 showJsDialog = false
                 editingJsSnippet = null
@@ -943,7 +967,11 @@ private fun SnippetSection(
     onEditClick: (Int, CodeSnippet) -> Unit,
     onDeleteClick: (Int) -> Unit,
     onToggleClick: (Int) -> Unit,
+    onMove: (Int, Int) -> Unit,
+    onSortEnabledFirst: () -> Unit,
 ) {
+    var pendingDelete by remember { mutableStateOf<Int?>(null) }
+
     Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -961,8 +989,18 @@ private fun SnippetSection(
                     style = MaterialTheme.typography.titleMedium,
                 )
             }
-            IconButton(onClick = onAddClick) {
-                Icon(Icons.Outlined.Add, contentDescription = stringResource(TDMR.strings.novel_add_snippet))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (snippets.size > 1) {
+                    IconButton(onClick = onSortEnabledFirst) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.Sort,
+                            contentDescription = stringResource(TDMR.strings.novel_snippets_enabled_first),
+                        )
+                    }
+                }
+                IconButton(onClick = onAddClick) {
+                    Icon(Icons.Outlined.Add, contentDescription = stringResource(TDMR.strings.novel_add_snippet))
+                }
             }
         }
 
@@ -976,44 +1014,48 @@ private fun SnippetSection(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(12.dp),
+                        .padding(start = 12.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = snippet.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = if (snippet.enabled) {
-                                MaterialTheme.colorScheme.onSurface
-                            } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                            },
-                        )
-                        Text(
-                            text = if (snippet.enabled) {
-                                stringResource(
-                                    TDMR.strings.novel_enabled,
-                                )
-                            } else {
-                                stringResource(TDMR.strings.novel_disabled)
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (snippet.enabled) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                            },
-                        )
-                    }
+                    Text(
+                        text = snippet.title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                        color = if (snippet.enabled) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        },
+                    )
                     Row {
+                        IconButton(
+                            onClick = { onMove(index, index - 1) },
+                            enabled = index > 0,
+                            modifier = Modifier.size(36.dp),
+                        ) {
+                            Icon(
+                                Icons.Outlined.ArrowUpward,
+                                contentDescription = stringResource(TDMR.strings.novel_snippet_move_up),
+                            )
+                        }
+                        IconButton(
+                            onClick = { onMove(index, index + 1) },
+                            enabled = index < snippets.lastIndex,
+                            modifier = Modifier.size(36.dp),
+                        ) {
+                            Icon(
+                                Icons.Outlined.ArrowDownward,
+                                contentDescription = stringResource(TDMR.strings.novel_snippet_move_down),
+                            )
+                        }
                         IconButton(onClick = { onEditClick(index, snippet) }) {
                             Icon(
                                 Icons.Outlined.Edit,
                                 contentDescription = stringResource(TDMR.strings.novel_edit_snippet),
                             )
                         }
-                        IconButton(onClick = { onDeleteClick(index) }) {
+                        IconButton(onClick = { pendingDelete = index }) {
                             Icon(
                                 Icons.Outlined.Delete,
                                 contentDescription = stringResource(TDMR.strings.novel_delete_snippet),
@@ -1033,6 +1075,29 @@ private fun SnippetSection(
             )
         }
     }
+
+    pendingDelete?.let { index ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text(stringResource(TDMR.strings.novel_delete_snippet)) },
+            text = { Text(stringResource(TDMR.strings.novel_delete_snippet_confirm)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDeleteClick(index)
+                        pendingDelete = null
+                    },
+                ) {
+                    Text(stringResource(MR.strings.action_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text(stringResource(MR.strings.action_cancel))
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -1040,11 +1105,13 @@ private fun SnippetEditDialog(
     title: String,
     initialSnippet: CodeSnippet?,
     focusCodeFieldByDefault: Boolean,
+    showRunOnAppend: Boolean,
     onDismiss: () -> Unit,
     onConfirm: (CodeSnippet) -> Unit,
 ) {
     var snippetTitle by remember { mutableStateOf(initialSnippet?.title ?: "") }
     var snippetCode by remember { mutableStateOf(initialSnippet?.code ?: "") }
+    var runOnAppend by remember { mutableStateOf(initialSnippet?.runOnAppend ?: false) }
     val codeFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(focusCodeFieldByDefault) {
@@ -1076,13 +1143,39 @@ private fun SnippetEditDialog(
                         .padding(top = 8.dp)
                         .focusRequester(codeFocusRequester),
                 )
+                if (showRunOnAppend) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { runOnAppend = !runOnAppend }
+                            .padding(top = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = runOnAppend,
+                            onCheckedChange = { runOnAppend = it },
+                        )
+                        Text(
+                            text = stringResource(TDMR.strings.novel_snippet_run_on_append),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                    }
+                }
             }
         },
         confirmButton = {
             TextButton(
                 onClick = {
                     if (snippetTitle.isNotBlank() && snippetCode.isNotBlank()) {
-                        onConfirm(CodeSnippet(snippetTitle.trim(), snippetCode, initialSnippet?.enabled ?: true))
+                        onConfirm(
+                            CodeSnippet(
+                                title = snippetTitle.trim(),
+                                code = snippetCode,
+                                enabled = initialSnippet?.enabled ?: true,
+                                runOnAppend = runOnAppend,
+                            ),
+                        )
                     }
                 },
             ) {
@@ -1107,6 +1200,7 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
 
     var showAddDialog by remember { mutableStateOf(false) }
     var editingRule by remember { mutableStateOf<Pair<Int, RegexReplacement>?>(null) }
+    var pendingDelete by remember { mutableStateOf<Int?>(null) }
 
     val rules = remember(regexJson) {
         try {
@@ -1174,8 +1268,6 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
                                     if (rule.matchWholeWord) append(" • whole-word")
                                     if (rule.caseSensitive) append(" • case-sensitive")
                                 }
-                                append(" • ")
-                                append(if (rule.enabled) "Enabled" else "Disabled")
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = if (rule.enabled) {
@@ -1188,7 +1280,7 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
                             text = "/${rule.pattern}/ → ${rule.replacement.ifEmpty { "(remove)" }}",
                             style = MaterialTheme.typography.labelSmall,
                             maxLines = 1,
-                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                            overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         )
                     }
@@ -1196,10 +1288,7 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
                         IconButton(onClick = { editingRule = index to rule }) {
                             Icon(Icons.Outlined.Edit, contentDescription = stringResource(MR.strings.action_edit))
                         }
-                        IconButton(onClick = {
-                            val updated = rules.toMutableList().apply { removeAt(index) }
-                            screenModel.preferences.novelRegexReplacements.set(Json.encodeToString(updated))
-                        }) {
+                        IconButton(onClick = { pendingDelete = index }) {
                             Icon(Icons.Outlined.Delete, contentDescription = stringResource(MR.strings.action_delete))
                         }
                     }
@@ -1234,6 +1323,30 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
                 screenModel.preferences.novelRegexReplacements.set(Json.encodeToString(updated))
                 showAddDialog = false
                 editingRule = null
+            },
+        )
+    }
+
+    pendingDelete?.let { index ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text(stringResource(MR.strings.action_delete)) },
+            text = { Text(stringResource(TDMR.strings.novel_delete_rule_confirm)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val updated = rules.toMutableList().apply { removeAt(index) }
+                        screenModel.preferences.novelRegexReplacements.set(Json.encodeToString(updated))
+                        pendingDelete = null
+                    },
+                ) {
+                    Text(stringResource(MR.strings.action_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text(stringResource(MR.strings.action_cancel))
+                }
             },
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -533,7 +533,7 @@ internal fun ColumnScope.NovelAppearanceTab(screenModel: ReaderSettingsScreenMod
 internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel, renderingMode: String) {
     val autoScrollSpeed by screenModel.preferences.novelAutoScrollSpeed.collectAsState()
 
-    // Auto Scroll Speed - pref is half-steps (x2), so 2..20 shows as 1.0..10.0 in 0.5 increments.
+    // Pref is half-steps (x2), so 2..20 shows as 1.0..10.0 in 0.5 increments.
     SliderItem(
         label = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
         value = autoScrollSpeed,

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -533,7 +533,6 @@ internal fun ColumnScope.NovelAppearanceTab(screenModel: ReaderSettingsScreenMod
 internal fun ColumnScope.NovelControlsTab(screenModel: ReaderSettingsScreenModel, renderingMode: String) {
     val autoScrollSpeed by screenModel.preferences.novelAutoScrollSpeed.collectAsState()
 
-    // Pref is half-steps (x2), so 2..20 shows as 1.0..10.0 in 0.5 increments.
     SliderItem(
         label = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
         value = autoScrollSpeed,

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -94,6 +94,10 @@ data class CodeSnippet(
     val enabled: Boolean = true,
     // JS only. Default off so one-shot snippets don't re-run on every infinite-scroll append.
     val runOnAppend: Boolean = false,
+    // Stable identity for edit/delete so a list reorder between opening a dialog and confirming it
+    // can't target the wrong entry. Absent from JSON saved before this field existed, in which case
+    // decoding assigns a fresh one -- harmless since those entries had no addressable identity before.
+    val id: String = java.util.UUID.randomUUID().toString(),
 )
 
 @Serializable
@@ -105,6 +109,7 @@ data class RegexReplacement(
     val isRegex: Boolean = true,
     val matchWholeWord: Boolean = false,
     val caseSensitive: Boolean = false,
+    val id: String = java.util.UUID.randomUUID().toString(),
 )
 
 private val novelThemes = listOf(
@@ -829,8 +834,8 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
 
     var showCssDialog by remember { mutableStateOf(false) }
     var showJsDialog by remember { mutableStateOf(false) }
-    var editingCssSnippet by remember { mutableStateOf<Pair<Int, CodeSnippet>?>(null) }
-    var editingJsSnippet by remember { mutableStateOf<Pair<Int, CodeSnippet>?>(null) }
+    var editingCssSnippet by remember { mutableStateOf<CodeSnippet?>(null) }
+    var editingJsSnippet by remember { mutableStateOf<CodeSnippet?>(null) }
 
     val cssSnippets = remember(cssSnippetsJson) {
         try {
@@ -853,9 +858,9 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
         title = stringResource(TDMR.strings.pref_novel_css_snippets),
         snippets = cssSnippets,
         onAddClick = { showCssDialog = true },
-        onEditClick = { index, snippet -> editingCssSnippet = index to snippet },
-        onDeleteClick = { index ->
-            val updated = cssSnippets.toMutableList().apply { removeAt(index) }
+        onEditClick = { snippet -> editingCssSnippet = snippet },
+        onDeleteClick = { id ->
+            val updated = cssSnippets.filterNot { it.id == id }
             screenModel.preferences.novelCustomCssSnippets.set(Json.encodeToString(updated))
         },
         onToggleClick = { index ->
@@ -879,9 +884,9 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
         title = stringResource(TDMR.strings.pref_novel_js_snippets),
         snippets = jsSnippets,
         onAddClick = { showJsDialog = true },
-        onEditClick = { index, snippet -> editingJsSnippet = index to snippet },
-        onDeleteClick = { index ->
-            val updated = jsSnippets.toMutableList().apply { removeAt(index) }
+        onEditClick = { snippet -> editingJsSnippet = snippet },
+        onDeleteClick = { id ->
+            val updated = jsSnippets.filterNot { it.id == id }
             screenModel.preferences.novelCustomJsSnippets.set(Json.encodeToString(updated))
         },
         onToggleClick = { index ->
@@ -908,7 +913,7 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             } else {
                 stringResource(TDMR.strings.novel_add_css_snippet)
             },
-            initialSnippet = editingCssSnippet?.second,
+            initialSnippet = editingCssSnippet,
             focusCodeFieldByDefault = editingCssSnippet != null,
             showRunOnAppend = false,
             onDismiss = {
@@ -916,11 +921,11 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
                 editingCssSnippet = null
             },
             onConfirm = { snippet ->
-                val updated = cssSnippets.toMutableList()
-                if (editingCssSnippet != null) {
-                    updated[editingCssSnippet!!.first] = snippet
+                val editingId = editingCssSnippet?.id
+                val updated = if (editingId != null) {
+                    cssSnippets.map { if (it.id == editingId) snippet else it }
                 } else {
-                    updated.add(snippet)
+                    cssSnippets + snippet
                 }
                 screenModel.preferences.novelCustomCssSnippets.set(Json.encodeToString(updated))
                 showCssDialog = false
@@ -937,7 +942,7 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             } else {
                 stringResource(TDMR.strings.novel_add_js_snippet)
             },
-            initialSnippet = editingJsSnippet?.second,
+            initialSnippet = editingJsSnippet,
             focusCodeFieldByDefault = editingJsSnippet != null,
             showRunOnAppend = true,
             onDismiss = {
@@ -945,11 +950,11 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
                 editingJsSnippet = null
             },
             onConfirm = { snippet ->
-                val updated = jsSnippets.toMutableList()
-                if (editingJsSnippet != null) {
-                    updated[editingJsSnippet!!.first] = snippet
+                val editingId = editingJsSnippet?.id
+                val updated = if (editingId != null) {
+                    jsSnippets.map { if (it.id == editingId) snippet else it }
                 } else {
-                    updated.add(snippet)
+                    jsSnippets + snippet
                 }
                 screenModel.preferences.novelCustomJsSnippets.set(Json.encodeToString(updated))
                 showJsDialog = false
@@ -964,13 +969,13 @@ private fun SnippetSection(
     title: String,
     snippets: List<CodeSnippet>,
     onAddClick: () -> Unit,
-    onEditClick: (Int, CodeSnippet) -> Unit,
-    onDeleteClick: (Int) -> Unit,
+    onEditClick: (CodeSnippet) -> Unit,
+    onDeleteClick: (String) -> Unit,
     onToggleClick: (Int) -> Unit,
     onMove: (Int, Int) -> Unit,
     onSortEnabledFirst: () -> Unit,
 ) {
-    var pendingDelete by remember { mutableStateOf<Int?>(null) }
+    var pendingDelete by remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
         Row(
@@ -1049,13 +1054,13 @@ private fun SnippetSection(
                                 contentDescription = stringResource(TDMR.strings.novel_snippet_move_down),
                             )
                         }
-                        IconButton(onClick = { onEditClick(index, snippet) }) {
+                        IconButton(onClick = { onEditClick(snippet) }) {
                             Icon(
                                 Icons.Outlined.Edit,
                                 contentDescription = stringResource(TDMR.strings.novel_edit_snippet),
                             )
                         }
-                        IconButton(onClick = { pendingDelete = index }) {
+                        IconButton(onClick = { pendingDelete = snippet.id }) {
                             Icon(
                                 Icons.Outlined.Delete,
                                 contentDescription = stringResource(TDMR.strings.novel_delete_snippet),
@@ -1076,7 +1081,7 @@ private fun SnippetSection(
         }
     }
 
-    pendingDelete?.let { index ->
+    pendingDelete?.let { id ->
         AlertDialog(
             onDismissRequest = { pendingDelete = null },
             title = { Text(stringResource(TDMR.strings.novel_delete_snippet)) },
@@ -1084,7 +1089,7 @@ private fun SnippetSection(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        onDeleteClick(index)
+                        onDeleteClick(id)
                         pendingDelete = null
                     },
                 ) {
@@ -1174,6 +1179,7 @@ private fun SnippetEditDialog(
                                 code = snippetCode,
                                 enabled = initialSnippet?.enabled ?: true,
                                 runOnAppend = runOnAppend,
+                                id = initialSnippet?.id ?: java.util.UUID.randomUUID().toString(),
                             ),
                         )
                     }
@@ -1199,8 +1205,8 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
     val regexJson by screenModel.preferences.novelRegexReplacements.collectAsState()
 
     var showAddDialog by remember { mutableStateOf(false) }
-    var editingRule by remember { mutableStateOf<Pair<Int, RegexReplacement>?>(null) }
-    var pendingDelete by remember { mutableStateOf<Int?>(null) }
+    var editingRule by remember { mutableStateOf<RegexReplacement?>(null) }
+    var pendingDelete by remember { mutableStateOf<String?>(null) }
 
     val rules = remember(regexJson) {
         try {
@@ -1285,10 +1291,10 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
                         )
                     }
                     Row {
-                        IconButton(onClick = { editingRule = index to rule }) {
+                        IconButton(onClick = { editingRule = rule }) {
                             Icon(Icons.Outlined.Edit, contentDescription = stringResource(MR.strings.action_edit))
                         }
-                        IconButton(onClick = { pendingDelete = index }) {
+                        IconButton(onClick = { pendingDelete = rule.id }) {
                             Icon(Icons.Outlined.Delete, contentDescription = stringResource(MR.strings.action_delete))
                         }
                     }
@@ -1308,17 +1314,17 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
 
     if (showAddDialog || editingRule != null) {
         RegexEditDialog(
-            initialRule = editingRule?.second,
+            initialRule = editingRule,
             onDismiss = {
                 showAddDialog = false
                 editingRule = null
             },
             onConfirm = { rule ->
-                val updated = rules.toMutableList()
-                if (editingRule != null) {
-                    updated[editingRule!!.first] = rule
+                val editingId = editingRule?.id
+                val updated = if (editingId != null) {
+                    rules.map { if (it.id == editingId) rule else it }
                 } else {
-                    updated.add(rule)
+                    rules + rule
                 }
                 screenModel.preferences.novelRegexReplacements.set(Json.encodeToString(updated))
                 showAddDialog = false
@@ -1327,7 +1333,7 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
         )
     }
 
-    pendingDelete?.let { index ->
+    pendingDelete?.let { id ->
         AlertDialog(
             onDismissRequest = { pendingDelete = null },
             title = { Text(stringResource(MR.strings.action_delete)) },
@@ -1335,7 +1341,7 @@ private fun ColumnScope.RegexReplacementSection(screenModel: ReaderSettingsScree
             confirmButton = {
                 TextButton(
                     onClick = {
-                        val updated = rules.toMutableList().apply { removeAt(index) }
+                        val updated = rules.filterNot { it.id == id }
                         screenModel.preferences.novelRegexReplacements.set(Json.encodeToString(updated))
                         pendingDelete = null
                     },
@@ -1583,6 +1589,7 @@ private fun RegexEditDialog(
                                 isRegex = isRegex,
                                 matchWholeWord = if (isRegex) false else matchWholeWord,
                                 caseSensitive = if (isRegex) false else caseSensitive,
+                                id = initialRule?.id ?: java.util.UUID.randomUUID().toString(),
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -435,7 +435,7 @@ class JsPluginManager(
                 logcat(LogPriority.DEBUG) {
                     "Found ${jsFiles.size} .js files and ${jsonFiles.size} .json files in plugins directory"
                 }
-                jsonFiles.forEach { f -> logcat(LogPriority.DEBUG) { "  JSON file: ${f.name}" } }
+                val jsonByName = jsonFiles.associateBy { it.name?.substringBeforeLast(".") }
 
                 val plugins = jsFiles.mapNotNull { file ->
                     try {
@@ -445,17 +445,10 @@ class JsPluginManager(
                             return@mapNotNull null
                         }
                         val nameWithoutExtension = file.name?.substringBeforeLast(".") ?: return@mapNotNull null
-                        val metadataFile = dir.findFile("$nameWithoutExtension.json")
-                        logcat(LogPriority.DEBUG) {
-                            "Looking for metadata: $nameWithoutExtension.json, found=${metadataFile != null}"
-                        }
-                        val plugin = if (metadataFile != null && metadataFile.exists()) {
+                        val metadataFile = jsonByName[nameWithoutExtension]
+                        val plugin = if (metadataFile != null) {
                             val metadataJson = metadataFile.openInputStream().bufferedReader().readText()
-                            logcat(LogPriority.DEBUG) {
-                                "Metadata content (len=${metadataJson.length}): ${metadataJson.take(100)}"
-                            }
                             if (metadataJson.isNotBlank() && metadataJson.trim().startsWith("{")) {
-                                logcat(LogPriority.DEBUG) { "Loading metadata for $nameWithoutExtension" }
                                 json.decodeFromString<JsPlugin>(metadataJson)
                             } else {
                                 logcat(LogPriority.DEBUG) {
@@ -562,9 +555,6 @@ class JsPluginManager(
         }
         logcat(LogPriority.INFO) {
             "JsPluginManager: rebuildSources() - emitting ${sources.size} sources to jsSources StateFlow"
-        }
-        sources.forEach { s ->
-            logcat(LogPriority.DEBUG) { "  JsSource: id=${s.id}, name=${s.name}, lang=${s.lang}" }
         }
         _jsSources.value = sources
         logcat(LogPriority.INFO) {

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -447,10 +447,19 @@ class JsPluginManager(
                         val nameWithoutExtension = file.name?.substringBeforeLast(".") ?: return@mapNotNull null
                         val metadataFile = jsonByName[nameWithoutExtension]
                         val plugin = if (metadataFile != null) {
-                            val metadataJson = metadataFile.openInputStream().bufferedReader().readText()
-                            if (metadataJson.isNotBlank() && metadataJson.trim().startsWith("{")) {
-                                json.decodeFromString<JsPlugin>(metadataJson)
-                            } else {
+                            // A stale SAF entry or corrupt metadata can throw on open/parse; fall back to
+                            // extracting from code rather than letting the outer catch drop the whole plugin.
+                            val parsedMetadata = try {
+                                val metadataJson = metadataFile.openInputStream().bufferedReader().readText()
+                                metadataJson.takeIf { it.isNotBlank() && it.trim().startsWith("{") }
+                                    ?.let { json.decodeFromString<JsPlugin>(it) }
+                            } catch (e: Exception) {
+                                logcat(LogPriority.WARN, e) {
+                                    "Failed to read metadata for $nameWithoutExtension, extracting from code"
+                                }
+                                null
+                            }
+                            parsedMetadata ?: run {
                                 logcat(LogPriority.DEBUG) {
                                     "Metadata file empty for $nameWithoutExtension, extracting from code"
                                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.ui.library
 
+import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
+import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
@@ -33,17 +35,7 @@ data class LibraryItem(
      */
     val fullUrl: String by lazy {
         val source = sourceManager.getOrStub(libraryManga.manga.source)
-        val baseUrl = (source as? eu.kanade.tachiyomi.source.online.HttpSource)?.baseUrl ?: ""
-        val mangaUrl = libraryManga.manga.url
-        if (baseUrl.isNotEmpty() && mangaUrl.isNotEmpty()) {
-            if (mangaUrl.startsWith("http://") || mangaUrl.startsWith("https://")) {
-                mangaUrl // Already a full URL
-            } else {
-                baseUrl.trimEnd('/') + (if (mangaUrl.startsWith("/")) mangaUrl else "/$mangaUrl")
-            }
-        } else {
-            mangaUrl
-        }
+        source.getMangaUrlOrNull(libraryManga.manga.toSManga()) ?: libraryManga.manga.url
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -83,6 +83,7 @@ import eu.kanade.presentation.library.DeleteLibraryMangaDialog
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
 import kotlinx.coroutines.launch
 import tachiyomi.domain.manga.interactor.DuplicateMatchMode
 import tachiyomi.domain.manga.model.MangaWithChapterCount
@@ -1147,17 +1148,7 @@ private fun DuplicateItem(
                 Spacer(modifier = Modifier.height(2.dp))
                 val source = remember(manga.manga.source) { sourceManager.getOrStub(manga.manga.source) }
                 val fullUrl = remember(manga.manga.url, source) {
-                    if (manga.manga.url.startsWith("http://") || manga.manga.url.startsWith("https://")) {
-                        manga.manga.url
-                    } else if (source is eu.kanade.tachiyomi.source.online.HttpSource) {
-                        try {
-                            source.getMangaUrl(manga.manga.toSManga())
-                        } catch (_: Exception) {
-                            source.baseUrl + manga.manga.url
-                        }
-                    } else {
-                        manga.manga.url
-                    }
+                    source.getMangaUrlOrNull(manga.manga.toSManga()) ?: manga.manga.url
                 }
                 Text(
                     text = fullUrl,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -627,13 +627,20 @@ class ReaderActivity : BaseActivity() {
     }
 
     /**
-     * The activity declares these config changes in the manifest so rotation no longer recreates it.
-     * That keeps the viewer (and its TTS engine, WebView state and scroll position) alive across an
-     * orientation change; re-assert immersive/menu since onResume won't run.
+     * The activity declares these config changes in the manifest so rotation no longer recreates it,
+     * which keeps a novel viewer (its TTS engine, WebView state and scroll position) alive across an
+     * orientation change; we only re-assert immersive/menu since onResume won't run.
+     *
+     * for non-novel viewers we recreate() to preserve the original behavior.
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        setMenuVisibility(viewModel.state.value.menuVisible)
+        val viewer = viewModel.state.value.viewer
+        if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
+            setMenuVisibility(viewModel.state.value.menuVisible)
+        } else {
+            recreate()
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -192,6 +192,7 @@ class ReaderActivity : BaseActivity() {
             true
         } catch (e: Exception) {
             webViewFileChooserCallback = null
+            callback.onReceiveValue(null)
             false
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -405,6 +406,39 @@ class ReaderActivity : BaseActivity() {
             )
         }
 
+        val isNovelViewer = state.viewer is NovelViewer || state.viewer is NovelWebViewViewer
+        val statusBarAtBottomEdge = novelStatusBarPosition != "top"
+
+        // Pad viewer_container by the status bar's height on its docked edge so content never renders
+        // under it. Reserved while enabled (not on menu visibility) so menu toggles don't resize the
+        // WebView and jump its scroll.
+        val statusBarReservePx = if (isNovelViewer && novelStatusBarEnabled) statusBarHeightPx else 0
+        LaunchedEffect(statusBarReservePx, statusBarAtBottomEdge) {
+            val top = if (statusBarAtBottomEdge) 0 else statusBarReservePx
+            val bottom = if (statusBarAtBottomEdge) statusBarReservePx else 0
+            val vc = binding.viewerContainer
+            if (vc.paddingTop != top || vc.paddingBottom != bottom) vc.setPadding(0, top, 0, bottom)
+        }
+
+        // Reader menu bars are transient overlays, so reserving layout for them would churn the
+        // WebView size on every toggle. Report their measured heights (system bars included) to the
+        // page as --tsundoku-safe-top/bottom + menuVisible. Read only inside snapshotFlow with
+        // remembered callbacks so scroll-driven recompositions stay off the per-frame path.
+        val menuTopBarPx = remember { mutableIntStateOf(0) }
+        val menuBottomBarPx = remember { mutableIntStateOf(0) }
+        val onTopBarHeight = remember { { px: Int -> menuTopBarPx.intValue = px } }
+        val onBottomBarHeight = remember { { px: Int -> menuBottomBarPx.intValue = px } }
+        val webViewer = state.viewer as? NovelWebViewViewer
+        val menuVisible = state.menuVisible
+        LaunchedEffect(webViewer, menuVisible, density) {
+            val viewer = webViewer ?: return@LaunchedEffect
+            snapshotFlow {
+                with(density) { menuTopBarPx.intValue.toDp().value to menuBottomBarPx.intValue.toDp().value }
+            }
+                .distinctUntilChanged()
+                .collect { (top, bottom) -> viewer.onReaderChromeChanged(menuVisible, top, bottom) }
+        }
+
         Box(modifier = Modifier.fillMaxSize()) {
             val isNovelMode = state.viewer is NovelViewer || state.viewer is NovelWebViewViewer
             if (!state.menuVisible && showPageNumber && !isNovelMode) {
@@ -428,7 +462,12 @@ class ReaderActivity : BaseActivity() {
                 0.dp
             }
 
-            AppBars(state = state, ttsOverlayBottomPadding = ttsOverlayBottomPadding)
+            AppBars(
+                state = state,
+                ttsOverlayBottomPadding = ttsOverlayBottomPadding,
+                onTopBarHeight = onTopBarHeight,
+                onBottomBarHeight = onBottomBarHeight,
+            )
 
             if (isNovelMode && !state.menuVisible && novelStatusBarEnabled) {
                 val chapter = state.novelVisibleChapter ?: state.currentChapter?.chapter
@@ -762,7 +801,12 @@ class ReaderActivity : BaseActivity() {
     }
 
     @Composable
-    fun AppBars(state: ReaderViewModel.State, ttsOverlayBottomPadding: Dp = 0.dp) {
+    fun AppBars(
+        state: ReaderViewModel.State,
+        ttsOverlayBottomPadding: Dp = 0.dp,
+        onTopBarHeight: (Int) -> Unit = {},
+        onBottomBarHeight: (Int) -> Unit = {},
+    ) {
         if (!ifSourcesLoaded()) {
             return
         }
@@ -1125,6 +1169,8 @@ class ReaderActivity : BaseActivity() {
                 bottomBarItems = bottomBarItems,
                 onQuotes = ::onQuotesClicked,
                 ttsOverlayBottomPadding = ttsOverlayBottomPadding,
+                onTopBarHeight = onTopBarHeight,
+                onBottomBarHeight = onBottomBarHeight,
             )
 
             androidx.activity.compose.BackHandler(enabled = isEditing && state.hasUnsavedChanges) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -8,6 +8,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
@@ -626,6 +627,16 @@ class ReaderActivity : BaseActivity() {
     }
 
     /**
+     * The activity declares these config changes in the manifest so rotation no longer recreates it.
+     * That keeps the viewer (and its TTS engine, WebView state and scroll position) alive across an
+     * orientation change; re-assert immersive/menu since onResume won't run.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        setMenuVisibility(viewModel.state.value.menuVisible)
+    }
+
+    /**
      * Called when the window focus changes. It sets the menu visibility to the last known state
      * to apply immersive mode again if needed.
      */
@@ -855,11 +866,23 @@ class ReaderActivity : BaseActivity() {
                 currentProgress = novelProgressFromState,
                 onProgressChange = { newProgress ->
                     viewModel.updateNovelProgressPercent(newProgress)
-                    val viewer = state.viewer
-                    if (viewer is NovelViewer) {
-                        viewer.setProgressPercent(newProgress)
-                    } else if (viewer is NovelWebViewViewer) {
-                        viewer.setProgressPercent(newProgress)
+                    // A seek is an explicit position choice; a running autoscroll would immediately
+                    // scroll away from it, so stop it first and reflect that in the toggle state.
+                    when (val viewer = state.viewer) {
+                        is NovelViewer -> {
+                            if (viewer.isAutoScrollActive()) {
+                                viewer.stopAutoScroll()
+                                isAutoScrolling = false
+                            }
+                            viewer.setProgressPercent(newProgress)
+                        }
+                        is NovelWebViewViewer -> {
+                            if (viewer.isAutoScrollActive()) {
+                                viewer.stopAutoScroll()
+                                isAutoScrolling = false
+                            }
+                            viewer.setProgressPercent(newProgress)
+                        }
                     }
                 },
 
@@ -1361,6 +1384,22 @@ class ReaderActivity : BaseActivity() {
      */
     private fun updateViewer() {
         val prevViewer = viewModel.state.value.viewer
+
+        // state.manga re-emits on non-viewer changes too: the reader's orientation dialog
+        // (setMangaOrientationType) fetches a fresh manga, which would otherwise rebuild the viewer
+        // here and tear down an active novel TTS session (and reset scroll). If the novel viewer
+        // already matches the current renderer, only (re)apply the orientation and keep the viewer.
+        if (prevViewer != null &&
+            ReadingMode.fromPreference(viewModel.getMangaReadingMode()) == ReadingMode.NOVEL
+        ) {
+            val wantsWebView = readerPreferences.novelRenderingMode.get() == "webview"
+            val matches = if (wantsWebView) prevViewer is NovelWebViewViewer else prevViewer is NovelViewer
+            if (matches) {
+                setOrientation(viewModel.getMangaOrientation())
+                return
+            }
+        }
+
         val newViewer = ReadingMode.toViewer(viewModel.getMangaReadingMode(), this)
 
         if (window.sharedElementEnterTransition is MaterialContainerTransform) {
@@ -1840,6 +1879,8 @@ class ReaderActivity : BaseActivity() {
 
         private val grayBackgroundColor = Color.rgb(0x20, 0x21, 0x25)
 
+        private var brightnessJob: Job? = null
+
         /*
          * Initializes the reader subscriptions.
          */
@@ -1986,13 +2027,15 @@ class ReaderActivity : BaseActivity() {
             if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
                 return
             }
-            if (enabled) {
+            brightnessJob?.cancel()
+            brightnessJob = if (enabled) {
                 readerPreferences.customBrightnessValue.changes()
                     .sample(0.1.seconds)
                     .onEach(::setCustomBrightnessValue)
                     .launchIn(lifecycleScope)
             } else {
                 setCustomBrightnessValue(0)
+                null
             }
         }
 
@@ -2005,13 +2048,15 @@ class ReaderActivity : BaseActivity() {
             if (viewer !is NovelViewer && viewer !is NovelWebViewViewer) {
                 return
             }
-            if (enabled) {
+            brightnessJob?.cancel()
+            brightnessJob = if (enabled) {
                 readerPreferences.novelCustomBrightnessValue.changes()
                     .sample(100)
                     .onEach(::setCustomBrightnessValue)
                     .launchIn(lifecycleScope)
             } else {
                 setCustomBrightnessValue(0)
+                null
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -21,8 +21,11 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.LAYER_TYPE_HARDWARE
 import android.view.WindowManager
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -167,6 +170,31 @@ class ReaderActivity : BaseActivity() {
     private var menuToggleToast: Toast? = null
     private var readingModeToast: Toast? = null
     private val displayRefreshHost = DisplayRefreshHost()
+
+    // Registered eagerly (before the viewer exists) so a WebView file chooser has a launcher to call.
+    private var webViewFileChooserCallback: ValueCallback<Array<Uri>>? = null
+    private val webViewFileChooserLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val uris = WebChromeClient.FileChooserParams.parseResult(result.resultCode, result.data)
+        webViewFileChooserCallback?.onReceiveValue(uris)
+        webViewFileChooserCallback = null
+    }
+
+    fun launchWebViewFileChooser(
+        callback: ValueCallback<Array<Uri>>,
+        params: WebChromeClient.FileChooserParams,
+    ): Boolean {
+        webViewFileChooserCallback?.onReceiveValue(null)
+        webViewFileChooserCallback = callback
+        return try {
+            webViewFileChooserLauncher.launch(params.createIntent())
+            true
+        } catch (e: Exception) {
+            webViewFileChooserCallback = null
+            false
+        }
+    }
 
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -627,11 +627,9 @@ class ReaderActivity : BaseActivity() {
     }
 
     /**
-     * The activity declares these config changes in the manifest so rotation no longer recreates it,
-     * which keeps a novel viewer (its TTS engine, WebView state and scroll position) alive across an
-     * orientation change; we only re-assert immersive/menu since onResume won't run.
-     *
-     * for non-novel viewers we recreate() to preserve the original behavior.
+     * The manifest declares these config changes so rotation no longer recreates the activity, keeping
+     * a novel viewer (TTS engine, WebView state, scroll position) alive across an orientation change.
+     * We re-assert immersive/menu since onResume won't run. Non-novel viewers recreate() as before.
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -633,9 +633,15 @@ class ReaderActivity : BaseActivity() {
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        val viewer = viewModel.state.value.viewer
-        if (viewer is NovelViewer || viewer is NovelWebViewViewer) {
-            setMenuVisibility(viewModel.state.value.menuVisible)
+        val state = viewModel.state.value
+        val viewer = state.viewer
+        // viewer is null until updateViewer() runs, which happens asynchronously after manga
+        // loads. Rotating in that window shouldn't fall through to recreate() for a novel entry,
+        // so fall back to the manga's type while the viewer hasn't been created yet.
+        val isNovel = viewer is NovelViewer || viewer is NovelWebViewViewer ||
+            (viewer == null && state.manga?.isNovel == true)
+        if (isNovel) {
+            setMenuVisibility(state.menuVisible)
         } else {
             recreate()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1946,7 +1946,13 @@ class ReaderActivity : BaseActivity() {
                         setNovelCustomBrightness(readerPreferences.novelCustomBrightness.get())
                         setKeepScreenOn(readerPreferences.novelKeepScreenOn.get())
                     } else {
-                        // Switch back to manga reader settings for non-novel viewers
+                        // Switch back to manga reader settings for non-novel viewers. Must also
+                        // resync brightness here, not just keep-screen-on: setNovelCustomBrightness
+                        // above shares brightnessJob with setCustomBrightness, and if novel custom
+                        // brightness was left active, leaving this branch to touch only
+                        // keepScreenOn would leave that job running and applying novel-preference
+                        // brightness to the new non-novel viewer.
+                        setCustomBrightness(readerPreferences.customBrightness.get())
                         setKeepScreenOn(readerPreferences.keepScreenOn.get())
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -684,7 +684,7 @@ class ReaderActivity : BaseActivity() {
      */
     override fun onResume() {
         super.onResume()
-        viewModel.restartReadTimer()
+        lifecycleScope.launch { viewModel.restartReadTimerSynced() }
         setMenuVisibility(viewModel.state.value.menuVisible)
         if (readerPreferences.novelTtsBackgroundPlayback.get() &&
             currentNovelTtsState()?.active == true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1015,7 +1015,15 @@ class ReaderViewModel @JvmOverloads constructor(
         val endTime = Date()
         val sessionReadDuration = chapterReadStartTime?.let { endTime.time - it } ?: 0
 
-        upsertHistory.await(HistoryUpdate(chapterId, endTime, sessionReadDuration))
+        // Novels stamp last_read on chapter entry via setNovelVisibleChapter, which owns recency.
+        // Re-stamping it here (on a chapter switch or pause flush) can push the just-left chapter's
+        // last_read past the one being read, so on a hard kill the wrong chapter tops history. Only
+        // accumulate duration for novels; manga keeps the entry-less last_read = now behavior.
+        if (manga?.isNovel == true) {
+            upsertHistory.awaitTimeReadOnly(HistoryUpdate(chapterId, endTime, sessionReadDuration))
+        } else {
+            upsertHistory.await(HistoryUpdate(chapterId, endTime, sessionReadDuration))
+        }
         chapterReadStartTime = null
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -287,6 +287,13 @@ class ReaderViewModel @JvmOverloads constructor(
     /** Serializes novel progress saves to prevent concurrent saves racing each other. */
     private val novelProgressMutex = Mutex()
 
+    /**
+     * Serializes history writes so the read+clear of [chapterReadStartTime] is atomic. A pause flush
+     * and a chapter-change flush can fire concurrently; without this both read the same start time
+     * before either clears it, double-counting the session's read duration.
+     */
+    private val historyMutex = Mutex()
+
     init {
         // To save state
         state.map { it.viewerChapters?.currChapter }
@@ -1010,8 +1017,8 @@ class ReaderViewModel @JvmOverloads constructor(
     /**
      * Saves the chapter last read history if incognito mode isn't on.
      */
-    private suspend fun updateHistory(readerChapter: ReaderChapter) {
-        if (incognitoMode) return
+    private suspend fun updateHistory(readerChapter: ReaderChapter) = historyMutex.withLock {
+        if (incognitoMode) return@withLock
 
         val chapterId = readerChapter.chapter.id!!
         val endTime = Date()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -62,6 +62,7 @@ import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -80,6 +81,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import mihon.core.archive.archiveReader
 import tachiyomi.core.common.preference.toggle
@@ -445,8 +447,7 @@ class ReaderViewModel @JvmOverloads constructor(
         viewModelScope.launchIO {
             logcat { "Loading ${chapter.chapter.url}" }
 
-            flushReadTimer()
-            restartReadTimer()
+            flushReadTimerAndRestart()
 
             try {
                 loadChapter(loader, chapter)
@@ -565,8 +566,7 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     private fun setActiveChapterWithoutReload(chapter: ReaderChapter) {
         viewModelScope.launchIO {
-            flushReadTimer()
-            restartReadTimer()
+            flushReadTimerAndRestart()
 
             val chapterPos = chapterList.indexOfFirst { it.chapter.id == chapter.chapter.id }
             if (chapterPos < 0) return@launchIO
@@ -1002,12 +1002,16 @@ class ReaderViewModel @JvmOverloads constructor(
         chapterReadStartTime = Instant.now().toEpochMilli()
     }
 
-    fun flushReadTimer() {
-        getCurrentChapter()?.let {
-            viewModelScope.launchNonCancellable {
-                updateHistory(it)
-            }
-        }
+    /**
+     * Flushes the current chapter's read timer, then starts a fresh one, ordered so the flush's
+     * read+clear of [chapterReadStartTime] completes before [restartReadTimer] writes the new start.
+     * A fire-and-forget flush + [restartReadTimer] pair can't guarantee this: the async flush would
+     * observe the already-restarted timer and record a ~0 session duration, losing the chapter that
+     * was just left. The write runs [NonCancellable] to survive the load being cancelled.
+     */
+    private suspend fun flushReadTimerAndRestart() {
+        getCurrentChapter()?.let { withContext(NonCancellable) { updateHistory(it) } }
+        restartReadTimer()
     }
 
     suspend fun updateHistory() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -14,6 +14,7 @@ import eu.kanade.domain.chapter.model.toDbChapter
 import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.model.readerOrientation
 import eu.kanade.domain.manga.model.readingMode
+import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.domain.track.service.TrackPreferences
@@ -55,6 +56,7 @@ import eu.kanade.tachiyomi.util.chapter.removeDuplicates
 import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.source.getChapterUrlOrNull
+import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import eu.kanade.tachiyomi.util.system.toast
@@ -1051,6 +1053,21 @@ class ReaderViewModel @JvmOverloads constructor(
     }
 
     fun getSource() = manga?.source?.let { sourceManager.getOrStub(it) }
+
+    fun getMangaUrl(): String? {
+        val manga = manga ?: return null
+        val source = getSource() ?: return null
+
+        return try {
+            when (source) {
+                is HttpSource, is JsSource -> source.getMangaUrlOrNull(manga.toSManga())
+                else -> manga.url.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            null
+        }
+    }
 
     fun getChapterUrl(): String? {
         val sChapter = getCurrentChapter()?.chapter ?: return null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1003,6 +1003,15 @@ class ReaderViewModel @JvmOverloads constructor(
     }
 
     /**
+     * [restartReadTimer], but serialized against [historyMutex] so a resume-triggered restart can't
+     * race an in-flight pause flush from [ReaderActivity.onPause] -- without this, a fast
+     * pause/resume can let the restart overwrite [chapterReadStartTime] before the flush reads it.
+     */
+    suspend fun restartReadTimerSynced() = historyMutex.withLock {
+        restartReadTimer()
+    }
+
+    /**
      * Flushes the current chapter's read timer, then starts a fresh one, ordered so the flush's
      * read+clear of [chapterReadStartTime] completes before [restartReadTimer] writes the new start.
      * A fire-and-forget flush + [restartReadTimer] pair can't guarantee this: the async flush would

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -227,7 +227,10 @@ class ReaderPreferences(
     val novelTheme: Preference<String> = preferenceStore.getString("pref_novel_theme", "app")
     val novelLineHeight: Preference<Float> = preferenceStore.getFloat("pref_novel_line_height", 1.6f)
     val novelTextAlign: Preference<String> = preferenceStore.getString("pref_novel_text_align", "left")
-    val novelAutoScrollSpeed: Preference<Int> = preferenceStore.getInt("pref_novel_auto_scroll_speed", 30)
+    // Stored as half-steps (speed x2) so the slider can move in 0.5 increments with an Int pref:
+    // 2..20 maps to speed 1.0..10.0. New key; the old "pref_novel_auto_scroll_speed" mixed a 1..10
+    // level and a 5..120 sec/screen scale, so it isn't reused. Divide by 2f to get the speed level.
+    val novelAutoScrollSpeed: Preference<Int> = preferenceStore.getInt("pref_novel_auto_scroll_speed_half", 6)
     val novelVolumeKeysScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_volume_keys_scroll", false)
     val novelTapToScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_tap_to_scroll", false)
     val novelTextSelectable: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_text_selectable", true)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -227,6 +227,7 @@ class ReaderPreferences(
     val novelTheme: Preference<String> = preferenceStore.getString("pref_novel_theme", "app")
     val novelLineHeight: Preference<Float> = preferenceStore.getFloat("pref_novel_line_height", 1.6f)
     val novelTextAlign: Preference<String> = preferenceStore.getString("pref_novel_text_align", "left")
+
     // Stored as half-steps (speed x2) so the slider can move in 0.5 increments with an Int pref.
     // 2..20 maps to speed 1.0..10.0. New key: the old "pref_novel_auto_scroll_speed" mixed a 1..10
     // level and a 5..120 sec/screen scale, so it isn't reused. Divide by 2f to get the speed level.
@@ -262,6 +263,14 @@ class ReaderPreferences(
     val enableEpubJs: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_enable_epub_js", false)
     val novelSourceCssPriority: Preference<Boolean> = preferenceStore.getBoolean(
         "pref_novel_source_css_priority",
+        false,
+    )
+
+    // Opt-in: kept off in case a WebChromeClient breaks compat on some OEM WebView builds.
+    val novelWebViewDevTools: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_webview_devtools", false)
+
+    val novelConsoleErrorToast: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_novel_console_error_toast",
         false,
     )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -227,8 +227,8 @@ class ReaderPreferences(
     val novelTheme: Preference<String> = preferenceStore.getString("pref_novel_theme", "app")
     val novelLineHeight: Preference<Float> = preferenceStore.getFloat("pref_novel_line_height", 1.6f)
     val novelTextAlign: Preference<String> = preferenceStore.getString("pref_novel_text_align", "left")
-    // Stored as half-steps (speed x2) so the slider can move in 0.5 increments with an Int pref:
-    // 2..20 maps to speed 1.0..10.0. New key; the old "pref_novel_auto_scroll_speed" mixed a 1..10
+    // Stored as half-steps (speed x2) so the slider can move in 0.5 increments with an Int pref.
+    // 2..20 maps to speed 1.0..10.0. New key: the old "pref_novel_auto_scroll_speed" mixed a 1..10
     // level and a 5..120 sec/screen scale, so it isn't reused. Divide by 2f to get the speed level.
     val novelAutoScrollSpeed: Preference<Int> = preferenceStore.getInt("pref_novel_auto_scroll_speed_half", 6)
     val novelVolumeKeysScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_volume_keys_scroll", false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -232,6 +232,9 @@ class ReaderPreferences(
     // 2..20 maps to speed 1.0..10.0. New key: the old "pref_novel_auto_scroll_speed" mixed a 1..10
     // level and a 5..120 sec/screen scale, so it isn't reused. Divide by 2f to get the speed level.
     val novelAutoScrollSpeed: Preference<Int> = preferenceStore.getInt("pref_novel_auto_scroll_speed_half", 6)
+
+    // Resolve the stored half-step Int to the speed level the viewers scroll at (1.0..10.0).
+    fun novelAutoScrollLevel(): Float = novelAutoScrollSpeed.get().coerceIn(2, 20) / 2f
     val novelVolumeKeysScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_volume_keys_scroll", false)
     val novelTapToScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_tap_to_scroll", false)
     val novelTextSelectable: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_text_selectable", true)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -1887,16 +1887,23 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     }
 
     fun startAutoScroll() {
-        val speed = preferences.novelAutoScrollSpeed.get().coerceIn(1, 10)
+        // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
+        val level = preferences.novelAutoScrollSpeed.get().coerceIn(2, 20) / 2f
         isAutoScrolling = true
 
         autoScrollJob?.cancel()
         autoScrollJob = scope.launch {
+            // Accumulate the fractional per-tick amount so half-step speeds (and levels below 1px per
+            // tick) still scroll smoothly instead of truncating to 0. Instant per-tick scroll matches
+            // the WebView path; smoothScrollBy re-arms a ~250ms animation every 50ms and juddered.
+            var acc = 0f
             while (isActive && isAutoScrolling) {
-                val scrollAmount = speed
-                // Instant per-tick scroll (matches the WebView path). smoothScrollBy re-arms a ~250ms
-                // animation every 50ms, so each tick fights the previous one and the speed judders.
-                scrollView.scrollBy(0, scrollAmount)
+                acc += level
+                val step = acc.toInt()
+                if (step > 0) {
+                    scrollView.scrollBy(0, step)
+                    acc -= step
+                }
                 delay(50L)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -439,6 +439,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     /** True when TTS autoplay is speaking the chapter currently on screen. */
     private fun isTtsDrivingVisibleChapter(): Boolean =
         ttsController.isTtsAutoPlay &&
+            !ttsController.ttsPaused &&
             ttsController.ttsPlaybackChapterId != null &&
             loadedChapters.getOrNull(currentChapterIndex)?.chapter?.chapter?.id == ttsController.ttsPlaybackChapterId
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -88,6 +88,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     private val navigator get() = config.navigator
 
     private var loadJob: Job? = null
+    private var attachListener: View.OnAttachStateChangeListener? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
     private var renderGeneration = 0L
@@ -284,13 +285,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         // Allow descendants to receive focus so TextView text selection works.
         // The reader container typically sets FOCUS_BLOCK_DESCENDANTS which prevents
         // the TextView's Editor from initializing properly for selection.
-        container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+        attachListener = object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(v: View) {
                 (container.parent as? ViewGroup)?.descendantFocusability =
                     ViewGroup.FOCUS_AFTER_DESCENDANTS
             }
             override fun onViewDetachedFromWindow(v: View) {}
-        })
+        }.also(container::addOnAttachStateChangeListener)
     }
 
     private fun setupScrollListener() {
@@ -316,7 +317,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
             val chapterProgress = calculateCurrentChapterProgress(scrollY)
 
-            if (!inGracePeriod) {
+            // While TTS is reading the visible chapter it owns progress for that chapter (chunk-based,
+            // persisted by saveTtsProgressForChunk and mirrored to the slider). Letting the scroll path
+            // also write would race the same page's last_page_read with a different percent.
+            if (!inGracePeriod && !isTtsDrivingVisibleChapter()) {
                 scheduleProgressSave(chapterProgress)
                 activity.onNovelProgressChanged(chapterProgress)
             }
@@ -431,6 +435,13 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
      * hook runs on every chunk advance and is independent of scroll.
      */
     private var lastSavedTtsChunkIndex: Int = -1
+
+    /** True when TTS autoplay is speaking the chapter currently on screen. */
+    private fun isTtsDrivingVisibleChapter(): Boolean =
+        ttsController.isTtsAutoPlay &&
+            ttsController.ttsPlaybackChapterId != null &&
+            loadedChapters.getOrNull(currentChapterIndex)?.chapter?.chapter?.id == ttsController.ttsPlaybackChapterId
+
     private fun saveTtsProgressForChunk(chunkIndex: Int) {
         if (chunkIndex == lastSavedTtsChunkIndex) return
         lastSavedTtsChunkIndex = chunkIndex
@@ -446,6 +457,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val page = loaded.chapter.pages?.firstOrNull() ?: return
         val percent = (((chunkIndex + 1) * 100f) / total).roundToInt().coerceIn(0, 100)
         activity.saveNovelProgress(page, percent)
+        // Keep the slider in sync with TTS when the spoken chapter is on screen, since the scroll
+        // path is suppressed for it (see isTtsDrivingVisibleChapter).
+        if (isTtsDrivingVisibleChapter()) activity.onNovelProgressChanged(percent / 100f)
     }
 
     private fun shouldAutoMarkShortChapter(page: ReaderPage?): Boolean {
@@ -1320,6 +1334,8 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         ttsController.destroy()
         scope.cancel() // cancels loadJob and all other child coroutines
         chapterQueue.clear()
+        attachListener?.let(container::removeOnAttachStateChangeListener)
+        attachListener = null
     }
 
     override fun getView(): View {
@@ -1878,7 +1894,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         autoScrollJob = scope.launch {
             while (isActive && isAutoScrolling) {
                 val scrollAmount = speed
-                scrollView.smoothScrollBy(0, scrollAmount)
+                // Instant per-tick scroll (matches the WebView path). smoothScrollBy re-arms a ~250ms
+                // animation every 50ms, so each tick fights the previous one and the speed judders.
+                scrollView.scrollBy(0, scrollAmount)
                 delay(50L)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -1889,7 +1889,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     fun startAutoScroll() {
         // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
-        val level = preferences.novelAutoScrollSpeed.get().coerceIn(2, 20) / 2f
+        val level = preferences.novelAutoScrollLevel()
         isAutoScrolling = true
 
         autoScrollJob?.cancel()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -35,6 +35,10 @@ internal object NovelWebViewChapterMeta {
     const val EVENT_CHAPTER_LOADING = "tsundoku:chapterloading"
     const val EVENT_TTS_STATE = "tsundoku:ttsstatechange"
 
+    // Fired page-side (scroll-tracking.js) as reading progress advances, throttled with the slider
+    // bridge. Dispatched from JS, not Kotlin, so there is no per-frame bridge hop.
+    const val EVENT_PROGRESS = "tsundoku:progresschange"
+
     // Safe-area CSS custom properties: the reader menu bar heights the page must clear (0 while the
     // menu is hidden). Single source of truth for both the injector and the CSS that reads them.
     const val CSS_VAR_SAFE_TOP = "--tsundoku-safe-top"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -35,6 +35,11 @@ internal object NovelWebViewChapterMeta {
     const val EVENT_CHAPTER_LOADING = "tsundoku:chapterloading"
     const val EVENT_TTS_STATE = "tsundoku:ttsstatechange"
 
+    // Safe-area CSS custom properties: the reader menu bar heights the page must clear (0 while the
+    // menu is hidden). Single source of truth for both the injector and the CSS that reads them.
+    const val CSS_VAR_SAFE_TOP = "--tsundoku-safe-top"
+    const val CSS_VAR_SAFE_BOTTOM = "--tsundoku-safe-bottom"
+
     fun String.jsEscape(): String =
         this.replace("\\", "\\\\")
             .replace("\"", "\\\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilder.kt
@@ -51,10 +51,29 @@ internal object NovelWebViewDocumentBuilder {
         }
 
         val finalContent = if (input.processed.isPlainText) {
+            // Per-paragraph <p> (textContent-set, never parsed as markup) instead of one <pre>, so
+            // plain text exposes the same block elements the copy/quote paragraph-index counter walks.
+            val paragraphsJsonArray = input.processed.text
+                .split(Regex("\n{2,}"))
+                .filter { it.isNotEmpty() }
+                .joinToString(",", prefix = "[", postfix = "]") { quoteForJson(it) }
             """
-                <pre class="$PLAIN_TEXT_CLASS" $ATTR_DATA_PLAIN_TEXT="1" style="white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere; margin: 0;"></pre>
+                <div class="$PLAIN_TEXT_CLASS" $ATTR_DATA_PLAIN_TEXT="1"></div>
                 <script>
-                    document.querySelector('.$PLAIN_TEXT_CLASS').textContent = ${quoteForJson(input.processed.text)};
+                    (function() {
+                        var container = document.querySelector('.$PLAIN_TEXT_CLASS');
+                        var paragraphs = $paragraphsJsonArray;
+                        var frag = document.createDocumentFragment();
+                        for (var i = 0; i < paragraphs.length; i++) {
+                            var p = document.createElement('p');
+                            p.style.whiteSpace = 'pre-wrap';
+                            p.style.wordBreak = 'break-word';
+                            p.style.overflowWrap = 'anywhere';
+                            p.textContent = paragraphs[i];
+                            frag.appendChild(p);
+                        }
+                        container.appendChild(frag);
+                    })();
                 </script>
             """.trimIndent()
         } else {
@@ -104,6 +123,7 @@ internal object NovelWebViewDocumentBuilder {
                     $chapterDividerCss
                     tsundoku-chapter {
                         display: block;
+                        contain: content;
                     }
                     img {
                         max-width: 100%;

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewImageCache.kt
@@ -44,7 +44,7 @@ internal class NovelWebViewImageCache(
         } else {
             fallbackChapterId to encodedSuffix
         }
-        val imagePath = URLDecoder.decode(encodedImagePath, "UTF-8")
+        val imagePath = runCatching { URLDecoder.decode(encodedImagePath, "UTF-8") }.getOrNull() ?: return null
 
         val loader = chapterId?.let { chapterLoaderMap[it] } ?: fallbackLoader
         val cacheKey = buildCacheKey(chapterId, imagePath)
@@ -134,7 +134,11 @@ internal class NovelWebViewImageCache(
         "${chapterId ?: -1L}:$imagePath"
 
     private fun makeCachedFile(cacheKey: String, imagePath: String): File {
-        val fileSuffix = imagePath.substringAfterLast('.', "bin").ifBlank { "bin" }
+        // substringAfterLast('.') alone would scan the whole path, not just the filename -- a '.' in
+        // a directory segment (e.g. "v1.2/cover.png") would put a "/" into the suffix and point the
+        // cache file at a nonexistent subdirectory.
+        val fileName = imagePath.substringAfterLast('/')
+        val fileSuffix = fileName.substringAfterLast('.', "bin").ifBlank { "bin" }
         val keyHash = java.security.MessageDigest.getInstance("SHA-256")
             .digest(cacheKey.toByteArray())
             .take(16)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -253,6 +253,7 @@ internal class NovelWebViewStyler(
                 "INFINITE_SCROLL_ENABLED" to preferences.novelInfiniteScroll.get().toString(),
                 "LOAD_THRESHOLD" to effectiveThreshold.toString(),
                 "DONE_THRESHOLD" to NovelProgress.DONE_THRESHOLD.toString(),
+                "PROGRESS_EVENT" to NovelWebViewChapterMeta.EVENT_PROGRESS,
             ),
         )
         evaluateJs(js)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -205,16 +205,21 @@ internal class NovelWebViewStyler(
         evaluateJs(js)
     }
 
-    fun injectScript(buildTsundokuScript: () -> String) {
+    fun injectScript(isAppend: Boolean = false, buildTsundokuScript: () -> String) {
         evaluateJs(buildTsundokuScript())
 
-        val customJs = preferences.novelCustomJs.get()
-        if (customJs.isNotBlank()) evaluateJs(customJs)
+        // Appends re-run only runOnAppend snippets; one-shot code stays on the initial load so it
+        // doesn't fire again on every appended chapter.
+        if (!isAppend) {
+            val customJs = preferences.novelCustomJs.get()
+            if (customJs.isNotBlank()) evaluateJs(customJs)
+        }
 
         val jsSnippetsJson = preferences.novelCustomJsSnippets.get()
         val enabledSnippetsJs = try {
             val snippets = Json.decodeFromString<List<CodeSnippet>>(jsSnippetsJson)
-            snippets.filter { it.enabled }.joinToString("\n") { it.code }
+            snippets.filter { it.enabled && (!isAppend || it.runOnAppend) }
+                .joinToString("\n") { it.code }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR) { "Failed to parse JS snippets: ${e.message}" }
             ""

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -232,7 +232,10 @@ internal class NovelWebViewStyler(
         val js = NovelWebViewJsAssets.loadWith(
             activity,
             "next-chapter-button.js",
-            mapOf("BTN_CONTAINER_ID" to ID_NEXT_CHAPTER_BTN_CONTAINER),
+            mapOf(
+                "BTN_CONTAINER_ID" to ID_NEXT_CHAPTER_BTN_CONTAINER,
+                "SAFE_BOTTOM_VAR" to NovelWebViewChapterMeta.CSS_VAR_SAFE_BOTTOM,
+            ),
         )
         evaluateJs(js)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -270,12 +270,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.NEXT,
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.RIGHT,
                     -> {
-                        webView.evaluateJavascript("window.scrollBy(0, ${(container.height * 0.8).toInt()});", null)
+                        pageScrollBy(1)
                     }
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.PREV,
                     eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion.LEFT,
                     -> {
-                        webView.evaluateJavascript("window.scrollBy(0, -${(container.height * 0.8).toInt()});", null)
+                        pageScrollBy(-1)
                     }
                 }
 
@@ -662,6 +662,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                                 TtsController.StartRequest.VIEWPORT -> startTtsFromViewport()
                             }
                         }
+                        // A full reload replaces window, dropping the autoscroll rAF loop; re-arm it
+                        // on the new document so autoscroll survives a non-inf-scroll chapter change.
+                        if (isAutoScrolling) startAutoScroll()
                     }
                 }
             }
@@ -1533,7 +1536,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     override fun handleKeyEvent(event: KeyEvent): Boolean {
         val isUp = event.action == KeyEvent.ACTION_UP
-        val scrollAmount = (container.height * 0.30).toInt()
 
         when (event.keyCode) {
             KeyEvent.KEYCODE_MENU -> {
@@ -1542,14 +1544,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             }
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
                 if (preferences.novelVolumeKeysScroll.get() && !activity.viewModel.state.value.menuVisible) {
-                    if (!isUp) webView.evaluateJavascript("window.scrollBy(0, $scrollAmount);", null)
+                    if (!isUp) pageScrollBy(1, 0.3)
                     return true
                 }
                 return false
             }
             KeyEvent.KEYCODE_VOLUME_UP -> {
                 if (preferences.novelVolumeKeysScroll.get() && !activity.viewModel.state.value.menuVisible) {
-                    if (!isUp) webView.evaluateJavascript("window.scrollBy(0, -$scrollAmount);", null)
+                    if (!isUp) pageScrollBy(-1, 0.3)
                     return true
                 }
                 return false
@@ -2156,6 +2158,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         webView.scrollTo(0, 0)
     }
 
+    /**
+     * Scroll by [fraction] of the viewport in [direction] (+1 down, -1 up). Uses window.innerHeight
+     * (CSS pixels) rather than container.height (device pixels): window.scrollBy expects CSS pixels,
+     * so passing device pixels overshoots by devicePixelRatio and skips content between taps.
+     */
+    private fun pageScrollBy(direction: Int, fraction: Double = 0.9) {
+        val sign = if (direction < 0) "-" else ""
+        webView.evaluateJavascript("window.scrollBy(0, $sign(window.innerHeight * $fraction));", null)
+    }
+
     fun toggleAutoScroll() {
         isAutoScrolling = !isAutoScrolling
 
@@ -2170,27 +2182,54 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         val speed = preferences.novelAutoScrollSpeed.get().coerceIn(1, 10)
         isAutoScrolling = true
 
-        autoScrollJob?.cancel()
-        autoScrollJob = scope.launch {
-            while (isActive && isAutoScrolling) {
-                val scrollAmount = speed
-                evaluateJavascriptSafe(
-                    """
-                    (function() {
-                        window.scrollBy(0, $scrollAmount);
-                    })();
-                    """.trimIndent(),
-                    null,
-                )
-                delay(50L)
-            }
-        }
+        // Drive the scroll from a single in-page requestAnimationFrame loop instead of a Kotlin
+        // timer that fires window.scrollBy over the JS bridge every 50ms: those round-trips arrive
+        // with jittery timing and each moves a fixed integer step, which reads as stutter. The rAF
+        // loop advances by (px/sec * frame delta) with sub-pixel accumulation for smooth motion, and
+        // naturally pauses while the WebView is backgrounded (no frames), resuming without a jump via
+        // the dt clamp. speed (1..10) maps to CSS px/sec.
+        val pxPerSec = speed * 20
+        evaluateJavascriptSafe(
+            """
+            (function() {
+                var s = window.__tdAutoScroll || (window.__tdAutoScroll = {});
+                s.pxPerSec = $pxPerSec;
+                if (s.running) return;
+                s.running = true;
+                s.last = null;
+                s.acc = 0;
+                function step(ts) {
+                    if (!s.running) return;
+                    if (s.last === null) s.last = ts;
+                    var dt = (ts - s.last) / 1000;
+                    s.last = ts;
+                    // Clamp so a long background gap (or first frame) can't jump the page.
+                    if (dt > 0.05) dt = 0.05;
+                    s.acc += s.pxPerSec * dt;
+                    var whole = Math.floor(s.acc);
+                    if (whole > 0) { window.scrollBy(0, whole); s.acc -= whole; }
+                    s.raf = requestAnimationFrame(step);
+                }
+                s.raf = requestAnimationFrame(step);
+            })();
+            """.trimIndent(),
+            null,
+        )
     }
 
     fun stopAutoScroll() {
         isAutoScrolling = false
         autoScrollJob?.cancel()
         autoScrollJob = null
+        evaluateJavascriptSafe(
+            """
+            (function() {
+                var s = window.__tdAutoScroll;
+                if (s) { s.running = false; if (s.raf) cancelAnimationFrame(s.raf); }
+            })();
+            """.trimIndent(),
+            null,
+        )
     }
 
     fun isAutoScrollActive(): Boolean = isAutoScrolling

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -196,7 +196,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var autoScrollStartAttempt = 0
 
     // The error page is a fresh document that drops the autoscroll rAF loop; re-arm it once its
-    // onPageFinished lands, since that load bypasses the isLoadingRealChapter re-arm path.
+    // onPageFinished lands, since that load never enters DocState.LOADING_REAL so the re-arm path
+    // in the real-chapter gate is skipped.
     private var rearmAutoScrollOnErrorPage = false
 
     // Tracked so a JS dialog still on screen at teardown is dismissed instead of leaking the window.
@@ -212,19 +213,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // Survives ttsController.stop() - set when TTS triggers a non-inf-scroll chapter load.
     private var pendingTtsAutoStartOnLoad = false
 
-    // True only while loadHtmlContent() has called loadDataWithBaseURL for real chapter content
-    // (not the loading-indicator page). Lets onPageFinished distinguish real vs loading loads.
-    private var isLoadingRealChapter = false
+    // Single source of truth for the loaded document's lifecycle, replacing three hand-synced
+    // booleans (isLoadingRealChapter/webChapterContentReady/webChapterIsError) that had to be flipped
+    // together on every load/error/finish. Only these four combinations were ever legal; the enum
+    // makes the illegal ones unrepresentable.
+    //   LOADING       loading-indicator page up, or a base load queued but not yet issued
+    //   LOADING_REAL  real-chapter loadDataWithBaseURL issued, awaiting its onPageFinished
+    //   READY         real content committed; TTS may read the body and appends may splice onto it
+    //   ERROR         error placeholder committed; body counts as ready but has no DOM to append onto
+    private enum class DocState { LOADING, LOADING_REAL, READY, ERROR }
+    private var docState = DocState.LOADING
 
-    // False while the loading indicator is up or real content is still loading; true once real
-    // chapter content has finished rendering. Guards TTS from reading the loading placeholder.
-    private var webChapterContentReady = false
+    // Real content or an error placeholder is committed. Error counts as ready so a failed load
+    // can't block infinite-scroll appends forever; webChapterIsError then suppresses the append.
+    private val webChapterContentReady get() = docState == DocState.READY || docState == DocState.ERROR
 
-    // True while the current DOM is an error placeholder rather than real chapter content.
-    // webChapterContentReady is force-set true on error (so appends aren't blocked forever), but
-    // there's no valid base DOM to append onto, so this suppresses infinite-scroll appends until a
-    // real chapter renders.
-    private var webChapterIsError = false
+    // Current DOM is an error placeholder, so there is no valid base to append the next chapter onto.
+    private val webChapterIsError get() = docState == DocState.ERROR
 
     private val ttsController: TtsController
 
@@ -659,7 +664,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     hideLoadingIndicator()
 
                     // The error page is a fresh document; re-arm autoscroll before the real-chapter
-                    // gate below, which the error load (isLoadingRealChapter=false) would skip.
+                    // gate below, which the error load (docState=ERROR, not LOADING_REAL) would skip.
                     if (rearmAutoScrollOnErrorPage) {
                         rearmAutoScrollOnErrorPage = false
                         if (isAutoScrolling) startAutoScroll()
@@ -668,8 +673,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     // Loading/error loads also fire onPageFinished(about:blank), and some WebView
                     // builds fire twice per navigation; gate the whole body so scripts/snippets
                     // inject only on the first genuine chapter load.
-                    if (!isLoadingRealChapter) return
-                    isLoadingRealChapter = false
+                    if (docState != DocState.LOADING_REAL) return
+                    docState = DocState.READY
 
                     styler.injectScript { buildTsundokuScript() }
                     styler.injectScrollTracking()
@@ -681,8 +686,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     if (isEditingMode) {
                         toggleEditMode(true)
                     }
-                    // Real content rendered; TTS may now read the body.
-                    webChapterContentReady = true
+                    // Real content rendered (docState = READY above); TTS may now read the body.
                     dispatchLoadingChapter(false)
                     if (pendingTtsAutoStartOnLoad) {
                         pendingTtsAutoStartOnLoad = false
@@ -1182,9 +1186,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             // avoids splicing a stale chapter's content onto the newly loaded one when it resumes.
             appendJob?.cancel()
             // Gate infinite-scroll appends until this base chapter's DOM is committed (onPageFinished
-            // flips it back true). Otherwise an early append (JS scroll threshold) is wiped by the
+            // sets READY). Otherwise an early append (JS scroll threshold) is wiped by the
             // clear()+loadHtmlContent this job runs, which re-appends and duplicates the chapter.
-            webChapterContentReady = false
+            docState = DocState.LOADING
         }
         val job = scope.launch {
             if (!isAppendOrPrepend && translator != null) {
@@ -1433,8 +1437,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         // Signal to onPageFinished that the next callback is for real chapter content, not
         // the loading-indicator page (which also fires onPageFinished with url="about:blank").
-        isLoadingRealChapter = true
-        webChapterContentReady = false
+        docState = DocState.LOADING_REAL
         dispatchLoadingChapter(true)
         // New document: hold scroll callbacks and clear the baseline so a stale flush can't write
         // the previous chapter's percent here, restoreScrollPosition seeds the real value.
@@ -1592,8 +1595,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             </html>
         """.trimIndent()
 
-        isLoadingRealChapter = false
-        webChapterContentReady = false
+        docState = DocState.LOADING
         webView.loadDataWithBaseURL(null, loadingHtml, "text/html", "UTF-8", null)
     }
 
@@ -1604,12 +1606,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         val fmt = ErrorFormatter.format(error)
         logcat(LogPriority.ERROR) { "NovelWebViewViewer: Chapter load failed\n${fmt.stackTrace}" }
 
-        // No real chapter DOM is coming for this load, so the onPageFinished check for
-        // isLoadingRealChapter won't fire and webChapterContentReady would otherwise stay
-        // false forever, permanently blocking infinite-scroll appends after any load error.
-        isLoadingRealChapter = false
-        webChapterContentReady = true
-        webChapterIsError = true
+        // No real chapter DOM is coming for this load, so onPageFinished won't reach the READY
+        // transition. ERROR keeps webChapterContentReady true (so a failed load can't block
+        // infinite-scroll appends forever) while marking the body un-appendable.
+        docState = DocState.ERROR
 
         val theme = preferences.novelTheme.get()
         val backgroundColor = preferences.novelBackgroundColor.get()
@@ -2535,7 +2535,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             "TTS (WebView): stopTts called ts=${System.currentTimeMillis()} currentChapterIndex=$currentChapterIndex, ttsCurrentChunkIndex=${ttsController.ttsCurrentChunkIndex}, ttsResumeChunkIndex=${ttsController.ttsResumeChunkIndex}, ttsPlaybackChapterIndex=${ttsController.ttsPlaybackChapterIndex}, ttsPlaybackChapterId=${ttsController.ttsPlaybackChapterId}"
         }
         pendingTtsAutoStartOnLoad = false
-        isLoadingRealChapter = false
+        // Drop a pending real-load signal so a stale onPageFinished after stop can't inject; leave a
+        // committed READY/ERROR document intact.
+        if (docState == DocState.LOADING_REAL) docState = DocState.LOADING
         ttsController.stop()
         handoffState = TtsHandoffState.Idle
         dispatchTtsState()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -19,6 +19,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import androidx.annotation.Keep
+import androidx.lifecycle.Lifecycle
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.loader.PageLoader
@@ -127,6 +128,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var loadJob: Job? = null
+    private var contentJob: Job? = null
+    private var attachListener: View.OnAttachStateChangeListener? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
     private val imageCache = NovelWebViewImageCache(activity.cacheDir, scope)
@@ -521,14 +524,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
     private fun initWebView() {
-        container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+        attachListener = object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(v: View) {
                 // Remove blocksDescendants from reader_activity.xml's viewer_container parent
                 // so the WebView can actually receive text input focus.
                 (container.parent as? ViewGroup)?.descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
             }
             override fun onViewDetachedFromWindow(v: View) {}
-        })
+        }.also(container::addOnAttachStateChangeListener)
 
         webView = object : WebView(activity) {
             override fun startActionMode(callback: ActionMode.Callback?, type: Int): ActionMode? {
@@ -812,6 +815,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         isDestroyed = true
 
         scope.cancel()
+
+        attachListener?.let(container::removeOnAttachStateChangeListener)
+        attachListener = null
+
+        container.removeView(webView)
+        webView.stopLoading()
+        webView.loadUrl("about:blank")
+        webView.removeJavascriptInterface("Android")
+        webView.webViewClient = WebViewClient()
         webView.destroy()
     }
 
@@ -858,6 +870,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
      */
     private var lastSavedTtsChunkIndex: Int = -1
     private fun saveTtsProgressForChunk(chunkIndex: Int) {
+        // Foreground: the per-chapter scroll bridge (onScrollProgress) owns progress and the slider.
+        // WebView TTS extracts the whole loaded (multi-chapter) body, so its chunk% is document-wide,
+        // not per-chapter, it would misattribute the visible chapter's position. Persist from TTS
+        // only when backgrounded, where the JS scroll bridge is paused and this is the sole source.
+        if (activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) return
         if (chunkIndex == lastSavedTtsChunkIndex) return
         lastSavedTtsChunkIndex = chunkIndex
         val total = ttsController.ttsChunks.size
@@ -926,7 +943,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             chapter.chapter.name,
         )
 
-        if (activity.isTranslationEnabled()) {
+        contentJob?.cancel()
+        contentJob = if (activity.isTranslationEnabled()) {
             loadingIndicator?.show()
             scope.launch {
                 val processed = withContext(Dispatchers.Default) {
@@ -1036,7 +1054,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             chapter.chapter.name,
         )
 
-        scope.launch {
+        if (!isAppendOrPrepend) {
+            contentJob?.cancel()
+            // Gate infinite-scroll appends until this base chapter's DOM is committed (onPageFinished
+            // flips it back true). Otherwise an early append (JS scroll threshold) is wiped by the
+            // clear()+loadHtmlContent this job runs, which re-appends and duplicates the chapter.
+            webChapterContentReady = false
+        }
+        val job = scope.launch {
             if (!isAppendOrPrepend && translator != null) {
                 val labelRes = if (activity.hasCachedTranslation(chapterId)) {
                     TDMR.strings.novel_chapter_translating_from_cache
@@ -1103,6 +1128,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 }
             }
         }
+        if (!isAppendOrPrepend) contentJob = job
     }
 
     /**
@@ -1212,6 +1238,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 chapterElement.setAttribute('${TSUNDOKU_CHAPTER_ATTR}', '1');
                 ${if (plainTextMode) "chapterElement.textContent = $escapedContent;" else "chapterElement.innerHTML = $escapedContent;"}
                 chaptersContainer.appendChild(chapterElement);
+
+                // Rebuild boundaries synchronously (getBoundingClientRect forces layout) BEFORE the
+                // browser can fire a scroll frame. Otherwise the DOM has the new chapter (doubled
+                // scrollHeight) while chapterBoundaries still has one entry, so computeState falls into
+                // the whole-document branch and reports the current chapter's position as a fraction of
+                // both chapters (e.g. 70% -> 50%) until the rAF rebuild catches up. The rAF rebuild
+                // below still runs to pick up late reflow (image/font load).
+                if (typeof window.updateChapterBoundaries === 'function') {
+                    window.updateChapterBoundaries();
+                }
 
                 requestAnimationFrame(function() {
                     if (typeof window.updateChapterBoundaries === 'function') {
@@ -1773,6 +1809,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 logcat(LogPriority.DEBUG) {
                     "NovelWebViewViewer: loadNextChapter triggered, infiniteScroll=${preferences.novelInfiniteScroll.get()}, isLoadingNext=$isLoadingNext, loadedCount=${loadedChapterIds.size}"
                 }
+                if (preferences.novelInfiniteScroll.get() && !webChapterContentReady) {
+                    // Base chapter DOM not committed yet. Appending now races the base load's
+                    // loadHtmlContent (replaces the body) and its chapterQueue.clear(), which would
+                    // wipe the just-appended chapter and cause a duplicate re-append. Release the JS
+                    // latch so the page retries once the base chapter has finished rendering.
+                    setJsLoadingNext()
+                    return@runOnUiThread
+                }
                 if (!preferences.novelInfiniteScroll.get()) {
                     activity.loadNextChapter()
                 } else if (reachedNovelEnd) {
@@ -2143,7 +2187,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         }
     }
 
-    private fun stopAutoScroll() {
+    fun stopAutoScroll() {
         isAutoScrolling = false
         autoScrollJob?.cancel()
         autoScrollJob = null
@@ -2262,6 +2306,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         ttsController.stop()
         handoffState = TtsHandoffState.Idle
         dispatchTtsState()
+        // The loadNextChapter TTS branch skips the JS-latch release, so after a threshold hit during
+        // playback runtime.loadingNext stays true and scroll-driven appending never re-fires. Clear
+        // it (plus the Kotlin mirror and end latch) so infinite scroll resumes once TTS is off.
+        isLoadingNext = false
+        reachedNovelEnd = false
+        setJsLoadingNext()
+        setJsNoMoreChapters(false)
     }
 
     fun pauseTts() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1477,6 +1477,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         val fmt = ErrorFormatter.format(error)
         logcat(LogPriority.ERROR) { "NovelWebViewViewer: Chapter load failed\n${fmt.stackTrace}" }
 
+        // No real chapter DOM is coming for this load, so the onPageFinished check for
+        // isLoadingRealChapter won't fire and webChapterContentReady would otherwise stay
+        // false forever, permanently blocking infinite-scroll appends after any load error.
+        isLoadingRealChapter = false
+        webChapterContentReady = true
+
         val theme = preferences.novelTheme.get()
         val backgroundColor = preferences.novelBackgroundColor.get()
         val fontColor = preferences.novelFontColor.get()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1158,8 +1158,19 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                         if (!isPrepend) activity.viewModel.setNovelVisibleChapter(page.chapter.chapter)
                     }
                     is Page.State.Error -> {
-                        if (!isPrepend) hideLoadingIndicator()
-                        displayError(state.error)
+                        if (isPrepend) {
+                            // A prepend fetch failing must not replace the whole multi-chapter DOM
+                            // (and scroll position) with a full-page error; surface it inline and
+                            // leave the document (and docState) intact.
+                            inlineFeedback.hideInlineLoading(isPrepend = true)
+                            inlineFeedback.showInlineError(
+                                ErrorFormatter.format(state.error).summary,
+                                isPrepend = true,
+                            )
+                        } else {
+                            hideLoadingIndicator()
+                            displayError(state.error)
+                        }
                     }
                     else -> {}
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -197,6 +197,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // onPageFinished lands, since that load bypasses the isLoadingRealChapter re-arm path.
     private var rearmAutoScrollOnErrorPage = false
 
+    // Tracked so a JS dialog still on screen at teardown is dismissed instead of leaking the window.
+    private var activeJsDialog: AlertDialog? = null
+
     private val config = NovelConfig(scope)
     private val navigator get() = config.navigator
 
@@ -653,6 +656,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     super.onPageFinished(view, url)
                     hideLoadingIndicator()
 
+                    // The error page is a fresh document; re-arm autoscroll before the real-chapter
+                    // gate below, which the error load (isLoadingRealChapter=false) would skip.
+                    if (rearmAutoScrollOnErrorPage) {
+                        rearmAutoScrollOnErrorPage = false
+                        if (isAutoScrolling) startAutoScroll()
+                    }
+
                     // Loading/error loads also fire onPageFinished(about:blank), and some WebView
                     // builds fire twice per navigation; gate the whole body so scripts/snippets
                     // inject only on the first genuine chapter load.
@@ -707,10 +717,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                             result.cancel()
                             return true
                         }
-                        AlertDialog.Builder(activity)
+                        activeJsDialog = AlertDialog.Builder(activity)
                             .setMessage(message)
                             .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm() }
                             .setOnCancelListener { result.cancel() }
+                            .setOnDismissListener { activeJsDialog = null }
                             .show()
                         return true
                     }
@@ -720,11 +731,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                             result.cancel()
                             return true
                         }
-                        AlertDialog.Builder(activity)
+                        activeJsDialog = AlertDialog.Builder(activity)
                             .setMessage(message)
                             .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm() }
                             .setNegativeButton(android.R.string.cancel) { _, _ -> result.cancel() }
                             .setOnCancelListener { result.cancel() }
+                            .setOnDismissListener { activeJsDialog = null }
                             .show()
                         return true
                     }
@@ -741,12 +753,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                             return true
                         }
                         val input = EditText(activity).apply { setText(defaultValue.orEmpty()) }
-                        AlertDialog.Builder(activity)
+                        activeJsDialog = AlertDialog.Builder(activity)
                             .setMessage(message)
                             .setView(input)
                             .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm(input.text.toString()) }
                             .setNegativeButton(android.R.string.cancel) { _, _ -> result.cancel() }
                             .setOnCancelListener { result.cancel() }
+                            .setOnDismissListener { activeJsDialog = null }
                             .show()
                         return true
                     }
@@ -758,10 +771,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     ): Boolean {
                         if (filePathCallback == null || fileChooserParams == null) return false
                         return activity.launchWebViewFileChooser(filePathCallback, fileChooserParams)
-                    }
-                    if (rearmAutoScrollOnErrorPage) {
-                        rearmAutoScrollOnErrorPage = false
-                        if (isAutoScrolling) startAutoScroll()
                     }
                 }
             }
@@ -918,6 +927,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         attachListener?.let(container::removeOnAttachStateChangeListener)
         attachListener = null
+
+        activeJsDialog?.dismiss()
+        activeJsDialog = null
 
         container.removeView(webView)
         webView.stopLoading()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -2179,7 +2179,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     private fun startAutoScroll() {
-        val speed = preferences.novelAutoScrollSpeed.get().coerceIn(1, 10)
+        // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
+        val level = preferences.novelAutoScrollSpeed.get().coerceIn(2, 20) / 2f
         isAutoScrolling = true
 
         // Drive the scroll from a single in-page requestAnimationFrame loop instead of a Kotlin
@@ -2187,8 +2188,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // with jittery timing and each moves a fixed integer step, which reads as stutter. The rAF
         // loop advances by (px/sec * frame delta) with sub-pixel accumulation for smooth motion, and
         // naturally pauses while the WebView is backgrounded (no frames), resuming without a jump via
-        // the dt clamp. speed (1..10) maps to CSS px/sec.
-        val pxPerSec = speed * 20
+        // the dt clamp. speed level (1..10) maps to CSS px/sec.
+        val pxPerSec = level * 20
         evaluateJavascriptSafe(
             """
             (function() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -2170,7 +2170,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
      */
     private fun pageScrollBy(direction: Int, fraction: Double = 0.9) {
         val sign = if (direction < 0) "-" else ""
-        webView.evaluateJavascript("window.scrollBy(0, $sign(window.innerHeight * $fraction));", null)
+        evaluateJavascriptSafe("window.scrollBy(0, $sign(window.innerHeight * $fraction));")
     }
 
     fun toggleAutoScroll() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -129,6 +129,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var loadJob: Job? = null
     private var contentJob: Job? = null
+    private var appendJob: Job? = null
     private var attachListener: View.OnAttachStateChangeListener? = null
     private var currentPage: ReaderPage? = null
     private var currentChapters: ViewerChapters? = null
@@ -1059,6 +1060,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         if (!isAppendOrPrepend) {
             contentJob?.cancel()
+            // Cancel any in-flight infinite-scroll append too - it targets the DOM this base load
+            // is about to replace, and would otherwise splice a stale chapter's content onto the
+            // newly loaded one once it resumes.
+            appendJob?.cancel()
             // Gate infinite-scroll appends until this base chapter's DOM is committed (onPageFinished
             // flips it back true). Otherwise an early append (JS scroll threshold) is wiped by the
             // clear()+loadHtmlContent this job runs, which re-appends and duplicates the chapter.
@@ -1847,7 +1852,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     logcat(LogPriority.DEBUG) { "NovelWebViewViewer: loadNextChapter ignored, in failure cooldown" }
                 } else if (!isLoadingNext) {
                     isLoadingNext = true
-                    scope.launch {
+                    appendJob = scope.launch {
                         try {
                             val ok = appendNextChapterIfAvailable()
                             lastNextLoadFailedAt = if (ok) 0L else System.currentTimeMillis()
@@ -1876,7 +1881,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 // Trigger infinite scroll append manually.
                 if (preferences.novelInfiniteScroll.get() && !isLoadingNext && !ttsController.isTtsAutoPlay) {
                     isLoadingNext = true
-                    scope.launch {
+                    appendJob = scope.launch {
                         try {
                             appendNextChapterIfAvailable()
                         } finally {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -185,6 +185,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var isAutoScrolling = false
     private var autoScrollJob: Job? = null
 
+    // The error page is a fresh document that drops the autoscroll rAF loop; re-arm it once its
+    // onPageFinished lands, since that load bypasses the isLoadingRealChapter re-arm path.
+    private var rearmAutoScrollOnErrorPage = false
+
     private val config = NovelConfig(scope)
     private val navigator get() = config.navigator
 
@@ -665,6 +669,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                         }
                         // A full reload replaces window, dropping the autoscroll rAF loop; re-arm it
                         // on the new document so autoscroll survives a non-inf-scroll chapter change.
+                        if (isAutoScrolling) startAutoScroll()
+                    }
+                    if (rearmAutoScrollOnErrorPage) {
+                        rearmAutoScrollOnErrorPage = false
                         if (isAutoScrolling) startAutoScroll()
                     }
                 }
@@ -1538,6 +1546,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             </html>
         """.trimIndent()
 
+        rearmAutoScrollOnErrorPage = isAutoScrolling
         webView.loadDataWithBaseURL(null, errorHtml, "text/html", "UTF-8", null)
     }
 
@@ -2358,9 +2367,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         dispatchTtsState()
         // The loadNextChapter TTS branch skips the JS-latch release, so after a threshold hit during
         // playback runtime.loadingNext stays true and scroll-driven appending never re-fires. Clear
-        // it so infinite scroll resumes once TTS is off.
-        isLoadingNext = false
-        setJsLoadingNext()
+        // it so infinite scroll resumes once TTS is off, but not while a real append is in flight:
+        // that append still owns the latch and will release it, and clobbering it here would let a
+        // second scroll launch a duplicate append.
+        if (appendJob?.isActive != true) {
+            isLoadingNext = false
+            setJsLoadingNext()
+        }
         // Don't clear the end-of-novel latch if it's already set: loadNextChapterForTts() calls
         // stopTts() right after appendNextChapterIfAvailable() sets reachedNovelEnd on a genuine
         // "no next chapter" result, and resetting it here would let the next scroll event re-fetch

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -92,6 +92,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         const val ATTR_DATA_EDITABLE = "data-tsundoku-editable"
         const val ID_EDIT_MODE_STYLE = "edit-mode-style"
         const val SEEK_ECHO_SUPPRESS_MS = 350L
+        const val AUTO_SCROLL_START_VERIFY_MS = 400L
+        const val AUTO_SCROLL_MAX_START_ATTEMPTS = 3
 
         const val TTS_TEXT_EXTRACTION_JS = """
             (function() {
@@ -191,6 +193,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var isEditingMode = false
 
     private var isAutoScrolling = false
+    private var autoScrollStartAttempt = 0
 
     // The error page is a fresh document that drops the autoscroll rAF loop; re-arm it once its
     // onPageFinished lands, since that load bypasses the isLoadingRealChapter re-arm path.
@@ -2340,19 +2343,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     fun toggleAutoScroll() {
-        isAutoScrolling = !isAutoScrolling
-
-        if (isAutoScrolling) {
-            startAutoScroll()
-        } else {
-            stopAutoScroll()
-        }
+        if (isAutoScrolling) stopAutoScroll() else startAutoScroll()
     }
 
     private fun startAutoScroll() {
+        isAutoScrolling = true
+        autoScrollStartAttempt = 0
+        issueAutoScrollStart()
+    }
+
+    private fun issueAutoScrollStart() {
         // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
         val level = preferences.novelAutoScrollLevel()
-        isAutoScrolling = true
 
         // Drive the scroll from a single in-page requestAnimationFrame loop instead of a Kotlin
         // timer that fires window.scrollBy over the JS bridge every 50ms: those round-trips arrive
@@ -2361,6 +2363,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // naturally pauses while the WebView is backgrounded (no frames), resuming without a jump via
         // the dt clamp. speed level (1..10) maps to CSS px/sec.
         val pxPerSec = level * 20
+        val attempt = ++autoScrollStartAttempt
         evaluateJavascriptSafe(
             """
             (function() {
@@ -2387,6 +2390,27 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             """.trimIndent(),
             null,
         )
+        // Confirm the in-page loop actually started: evaluateJavascript is silently dropped when the
+        // JS context isn't ready, which would leave isAutoScrolling stuck on with no motion. Query the
+        // loop's own flag; retry a few times, then give up and clear isAutoScrolling so the state
+        // reflects reality. s.running stays true while backgrounded (rAF paused), so this won't
+        // false-negative on a paused page.
+        webView.postDelayed({
+            if (!isAutoScrolling || attempt != autoScrollStartAttempt) return@postDelayed
+            evaluateJavascriptSafe(
+                "(function(){ return !!(window.__tdAutoScroll && window.__tdAutoScroll.running); })();",
+            ) { running ->
+                if (!isAutoScrolling || attempt != autoScrollStartAttempt) return@evaluateJavascriptSafe
+                if (running != "true") {
+                    if (autoScrollStartAttempt < AUTO_SCROLL_MAX_START_ATTEMPTS) {
+                        issueAutoScrollStart()
+                    } else {
+                        isAutoScrolling = false
+                        logcat(LogPriority.WARN) { "NovelWebViewViewer: autoscroll failed to start, giving up" }
+                    }
+                }
+            }
+        }, AUTO_SCROLL_START_VERIFY_MS)
     }
 
     fun stopAutoScroll() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -3,7 +3,9 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Context
+import android.net.Uri
 import android.view.ActionMode
 import android.view.GestureDetector
 import android.view.KeyEvent
@@ -13,10 +15,16 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
+import android.webkit.JsPromptResult
+import android.webkit.JsResult
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.EditText
 import android.widget.FrameLayout
 import androidx.annotation.Keep
 import androidx.lifecycle.Lifecycle
@@ -206,6 +214,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // False while the loading indicator is up or real content is still loading; true once real
     // chapter content has finished rendering. Guards TTS from reading the loading placeholder.
     private var webChapterContentReady = false
+
+    // True while the current DOM is an error placeholder rather than real chapter content.
+    // webChapterContentReady is force-set true on error (so appends aren't blocked forever), but
+    // there's no valid base DOM to append onto, so this suppresses infinite-scroll appends until a
+    // real chapter renders.
+    private var webChapterIsError = false
 
     private val ttsController: TtsController
 
@@ -638,6 +652,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
                     hideLoadingIndicator()
+
+                    // Loading/error loads also fire onPageFinished(about:blank), and some WebView
+                    // builds fire twice per navigation; gate the whole body so scripts/snippets
+                    // inject only on the first genuine chapter load.
+                    if (!isLoadingRealChapter) return
+                    isLoadingRealChapter = false
+
                     styler.injectScript { buildTsundokuScript() }
                     styler.injectScrollTracking()
                     restoreScrollPosition()
@@ -648,28 +669,95 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     if (isEditingMode) {
                         toggleEditMode(true)
                     }
-                    // isLoadingRealChapter distinguishes real chapter loads from
-                    // showLoadingIndicator() loads - both fire onPageFinished(about:blank)
-                    // when the chapter URL is relative, making the URL useless as a guard.
-                    if (isLoadingRealChapter) {
-                        isLoadingRealChapter = false
-                        // Real content rendered; TTS may now read the body.
-                        webChapterContentReady = true
-                        dispatchLoadingChapter(false)
-                        if (pendingTtsAutoStartOnLoad) {
-                            pendingTtsAutoStartOnLoad = false
-                            startTts()
+                    // Real content rendered; TTS may now read the body.
+                    webChapterContentReady = true
+                    dispatchLoadingChapter(false)
+                    if (pendingTtsAutoStartOnLoad) {
+                        pendingTtsAutoStartOnLoad = false
+                        startTts()
+                    }
+                    ttsController.pendingStartRequest?.let { request ->
+                        ttsController.pendingStartRequest = null
+                        when (request) {
+                            TtsController.StartRequest.NORMAL -> startTts()
+                            TtsController.StartRequest.VIEWPORT -> startTtsFromViewport()
                         }
-                        ttsController.pendingStartRequest?.let { request ->
-                            ttsController.pendingStartRequest = null
-                            when (request) {
-                                TtsController.StartRequest.NORMAL -> startTts()
-                                TtsController.StartRequest.VIEWPORT -> startTtsFromViewport()
-                            }
+                    }
+                    // A full reload replaces window, dropping the autoscroll rAF loop; re-arm it
+                    // on the new document so autoscroll survives a non-inf-scroll chapter change.
+                    if (isAutoScrolling) startAutoScroll()
+                }
+            }
+
+            if (preferences.novelWebViewDevTools.get()) {
+                webChromeClient = object : WebChromeClient() {
+                    override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+                        val level = consoleMessage.messageLevel()
+                        val shouldToast = level == ConsoleMessage.MessageLevel.LOG ||
+                            level == ConsoleMessage.MessageLevel.WARNING ||
+                            level == ConsoleMessage.MessageLevel.ERROR
+                        if (shouldToast && preferences.novelConsoleErrorToast.get()) {
+                            activity.toast(consoleMessage.message().take(120))
                         }
-                        // A full reload replaces window, dropping the autoscroll rAF loop; re-arm it
-                        // on the new document so autoscroll survives a non-inf-scroll chapter change.
-                        if (isAutoScrolling) startAutoScroll()
+                        return true
+                    }
+
+                    override fun onJsAlert(view: WebView?, url: String?, message: String?, result: JsResult): Boolean {
+                        if (activity.isFinishing || activity.isDestroyed) {
+                            result.cancel()
+                            return true
+                        }
+                        AlertDialog.Builder(activity)
+                            .setMessage(message)
+                            .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm() }
+                            .setOnCancelListener { result.cancel() }
+                            .show()
+                        return true
+                    }
+
+                    override fun onJsConfirm(view: WebView?, url: String?, message: String?, result: JsResult): Boolean {
+                        if (activity.isFinishing || activity.isDestroyed) {
+                            result.cancel()
+                            return true
+                        }
+                        AlertDialog.Builder(activity)
+                            .setMessage(message)
+                            .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm() }
+                            .setNegativeButton(android.R.string.cancel) { _, _ -> result.cancel() }
+                            .setOnCancelListener { result.cancel() }
+                            .show()
+                        return true
+                    }
+
+                    override fun onJsPrompt(
+                        view: WebView?,
+                        url: String?,
+                        message: String?,
+                        defaultValue: String?,
+                        result: JsPromptResult,
+                    ): Boolean {
+                        if (activity.isFinishing || activity.isDestroyed) {
+                            result.cancel()
+                            return true
+                        }
+                        val input = EditText(activity).apply { setText(defaultValue.orEmpty()) }
+                        AlertDialog.Builder(activity)
+                            .setMessage(message)
+                            .setView(input)
+                            .setPositiveButton(android.R.string.ok) { _, _ -> result.confirm(input.text.toString()) }
+                            .setNegativeButton(android.R.string.cancel) { _, _ -> result.cancel() }
+                            .setOnCancelListener { result.cancel() }
+                            .show()
+                        return true
+                    }
+
+                    override fun onShowFileChooser(
+                        webView: WebView?,
+                        filePathCallback: ValueCallback<Array<Uri>>?,
+                        fileChooserParams: FileChooserParams?,
+                    ): Boolean {
+                        if (filePathCallback == null || fileChooserParams == null) return false
+                        return activity.launchWebViewFileChooser(filePathCallback, fileChooserParams)
                     }
                     if (rearmAutoScrollOnErrorPage) {
                         rearmAutoScrollOnErrorPage = false
@@ -836,6 +924,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         webView.loadUrl("about:blank")
         webView.removeJavascriptInterface("Android")
         webView.webViewClient = WebViewClient()
+        webView.webChromeClient = null
         webView.destroy()
     }
 
@@ -1110,29 +1199,29 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
             withContext(Dispatchers.Main) {
                 if (isAppendOrPrepend && preferences.novelInfiniteScroll.get()) {
+                    // Queue add and DOM insert share one guard: a redundant displayContent() for the
+                    // same chapter would otherwise skip the queue add but still re-insert the DOM copy,
+                    // corrupting chapterBoundaries.
                     if (!loadedChapterIds.contains(chapterId)) {
                         if (isPrepend) {
                             chapterQueue.prepend(chapter)
+                            prependHtmlContent(
+                                finalProcessed,
+                                chapterId,
+                                chapter.chapter.name,
+                                chapter.chapter.chapter_number,
+                                chapter.chapter.url,
+                            )
                         } else {
                             chapterQueue.append(chapter)
+                            appendHtmlContent(
+                                finalProcessed,
+                                chapterId,
+                                chapter.chapter.name,
+                                chapter.chapter.chapter_number,
+                                chapter.chapter.url,
+                            )
                         }
-                    }
-                    if (isPrepend) {
-                        prependHtmlContent(
-                            finalProcessed,
-                            chapterId,
-                            chapter.chapter.name,
-                            chapter.chapter.chapter_number,
-                            chapter.chapter.url,
-                        )
-                    } else {
-                        appendHtmlContent(
-                            finalProcessed,
-                            chapterId,
-                            chapter.chapter.name,
-                            chapter.chapter.chapter_number,
-                            chapter.chapter.url,
-                        )
                     }
                 } else {
                     loadHtmlContent(finalProcessed, chapter)
@@ -1209,7 +1298,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // Guard scroll callbacks while the prepend shifts every startOffset, JS lifts it when done.
         isRestoringScroll = true
         evaluateJavascriptSafe(js) {
-            styler.injectScript { buildTsundokuScript() }
+            styler.injectScript(isAppend = true) { buildTsundokuScript() }
         }
         // JS lift runs in rAF (paused while backgrounded); fallback so the guard can't stick forever.
         webView.postDelayed({ liftRestoreGuard(token) }, 3000)
@@ -1277,7 +1366,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         dispatchLoadingChapter(true)
         evaluateJavascriptSafe(js) {
-            styler.injectScript { buildTsundokuScript() }
+            styler.injectScript(isAppend = true) { buildTsundokuScript() }
             dispatchLoadingChapter(false)
         }
 
@@ -1350,7 +1439,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     private fun buildTsundokuScript(): String {
         val context = NovelWebViewChapterMeta.TsundokuScriptContext(
-            novelUrl = activity.viewModel.manga?.url,
+            novelUrl = activity.viewModel.getMangaUrl() ?: activity.viewModel.manga?.url,
             currentChapter = getCurrentTsundokuChapter(),
             chaptersInOrder = if (loadedChapters.isNotEmpty()) {
                 loadedChapters
@@ -1489,6 +1578,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // false forever, permanently blocking infinite-scroll appends after any load error.
         isLoadingRealChapter = false
         webChapterContentReady = true
+        webChapterIsError = true
 
         val theme = preferences.novelTheme.get()
         val backgroundColor = preferences.novelBackgroundColor.get()
@@ -1619,6 +1709,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         updateChapterMetaJs()
 
         if (isEditing) {
+            // Focusing a contenteditable for the keyboard scrolls Chromium to the top; snapshot the
+            // ratio, restore it after focus settles, and gate onScrollProgress meanwhile.
+            val restoreRatio = lastSavedProgress
+            isRestoringScroll = true
             webView.post {
                 activity.window.decorView.clearFocus()
                 webView.requestFocus()
@@ -1629,6 +1723,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     imm?.showSoftInput(webView, 0)
                 }, 120)
             }
+            webView.postDelayed({
+                evaluateJavascriptSafe(
+                    """
+                    (function() {
+                        var target = $restoreRatio;
+                        var docHeight = Math.max(
+                            document.documentElement.scrollHeight,
+                            document.body ? document.body.scrollHeight : 0
+                        );
+                        var viewport = window.innerHeight || document.documentElement.clientHeight;
+                        var range = docHeight - viewport;
+                        if (range > 0) window.scrollTo(0, range * target);
+                    })();
+                    """.trimIndent(),
+                )
+                isRestoringScroll = false
+            }, 220)
         } else {
             webView.evaluateJavascript(
                 "(function() { window.getSelection().removeAllRanges(); document.activeElement.blur(); })();",
@@ -1838,6 +1949,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     setJsLoadingNext()
                     return@runOnUiThread
                 }
+                if (preferences.novelInfiniteScroll.get() && webChapterIsError) {
+                    // Current DOM is an error placeholder, not a real chapter; appending the next
+                    // chapter onto it would stack content below the error and race a reload. Release
+                    // the latch and wait for a successful reload to clear webChapterIsError.
+                    setJsLoadingNext()
+                    return@runOnUiThread
+                }
                 if (!preferences.novelInfiniteScroll.get()) {
                     activity.loadNextChapter()
                 } else if (reachedNovelEnd) {
@@ -1893,7 +2011,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
                 // Chapter fits in viewport → no scroll events fire → threshold never reached.
                 // Trigger infinite scroll append manually.
-                if (preferences.novelInfiniteScroll.get() && !isLoadingNext && !ttsController.isTtsAutoPlay) {
+                if (preferences.novelInfiniteScroll.get() && !isLoadingNext && !ttsController.isTtsAutoPlay &&
+                    !webChapterIsError
+                ) {
                     isLoadingNext = true
                     appendJob = scope.launch {
                         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -928,7 +928,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         attachListener?.let(container::removeOnAttachStateChangeListener)
         attachListener = null
 
-        activeJsDialog?.dismiss()
+        // cancel(), not dismiss(): dismiss() skips the OnCancelListener, so the pending
+        // JsResult/JsPromptResult would never resolve and the WebView's JS thread stays blocked.
+        try {
+            activeJsDialog?.cancel()
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN) { "Failed to cancel active JS dialog during destroy (${e.message})" }
+        }
         activeJsDialog = null
 
         container.removeView(webView)
@@ -1436,8 +1442,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         webView.loadDataWithBaseURL(resolveWebViewBaseUrl(chapterPath), html, "text/html", "UTF-8", null)
     }
 
+    // Memoized: the manga URL is fixed for the viewer's lifetime, and getMangaUrl() does a source
+    // lookup + toSManga() + getMangaUrlOrNull() that ran twice per chapter load/append otherwise.
+    private var cachedMangaUrl: String? = null
+
+    private fun resolvedMangaUrl(): String? {
+        cachedMangaUrl?.let { return it }
+        return (activity.viewModel.getMangaUrl() ?: activity.viewModel.manga?.url)
+            ?.also { cachedMangaUrl = it }
+    }
+
     private fun resolveWebViewBaseUrl(chapterUrl: String?): String? =
-        NovelWebViewChapterMeta.resolveWebViewBaseUrl(chapterUrl, activity.viewModel.manga?.url, sourceBaseUrl())
+        NovelWebViewChapterMeta.resolveWebViewBaseUrl(chapterUrl, resolvedMangaUrl(), sourceBaseUrl())
 
     // Site url of the current source, so relative asset paths in chapter HTML resolve like a browser.
     private fun sourceBaseUrl(): String? = when (val source = activity.viewModel.getSource()) {
@@ -1451,7 +1467,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     private fun buildTsundokuScript(): String {
         val context = NovelWebViewChapterMeta.TsundokuScriptContext(
-            novelUrl = activity.viewModel.getMangaUrl() ?: activity.viewModel.manga?.url,
+            novelUrl = resolvedMangaUrl(),
             currentChapter = getCurrentTsundokuChapter(),
             chaptersInOrder = if (loadedChapters.isNotEmpty()) {
                 loadedChapters
@@ -1725,6 +1741,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             // ratio, restore it after focus settles, and gate onScrollProgress meanwhile.
             val restoreRatio = lastSavedProgress
             isRestoringScroll = true
+            val token = ++scrollRestoreToken
             webView.post {
                 activity.window.decorView.clearFocus()
                 webView.requestFocus()
@@ -2334,7 +2351,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     private fun startAutoScroll() {
         // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
-        val level = preferences.novelAutoScrollSpeed.get().coerceIn(2, 20) / 2f
+        val level = preferences.novelAutoScrollLevel()
         isAutoScrolling = true
 
         // Drive the scroll from a single in-page requestAnimationFrame loop instead of a Kotlin

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -203,6 +203,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // Tracked so a JS dialog still on screen at teardown is dismissed instead of leaking the window.
     private var activeJsDialog: AlertDialog? = null
 
+    // Reader-chrome obstruction pushed from ReaderActivity: the transient reader menu bars (shown
+    // only with the menu) plus system bars. The novel status bar is NOT here - it gets real layout
+    // space via viewer_container padding. Exposed as --tsundoku-safe-top/bottom +
+    // Tsundoku.runtime.menuVisible so fixed elements clear the menu. Re-applied on each fresh-DOM load.
+    private var chromeMenuVisible = false
+    private var chromeSafeTopDp = 0f
+    private var chromeSafeBottomDp = 0f
+
     private val config = NovelConfig(scope)
     private val navigator get() = config.navigator
 
@@ -678,6 +686,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
                     styler.injectScript { buildTsundokuScript() }
                     styler.injectScrollTracking()
+                    // Fresh DOM lost the --tsundoku-safe-* vars and menuVisible flag; re-apply them.
+                    pushReaderChrome()
                     restoreScrollPosition()
                     syncShortChapterProgressIfNeeded()
                     if (!preferences.novelInfiniteScroll.get()) {
@@ -1556,6 +1566,35 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             "t.runtime.${NovelWebViewChapterMeta.TSUNDOKU_TTS_STATE_KEY} = '$state';",
             "{ state: '$state' }",
         )
+    }
+
+    /** Called from ReaderActivity when the menu or reader-chrome insets change. */
+    fun onReaderChromeChanged(menuVisible: Boolean, safeTopDp: Float, safeBottomDp: Float) {
+        chromeMenuVisible = menuVisible
+        chromeSafeTopDp = safeTopDp
+        chromeSafeBottomDp = safeBottomDp
+        pushReaderChrome()
+    }
+
+    // Sets the safe-area CSS vars and Tsundoku.runtime.menuVisible via the reader-chrome.js asset
+    // (same token-substitution path as the other injected scripts), firing the menu-visibility event
+    // only when the flag actually flips so a load/inset re-apply is silent.
+    private fun pushReaderChrome() {
+        val js = NovelWebViewJsAssets.loadWith(
+            activity,
+            "reader-chrome.js",
+            mapOf(
+                "SAFE_TOP_VAR" to NovelWebViewChapterMeta.CSS_VAR_SAFE_TOP,
+                "SAFE_BOTTOM_VAR" to NovelWebViewChapterMeta.CSS_VAR_SAFE_BOTTOM,
+                "SAFE_TOP" to chromeSafeTopDp.toString(),
+                "SAFE_BOTTOM" to chromeSafeBottomDp.toString(),
+                "OBJECT" to NovelWebViewChapterMeta.TSUNDOKU_OBJECT_NAME,
+                "MENU_KEY" to NovelWebViewChapterMeta.TSUNDOKU_MENU_VISIBLE_KEY,
+                "MENU_VISIBLE" to chromeMenuVisible.toString(),
+                "EVENT" to NovelWebViewChapterMeta.EVENT_MENU_VISIBILITY,
+            ),
+        )
+        evaluateJavascriptSafe(js, null)
     }
 
     private fun showLoadingIndicator(message: String = "Loading...") {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1060,9 +1060,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         if (!isAppendOrPrepend) {
             contentJob?.cancel()
-            // Cancel any in-flight infinite-scroll append too - it targets the DOM this base load
-            // is about to replace, and would otherwise splice a stale chapter's content onto the
-            // newly loaded one once it resumes.
+            // An in-flight append targets the DOM this base load is about to replace; cancelling it
+            // avoids splicing a stale chapter's content onto the newly loaded one when it resumes.
             appendJob?.cancel()
             // Gate infinite-scroll appends until this base chapter's DOM is committed (onPageFinished
             // flips it back true). Otherwise an early append (JS scroll threshold) is wiped by the

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -2359,11 +2359,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         dispatchTtsState()
         // The loadNextChapter TTS branch skips the JS-latch release, so after a threshold hit during
         // playback runtime.loadingNext stays true and scroll-driven appending never re-fires. Clear
-        // it (plus the Kotlin mirror and end latch) so infinite scroll resumes once TTS is off.
+        // it so infinite scroll resumes once TTS is off.
         isLoadingNext = false
-        reachedNovelEnd = false
         setJsLoadingNext()
-        setJsNoMoreChapters(false)
+        // Don't clear the end-of-novel latch if it's already set: loadNextChapterForTts() calls
+        // stopTts() right after appendNextChapterIfAvailable() sets reachedNovelEnd on a genuine
+        // "no next chapter" result, and resetting it here would let the next scroll event re-fetch
+        // and re-show the "No next chapter available" error a second time.
+        if (!reachedNovelEnd) {
+            setJsNoMoreChapters(false)
+        }
     }
 
     fun pauseTts() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -191,7 +191,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var isEditingMode = false
 
     private var isAutoScrolling = false
-    private var autoScrollJob: Job? = null
 
     // The error page is a fresh document that drops the autoscroll rAF loop; re-arm it once its
     // onPageFinished lands, since that load bypasses the isLoadingRealChapter re-arm path.
@@ -912,6 +911,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         ThemeUtils.getThemeColors(activity, preferences, theme)
 
     override fun destroy() {
+        if (isDestroyed) return
         // Only persist if real progress exists. lastSavedProgress starts at 0 and stays 0
         // until onPageFinished restores or the user scrolls. Saving 0 here on an early
         // teardown (orientation lock recreates the activity before restore runs) would
@@ -2117,19 +2117,22 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             if (isDestroyed) return@withContext
 
             if (isAppendOrPrepend && preferences.novelInfiniteScroll.get()) {
+                // Queue add and DOM insert share one guard: a redundant append for the same
+                // chapter would otherwise skip the queue add but still re-insert the DOM copy,
+                // corrupting chapterBoundaries.
                 if (!loadedChapterIds.contains(chapterId)) {
                     if (isPrepend) {
                         return@withContext
                     }
                     chapterQueue.append(chapter)
+                    appendHtmlContent(
+                        processed,
+                        chapterId,
+                        chapter.chapter.name,
+                        chapter.chapter.chapter_number,
+                        chapter.chapter.url,
+                    )
                 }
-                appendHtmlContent(
-                    processed,
-                    chapterId,
-                    chapter.chapter.name,
-                    chapter.chapter.chapter_number,
-                    chapter.chapter.url,
-                )
             } else {
                 loadHtmlContent(processed, chapter)
                 chapterQueue.reset(chapter)
@@ -2371,8 +2374,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     fun stopAutoScroll() {
         isAutoScrolling = false
-        autoScrollJob?.cancel()
-        autoScrollJob = null
         evaluateJavascriptSafe(
             """
             (function() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1806,6 +1806,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 }, 120)
             }
             webView.postDelayed({
+                if (token != scrollRestoreToken) return@postDelayed
                 evaluateJavascriptSafe(
                     """
                     (function() {
@@ -1823,6 +1824,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 isRestoringScroll = false
             }, 220)
         } else {
+            // Invalidate a pending entry-side restore callback so it can't fire after we've
+            // already left edit mode.
+            ++scrollRestoreToken
+            isRestoringScroll = false
             webView.evaluateJavascript(
                 "(function() { window.getSelection().removeAllRanges(); document.activeElement.blur(); })();",
                 null,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -207,7 +207,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // only with the menu) plus system bars. The novel status bar is NOT here - it gets real layout
     // space via viewer_container padding. Exposed as --tsundoku-safe-top/bottom +
     // Tsundoku.runtime.menuVisible so fixed elements clear the menu. Re-applied on each fresh-DOM load.
-    private var chromeMenuVisible = false
+    // Menu visibility itself isn't cached here -- pushReaderChrome() reads it live off the ViewModel
+    // so a DOM reload can't race a stale value against buildTsundokuScript()'s live read of the same
+    // state and clobber it back (or fire a spurious/missed menuvisibilitychange event).
     private var chromeSafeTopDp = 0f
     private var chromeSafeBottomDp = 0f
 
@@ -1581,7 +1583,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     /** Called from ReaderActivity when the menu or reader-chrome insets change. */
     fun onReaderChromeChanged(menuVisible: Boolean, safeTopDp: Float, safeBottomDp: Float) {
-        chromeMenuVisible = menuVisible
         chromeSafeTopDp = safeTopDp
         chromeSafeBottomDp = safeBottomDp
         pushReaderChrome()
@@ -1601,7 +1602,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 "SAFE_BOTTOM" to chromeSafeBottomDp.toString(),
                 "OBJECT" to NovelWebViewChapterMeta.TSUNDOKU_OBJECT_NAME,
                 "MENU_KEY" to NovelWebViewChapterMeta.TSUNDOKU_MENU_VISIBLE_KEY,
-                "MENU_VISIBLE" to chromeMenuVisible.toString(),
+                "MENU_VISIBLE" to activity.viewModel.state.value.menuVisible.toString(),
                 "EVENT" to NovelWebViewChapterMeta.EVENT_MENU_VISIBILITY,
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -195,6 +195,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private var isAutoScrolling = false
     private var autoScrollStartAttempt = 0
 
+    // Never reset (unlike autoScrollStartAttempt, which restarts at 0 each session), so a verify
+    // callback from a stopped/superseded session can't collide with a same-numbered attempt from a
+    // fresh one started within the same AUTO_SCROLL_START_VERIFY_MS window.
+    private var autoScrollSession = 0
+
     // The error page is a fresh document that drops the autoscroll rAF loop; re-arm it once its
     // onPageFinished lands, since that load never enters DocState.LOADING_REAL so the re-arm path
     // in the real-chapter gate is skipped.
@@ -2405,10 +2410,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private fun startAutoScroll() {
         isAutoScrolling = true
         autoScrollStartAttempt = 0
-        issueAutoScrollStart()
+        issueAutoScrollStart(++autoScrollSession)
     }
 
-    private fun issueAutoScrollStart() {
+    private fun issueAutoScrollStart(session: Int) {
         // Pref is half-steps (speed x2); level is 1.0..10.0 in 0.5 increments.
         val level = preferences.novelAutoScrollLevel()
 
@@ -2452,14 +2457,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // reflects reality. s.running stays true while backgrounded (rAF paused), so this won't
         // false-negative on a paused page.
         webView.postDelayed({
-            if (!isAutoScrolling || attempt != autoScrollStartAttempt) return@postDelayed
+            if (!isAutoScrolling || session != autoScrollSession || attempt != autoScrollStartAttempt) {
+                return@postDelayed
+            }
             evaluateJavascriptSafe(
                 "(function(){ return !!(window.__tdAutoScroll && window.__tdAutoScroll.running); })();",
             ) { running ->
-                if (!isAutoScrolling || attempt != autoScrollStartAttempt) return@evaluateJavascriptSafe
+                if (!isAutoScrolling || session != autoScrollSession || attempt != autoScrollStartAttempt) {
+                    return@evaluateJavascriptSafe
+                }
                 if (running != "true") {
                     if (autoScrollStartAttempt < AUTO_SCROLL_MAX_START_ATTEMPTS) {
-                        issueAutoScrollStart()
+                        issueAutoScrollStart(session)
                     } else {
                         isAutoScrolling = false
                         logcat(LogPriority.WARN) { "NovelWebViewViewer: autoscroll failed to start, giving up" }
@@ -2471,6 +2480,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     fun stopAutoScroll() {
         isAutoScrolling = false
+        ++autoScrollSession
         evaluateJavascriptSafe(
             """
             (function() {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/source/SourceUrlUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/source/SourceUrlUtil.kt
@@ -71,19 +71,27 @@ fun normalizeSourcePath(source: Source, pathOrUrl: String): String {
 }
 
 fun Source.getMangaUrlOrNull(manga: SManga): String? {
-    return when (this) {
-        is CustomNovelSource -> resolveRelativeUrl(baseUrl, manga.url)
-        is HttpSource -> getMangaUrl(manga)
-        is JsSource -> resolveRelativeUrl(baseUrl, manga.url)
-        else -> manga.url.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+    return try {
+        when (this) {
+            is CustomNovelSource -> resolveRelativeUrl(baseUrl, manga.url)
+            is HttpSource -> getMangaUrl(manga)
+            is JsSource -> resolveRelativeUrl(baseUrl, manga.url)
+            else -> manga.url.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+        }
+    } catch (_: Exception) {
+        null
     }
 }
 
 fun Source.getChapterUrlOrNull(chapter: SChapter): String? {
-    return when (this) {
-        is CustomNovelSource -> resolveRelativeUrl(baseUrl, chapter.url)
-        is HttpSource -> getChapterUrl(chapter)
-        is JsSource -> resolveRelativeUrl(baseUrl, chapter.url)
-        else -> chapter.url.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+    return try {
+        when (this) {
+            is CustomNovelSource -> resolveRelativeUrl(baseUrl, chapter.url)
+            is HttpSource -> getChapterUrl(chapter)
+            is JsSource -> resolveRelativeUrl(baseUrl, chapter.url)
+            else -> chapter.url.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+        }
+    } catch (_: Exception) {
+        null
     }
 }

--- a/app/src/test/java/eu/kanade/presentation/reader/settings/CodeSnippetTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/reader/settings/CodeSnippetTest.kt
@@ -1,0 +1,34 @@
+package eu.kanade.presentation.reader.settings
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CodeSnippetTest {
+
+    @Test
+    fun `decodes legacy json without runOnAppend to default false`() {
+        val legacy = """[{"title":"a","code":"x","enabled":true}]"""
+        val snippets = Json.decodeFromString<List<CodeSnippet>>(legacy)
+        assertEquals(1, snippets.size)
+        assertFalse(snippets[0].runOnAppend)
+        assertTrue(snippets[0].enabled)
+    }
+
+    @Test
+    fun `runOnAppend survives an encode-decode roundtrip`() {
+        val original = listOf(
+            CodeSnippet(title = "a", code = "x", enabled = true, runOnAppend = true),
+            CodeSnippet(title = "b", code = "y", enabled = false, runOnAppend = false),
+        )
+        val roundTripped = Json.decodeFromString<List<CodeSnippet>>(Json.encodeToString(original))
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
+    fun `new snippet defaults runOnAppend to false`() {
+        assertFalse(CodeSnippet(title = "a", code = "x").runOnAppend)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 class NovelWebViewChapterMetaTest {
 
-    // â”€â”€ jsEscape â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // jsEscape
 
     @Test
     fun `jsEscape escapes backslashes`() {
@@ -41,7 +41,7 @@ class NovelWebViewChapterMetaTest {
         assertEquals("hello world", "hello world".jsEscape())
     }
 
-    // â”€â”€ htmlAttributeEscape â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // htmlAttributeEscape
 
     @Test
     fun `htmlAttributeEscape escapes ampersand first to avoid double-escape`() {
@@ -53,7 +53,7 @@ class NovelWebViewChapterMetaTest {
         assertEquals("&quot;&#39;&lt;&gt;", "\"'<>".htmlAttributeEscape())
     }
 
-    // â”€â”€ quoteForJson â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // quoteForJson
 
     @Test
     fun `quoteForJson wraps in double quotes`() {
@@ -95,7 +95,7 @@ class NovelWebViewChapterMetaTest {
         assertEquals("\"Hello, world!\"", result)
     }
 
-    // â”€â”€ toAbsoluteChapterUrl â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // toAbsoluteChapterUrl
 
     @Test
     fun `toAbsoluteChapterUrl passes absolute http urls through`() {
@@ -150,7 +150,7 @@ class NovelWebViewChapterMetaTest {
         )
     }
 
-    // â”€â”€ resolveWebViewBaseUrl â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // resolveWebViewBaseUrl
 
     @Test
     fun `resolveWebViewBaseUrl prefers absolute chapter url`() {
@@ -174,7 +174,7 @@ class NovelWebViewChapterMetaTest {
         assertEquals(null, resolveWebViewBaseUrl(null, null))
     }
 
-    // â”€â”€ buildChapterJson â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // buildChapterJson
 
     @Test
     fun `buildChapterJson returns null sentinels for null chapter`() {
@@ -185,14 +185,14 @@ class NovelWebViewChapterMetaTest {
         assertTrue(json.contains("\"path\": \"\""))
     }
 
-    // â”€â”€ buildChaptersJson â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // buildChaptersJson
 
     @Test
     fun `buildChaptersJson empty list returns empty array literal`() {
         assertEquals("[]", NovelWebViewChapterMeta.buildChaptersJson(emptyList(), "https://n.com"))
     }
 
-    // â”€â”€ buildTsundokuScript: assembled script contains all keys â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // buildTsundokuScript: assembled script contains all keys
 
     @Test
     fun `buildTsundokuScript includes the required Tsundoku keys`() {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
@@ -134,6 +134,22 @@ class NovelWebViewChapterMetaTest {
         )
     }
 
+    @Test
+    fun `toAbsoluteChapterUrl resolves root-relative path against novel origin`() {
+        assertEquals(
+            "https://example.com/dir/img.webp",
+            toAbsoluteChapterUrl("/dir/img.webp", "https://example.com/dir/"),
+        )
+    }
+
+    @Test
+    fun `toAbsoluteChapterUrl resolves document-relative path against novel directory`() {
+        assertEquals(
+            "https://example.com/dir/img.webp",
+            toAbsoluteChapterUrl("img.webp", "https://example.com/dir/"),
+        )
+    }
+
     // â”€â”€ resolveWebViewBaseUrl â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     @Test

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilderTest.kt
@@ -124,8 +124,8 @@ class NovelWebViewDocumentBuilderTest {
         assertTrue(html.contains("Hello"))
         // Raw unescaped angle brackets must NOT appear outside the script
         val bodySection = html.substringAfter("<body>")
-        // The pre element is empty; content is set via JS
-        assertTrue(bodySection.contains("<pre "))
+        // The plain-text container is empty; paragraphs are appended via JS
+        assertTrue(bodySection.contains("<div class=\"${NovelWebViewDocumentBuilder.PLAIN_TEXT_CLASS}\""))
     }
 
     @Test

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -433,14 +433,16 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 }
 
                 val src = rawSrc.substringBefore("#").trim().urlDecoded()
-                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:")) {
+                if (src.isBlank() || src.startsWith("http") || src.startsWith("//") || src.startsWith("data:") ||
+                    src.startsWith(NOVEL_IMAGE_SCHEME)
+                ) {
                     return@forEach
                 }
 
                 val imagePath = resolveZipPath(imageBasePath, src)
                 val replacement = when {
                     useReaderImageScheme -> {
-                        "tsundoku-novel-image://${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
+                        "$NOVEL_IMAGE_SCHEME${java.net.URLEncoder.encode(imagePath, "UTF-8")}"
                     }
                     imageCollector != null -> {
                         val bytes = runCatching {
@@ -449,7 +451,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                         if (bytes == null || bytes.isEmpty()) return@forEach
                         val id = buildExportImageId(imagePath)
                         imageCollector.putIfAbsent(id, bytes)
-                        "tsundoku-novel-image://$id"
+                        "$NOVEL_IMAGE_SCHEME$id"
                     }
                     else -> inlineAssetAsDataUri(imagePath) ?: return@forEach
                 }

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -122,4 +122,16 @@ class HistoryRepositoryImpl(
             logcat(LogPriority.ERROR, throwable = e)
         }
     }
+
+    override suspend fun upsertHistoryTimeRead(historyUpdate: HistoryUpdate) {
+        try {
+            database.historyQueries.upsertTimeRead(
+                historyUpdate.chapterId,
+                historyUpdate.readAt,
+                historyUpdate.sessionReadDuration,
+            )
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, throwable = e)
+        }
+    }
 }

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -145,6 +145,17 @@ SET
     time_read = time_read + :time_read
 WHERE chapter_id = :chapterId;
 
+-- Accumulate read duration without moving last_read on an existing row. Used by novel readers,
+-- where the visible-chapter entry stamp owns recency; a leaving/pause flush that re-stamped
+-- last_read=now could outrank the chapter actually being read (e.g. after a hard kill).
+upsertTimeRead:
+INSERT INTO history(chapter_id, last_read, time_read)
+VALUES (:chapterId, :readAt, :time_read)
+ON CONFLICT(chapter_id)
+DO UPDATE
+SET time_read = time_read + :time_read
+WHERE chapter_id = :chapterId;
+
 getReadDuration:
 SELECT coalesce(sum(time_read), 0)
 FROM history;

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
@@ -10,4 +10,9 @@ class UpsertHistory(
     suspend fun await(historyUpdate: HistoryUpdate) {
         historyRepository.upsertHistory(historyUpdate)
     }
+
+    /** Adds read duration without moving last_read on an existing row (novel readers). */
+    suspend fun awaitTimeReadOnly(historyUpdate: HistoryUpdate) {
+        historyRepository.upsertHistoryTimeRead(historyUpdate)
+    }
 }

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -24,4 +24,7 @@ interface HistoryRepository {
     suspend fun deleteAllHistory(): Boolean
 
     suspend fun upsertHistory(historyUpdate: HistoryUpdate)
+
+    /** Adds read duration without moving last_read on an existing row (novel readers). */
+    suspend fun upsertHistoryTimeRead(historyUpdate: HistoryUpdate)
 }

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -420,9 +420,13 @@
     <string name="novel_split_word_count">Split word count (×50)</string>
     <string name="novel_force_lowercase">Force text to lowercase</string>
     <string name="novel_engine_format">Engine #%d</string>
-    <string name="novel_enabled">Enabled</string>
-    <string name="novel_disabled">Disabled</string>
     <string name="novel_no_snippets">No snippets added</string>
+    <string name="novel_delete_snippet_confirm">Delete this snippet?</string>
+    <string name="novel_delete_rule_confirm">Delete this rule?</string>
+    <string name="novel_snippet_run_on_append">Re-run on infinite-scroll append</string>
+    <string name="novel_snippets_enabled_first">Move enabled snippets first</string>
+    <string name="novel_snippet_move_up">Move up</string>
+    <string name="novel_snippet_move_down">Move down</string>
     <string name="novel_regex_find_replace">Regex Find &amp; Replace</string>
     <string name="novel_add_rule">Add rule</string>
     <string name="novel_tag_regex">regex</string>
@@ -555,6 +559,13 @@
     <string name="pref_category_novel_downloads">Novel Downloads</string>
     <string name="pref_novel_source_overrides">Source-specific overrides</string>
     <string name="pref_novel_source_overrides_summary">Configure delays for specific sources</string>
+
+    <!-- Novel WebView (advanced) -->
+    <string name="pref_category_novel_webview">Novel WebView</string>
+    <string name="pref_novel_webview_devtools">WebView console client</string>
+    <string name="pref_novel_webview_devtools_summary">Attach a Chrome WebView client so JS alert/confirm/prompt dialogs and file pickers work, and console messages can be surfaced</string>
+    <string name="pref_novel_console_error_toast">Toast on console messages</string>
+    <string name="pref_novel_console_error_toast_summary">Show a toast for console log, warning and error messages from the novel WebView</string>
 
     <!-- Novel Image Embedding (category header only) -->
     <string name="pref_category_novel_images">Chapter Images</string>

--- a/reader-snippets/README.md
+++ b/reader-snippets/README.md
@@ -1,0 +1,64 @@
+# Novel WebView reader snippets
+
+Console snippets for exercising the novel WebView reader features/fixes on the
+`fix/reader-lifecycle-leaks` branch. Paste one into the reader's snippet runner
+(overflow menu -> snippet row) while a novel chapter is open.
+
+The debug panel lives separately in `../PR_DESCRIPTIONS.md` (a singleton dump of the
+`Tsundoku` runtime object, autoscroll/TTS state, the `Android` bridge, and chapter DOM).
+
+## Prerequisite for the devtools snippets
+
+The dialog / file-chooser / console snippets need the opt-in WebChromeClient:
+
+- **Advanced settings -> `novelWebViewDevTools` = ON** — installs the chrome client
+  (off by default; some OEM WebView builds break compat, hence the gate).
+- **`novelConsoleErrorToast` = ON** — additionally routes `console.log/warn/error` to toasts.
+
+| Snippet | Feature / fix it tests | Prereq |
+| --- | --- | --- |
+| `console-toast.js` | `onConsoleMessage` toast + level gate | devtools + console toast |
+| `js-dialogs.js` | `onJsAlert` / `onJsConfirm` / `onJsPrompt` wired to reader actions | devtools |
+| `set-background-image.js` | `onShowFileChooser` -> pick image, set as background, persist to `localStorage['tsundoku:customBg']` | devtools |
+| `menu-fab.js` | `Tsundoku.runtime.menuVisible` + `tsundoku:menuvisibilitychange` event: FABs mirror the reader menu | none |
+| `find-replace.js` | Bottom overlay (safe-area aware): find-in-chapter with Next/Prev + Replace / Replace all | none |
+| `infscroll-append-probe.js` | DocState / `loadedChapterIds` dedup: no duplicate chapter on rapid `loadNextChapter` | infinite scroll ON |
+
+## Menu visibility + safe-area insets
+
+Two separate mechanisms keep content clear of the reader chrome:
+
+- **Novel status bar** — has its own **layout space**: `viewer_container` is padded by its height on
+  the docked edge, so the WebView/TextView genuinely shrink and content never renders under it.
+  Nothing in JS needs to account for it.
+- **Reader menu bars** (top app bar + bottom bar) — transient overlays shown only with the menu, so
+  they can't take layout space without resizing the WebView on every toggle. Their measured heights
+  (plus system bars) are exposed to JS instead:
+  - `Tsundoku.runtime.menuVisible` — boolean, current reader-menu state.
+  - `window` event `tsundoku:menuvisibilitychange` — fired on change. `reader-chrome.js` sends
+    `detail.visible`; the reader-event system sends `detail.menuVisible` — read either.
+  - CSS vars `--tsundoku-safe-top` / `--tsundoku-safe-bottom` — px height of the top/bottom menu bar
+    (0 while the menu is hidden). Position fixed elements with e.g.
+    `bottom: calc(8px + var(--tsundoku-safe-bottom, 0px))`, or bound a column top **and** bottom to
+    sit in the free band between the bars (see `menu-fab.js`).
+
+All bars in these snippets and the debug panel already use those vars.
+
+## Notes
+
+- `set-background-image.js` downscales the chosen image (canvas, longest edge 1280px,
+  JPEG q0.82) before storing, so a multi-MB photo fits localStorage's ~5 MB budget.
+  It uses one **fixed** key (overwrite, never accumulate) and re-applies on each run,
+  so the background survives chapter loads and infinite-scroll appends.
+- `tsundoku:*` CustomEvents dispatched on `window`: `tsundoku:menuvisibilitychange`,
+  `tsundoku:chapternavigate`, `tsundoku:chapterloading`, `tsundoku:ttsstatechange`,
+  `tsundoku:progresschange`. The debug panel's event tap also listens to native `scrollend` /
+  `visibilitychange` / `resize`.
+- Reading progress: read `Tsundoku.runtime.chapterProgress` / `.progress` (0..1, set every scroll
+  frame by the scroll tracker) or subscribe to `tsundoku:progresschange`
+  (`detail { progress, chapterProgress, chapterId, isLast }`) instead of re-deriving % from
+  `scrollTop`, which drifts under infinite scroll / wide-viewport. `chapterProgress` is progress
+  through the current chapter (drives the slider); `progress` is the whole loaded document.
+- `find-replace.js` pins to the bottom via `bottom: calc(8px + var(--tsundoku-safe-bottom, 0px))`,
+  so it never hides under the reader's bottom bar; matching is literal + case-insensitive and scoped
+  to `tsundoku-chapter` content.

--- a/reader-snippets/console-toast.js
+++ b/reader-snippets/console-toast.js
@@ -1,0 +1,13 @@
+// Console -> toast bridge check. Confirms the devtools WebChromeClient is attached on this build.
+// Requires Advanced settings: novelWebViewDevTools ON + novelConsoleErrorToast ON.
+// The client toasts LOG/WARNING/ERROR (capped 120 chars).
+(function() {
+    var stamp = (performance && performance.now) ? Math.round(performance.now()) : 0;
+    console.log('Tsundoku devtools: LOG ok @' + stamp);
+    console.warn('Tsundoku devtools: WARN ok');
+    console.error('Tsundoku devtools: ERROR ok');
+    // WebView maps console.info to MessageLevel.LOG, so INFO also toasts; console.debug maps to
+    // DEBUG, which the client's gate skips.
+    console.debug('Tsundoku devtools: DEBUG (not toasted)');
+    console.info('Tsundoku devtools: INFO (toasts, maps to LOG)');
+})();

--- a/reader-snippets/find-replace.js
+++ b/reader-snippets/find-replace.js
@@ -1,0 +1,186 @@
+// In-chapter Find & Replace with a bottom overlay bar (Next / Prev match navigation).
+// The bar is fixed to the bottom and clears the reader menu via --tsundoku-safe-bottom, so it never
+// hides under the bottom app bar. Matching is literal + case-insensitive, scoped to chapter content.
+//
+// Find highlights every match and steps through them with Next / Prev; Replace swaps the current
+// match, Replace all swaps them all. Edits are in-page only (lost on reload), like any DOM snippet.
+(function () {
+    var BAR_ID = 'tsundoku-fr-bar';
+    var HIT_CLASS = 'tsundoku-fr-hit';
+    var CURRENT_CLASS = 'tsundoku-fr-current';
+
+    var old = document.getElementById(BAR_ID);
+    if (old) old.remove();
+
+    var hits = [];
+    var index = -1;
+
+    function chapterRoots() {
+        var roots = document.querySelectorAll('tsundoku-chapter');
+        return roots.length ? Array.prototype.slice.call(roots) : [document.body];
+    }
+
+    // Unwrap previous <mark> hits back into plain text so a new search starts clean.
+    function clearHits() {
+        var marks = document.querySelectorAll('.' + HIT_CLASS);
+        for (var i = 0; i < marks.length; i++) {
+            var m = marks[i];
+            var parent = m.parentNode;
+            if (!parent) continue;
+            parent.replaceChild(document.createTextNode(m.textContent), m);
+            parent.normalize();
+        }
+        hits = [];
+        index = -1;
+    }
+
+    function textNodesIn(root) {
+        var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode: function (node) {
+                if (!node.nodeValue || !node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+                var p = node.parentNode;
+                // Skip our own UI and non-content elements.
+                while (p && p !== root) {
+                    var tag = p.nodeName;
+                    if (p.id === BAR_ID || tag === 'SCRIPT' || tag === 'STYLE' || tag === 'MARK') {
+                        return NodeFilter.FILTER_REJECT;
+                    }
+                    p = p.parentNode;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            },
+        });
+        var nodes = [];
+        var n;
+        while ((n = walker.nextNode())) nodes.push(n);
+        return nodes;
+    }
+
+    function highlightInNode(node, term) {
+        var text = node.nodeValue;
+        var lower = text.toLowerCase();
+        var needle = term.toLowerCase();
+        var from = 0, at;
+        var frag = null, last = 0;
+        while ((at = lower.indexOf(needle, from)) !== -1) {
+            if (!frag) frag = document.createDocumentFragment();
+            if (at > last) frag.appendChild(document.createTextNode(text.slice(last, at)));
+            var mark = document.createElement('mark');
+            mark.className = HIT_CLASS;
+            mark.textContent = text.slice(at, at + term.length);
+            frag.appendChild(mark);
+            hits.push(mark);
+            last = at + term.length;
+            from = last;
+        }
+        if (frag) {
+            if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+            node.parentNode.replaceChild(frag, node);
+        }
+    }
+
+    function doFind(term) {
+        clearHits();
+        if (!term) { updateCount(); return; }
+        chapterRoots().forEach(function (root) {
+            textNodesIn(root).forEach(function (node) { highlightInNode(node, term); });
+        });
+        if (hits.length) focus(0);
+        updateCount();
+    }
+
+    function focus(i) {
+        if (!hits.length) return;
+        if (index >= 0 && hits[index]) hits[index].classList.remove(CURRENT_CLASS);
+        index = (i + hits.length) % hits.length;
+        var el = hits[index];
+        el.classList.add(CURRENT_CLASS);
+        el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        updateCount();
+    }
+
+    function replaceCurrent(rep) {
+        if (index < 0 || !hits[index]) return;
+        var mark = hits[index];
+        var parent = mark.parentNode;
+        parent.replaceChild(document.createTextNode(rep), mark);
+        parent.normalize();
+        hits.splice(index, 1);
+        if (hits.length) focus(index); else { index = -1; updateCount(); }
+    }
+
+    function replaceAll(rep) {
+        for (var i = 0; i < hits.length; i++) {
+            var mark = hits[i];
+            var parent = mark.parentNode;
+            if (!parent) continue;
+            parent.replaceChild(document.createTextNode(rep), mark);
+            parent.normalize();
+        }
+        hits = [];
+        index = -1;
+        updateCount();
+    }
+
+    // UI
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.style.cssText = 'position:fixed;left:8px;right:8px;z-index:100001;display:flex;flex-wrap:wrap;' +
+        'gap:6px;align-items:center;' +
+        'bottom:calc(8px + var(--tsundoku-safe-bottom, 0px));' +
+        'background:rgba(0,0,0,0.85);padding:8px;border-radius:8px;font-family:monospace;';
+
+    function field(placeholder) {
+        var i = document.createElement('input');
+        i.type = 'text';
+        i.placeholder = placeholder;
+        i.style.cssText = 'flex:1 1 120px;min-width:90px;padding:6px 8px;border:none;border-radius:5px;' +
+            'font-family:monospace;font-size:14px;';
+        return i;
+    }
+
+    function button(label, bg, onClick) {
+        var b = document.createElement('button');
+        b.textContent = label;
+        b.style.cssText = 'padding:6px 10px;border:none;border-radius:5px;background:' + bg + ';' +
+            'color:#000;font-weight:bold;cursor:pointer;';
+        b.onclick = onClick;
+        return b;
+    }
+
+    var findInput = field('Find');
+    var replaceInput = field('Replace with');
+    var count = document.createElement('span');
+    count.style.cssText = 'color:#0f0;font-size:13px;min-width:56px;text-align:center;';
+
+    function updateCount() {
+        count.textContent = hits.length ? ((index + 1) + '/' + hits.length) : '0/0';
+    }
+
+    findInput.addEventListener('input', function () { doFind(findInput.value); });
+    findInput.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') { e.preventDefault(); focus(index + 1); }
+    });
+
+    bar.appendChild(findInput);
+    bar.appendChild(button('◀', '#0f0', function () { focus(index - 1); }));
+    bar.appendChild(count);
+    bar.appendChild(button('▶', '#0f0', function () { focus(index + 1); }));
+    bar.appendChild(replaceInput);
+    bar.appendChild(button('Replace', '#ffb300', function () { replaceCurrent(replaceInput.value); }));
+    bar.appendChild(button('All', '#ffb300', function () { replaceAll(replaceInput.value); }));
+    bar.appendChild(button('x', '#f00', function () { clearHits(); bar.remove(); }));
+
+    // Highlight style, injected once.
+    if (!document.getElementById('tsundoku-fr-style')) {
+        var style = document.createElement('style');
+        style.id = 'tsundoku-fr-style';
+        style.textContent =
+            '.' + HIT_CLASS + '{background:#ff0;color:#000;}' +
+            '.' + CURRENT_CLASS + '{background:#ff9800;outline:2px solid #ff5722;}';
+        document.head.appendChild(style);
+    }
+
+    document.body.appendChild(bar);
+    updateCount();
+})();

--- a/reader-snippets/infscroll-append-probe.js
+++ b/reader-snippets/infscroll-append-probe.js
@@ -1,0 +1,46 @@
+// Infinite-scroll append probe: verifies the append dedup fix.
+// Fires loadNextChapter() several times in quick succession (the pathological case), then reports
+// whether any chapter id appears more than once in the DOM. Requires infinite scroll ON.
+(function() {
+    function nodeIds() {
+        return Array.prototype.slice.call(document.querySelectorAll('tsundoku-chapter'))
+            .map(function(n) { return n.getAttribute('data-chapter-id'); })
+            .filter(Boolean);
+    }
+
+    function duplicates(ids) {
+        var seen = {}, dups = [];
+        ids.forEach(function(id) {
+            seen[id] = (seen[id] || 0) + 1;
+            if (seen[id] === 2) dups.push(id);
+        });
+        return dups;
+    }
+
+    var before = nodeIds();
+    var runtime = (window.Tsundoku && Tsundoku.runtime) || {};
+    if (!runtime.isInfScroll) {
+        alert('Infinite scroll is OFF (Tsundoku.runtime.isInfScroll=false) — nothing to probe.');
+        return;
+    }
+    if (!(window.Android && typeof window.Android.loadNextChapter === 'function')) {
+        alert('Android.loadNextChapter bridge not present.');
+        return;
+    }
+
+    // Hammer the append trigger; the native side must coalesce these into at most one real append.
+    for (var i = 0; i < 5; i++) window.Android.loadNextChapter();
+
+    // Give the append coroutine time to run, then compare.
+    setTimeout(function() {
+        var after = nodeIds();
+        var dups = duplicates(after);
+        alert(
+            'Append probe\n' +
+            'nodes before: ' + before.length + '\n' +
+            'nodes after: ' + after.length + '\n' +
+            'net added: ' + (after.length - before.length) + ' (expect 0 or 1, never per-call)\n' +
+            'duplicate ids: ' + (dups.length ? dups.join(', ') : 'none (PASS)')
+        );
+    }, 1500);
+})();

--- a/reader-snippets/js-dialogs.js
+++ b/reader-snippets/js-dialogs.js
@@ -1,0 +1,89 @@
+// Native JS dialogs (alert / confirm / prompt) wired to real reader actions.
+// Requires Advanced settings: novelWebViewDevTools ON.
+// Adds a floating toolbar whose buttons drive alert/confirm/prompt, verifying they render and
+// resolve the pending JsResult (so the JS thread never hangs).
+(function() {
+    var BAR_ID = 'tsundoku-dialogs-bar';
+    var existing = document.getElementById(BAR_ID);
+    if (existing) existing.remove();
+
+    function scrollToPercent(pct) {
+        var doc = document.documentElement;
+        var max = Math.max((doc.scrollHeight || 0) - (doc.clientHeight || window.innerHeight || 0), 0);
+        window.scrollTo(0, Math.round(max * (pct / 100)));
+    }
+
+    // Read the app's own reading progress (boundary-aware, matches the slider) instead of
+    // re-deriving it from scrollTop, which drifts under infinite scroll and wide-viewport modes.
+    function currentProgressPercent() {
+        var rt = (window.Tsundoku && Tsundoku.runtime) || {};
+        var p = (typeof rt.chapterProgress === 'number') ? rt.chapterProgress : rt.progress;
+        return Math.round((p || 0) * 100);
+    }
+
+    // alert(): read-only status, sourced entirely from the app-provided Tsundoku object.
+    function doAlert() {
+        var T = window.Tsundoku || {};
+        var ch = T.currentChapter || {};
+        var rt = T.runtime || {};
+        var total = (T.chapters && T.chapters.length) || 0;
+        alert(
+            'Chapter: ' + (ch.title || '(unknown)') + '\n' +
+            'Number: ' + (ch.number >= 0 ? ch.number : '?') + '\n' +
+            'Loaded in page: ' + document.querySelectorAll('tsundoku-chapter').length + ' / ' + total + '\n' +
+            'Progress: ' + currentProgressPercent() + '% (chapter) / ' +
+                Math.round((rt.progress || 0) * 100) + '% (document)\n' +
+            'TTS: ' + (rt.ttsState || 'stopped') + '\n' +
+            'Loading chapter: ' + !!rt.loadingChapter + '\n' +
+            'Menu visible: ' + !!rt.menuVisible
+        );
+    }
+
+    // confirm(): yes/no gate before loading the next chapter. Gate on the runtime flags the app
+    // provides so we don't fire a pointless append.
+    function doConfirm() {
+        var rt = (window.Tsundoku && Tsundoku.runtime) || {};
+        if (!rt.isInfScroll) { alert('Infinite scroll is OFF — append does nothing here.'); return; }
+        if (rt.noMoreChapters) { alert('Already at the last chapter (runtime.noMoreChapters=true).'); return; }
+        if (confirm('Load the next chapter now (infinite scroll append)?')) {
+            if (window.Android && typeof window.Android.loadNextChapter === 'function') {
+                window.Android.loadNextChapter();
+            } else {
+                alert('Android.loadNextChapter bridge not present.');
+            }
+        }
+    }
+
+    // prompt(): text input to jump to a progress %.
+    function doPrompt() {
+        var raw = prompt('Jump to progress %', String(currentProgressPercent()));
+        if (raw === null) return; // Cancel
+        var pct = parseFloat(raw);
+        if (isNaN(pct)) { alert('Not a number: ' + raw); return; }
+        scrollToPercent(Math.max(0, Math.min(100, pct)));
+    }
+
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.style.cssText = 'position:fixed;left:8px;z-index:100001;display:flex;gap:6px;' +
+        'bottom:calc(8px + var(--tsundoku-safe-bottom, 0px));' +
+        'background:rgba(0,0,0,0.8);padding:6px;border-radius:8px;font-family:monospace;';
+
+    [['alert: status', doAlert],
+     ['confirm: next', doConfirm],
+     ['prompt: jump %', doPrompt]].forEach(function(pair) {
+        var b = document.createElement('button');
+        b.textContent = pair[0];
+        b.style.cssText = 'padding:6px 10px;border:none;border-radius:5px;background:#0f0;color:#000;font-weight:bold;cursor:pointer;';
+        b.onclick = pair[1];
+        bar.appendChild(b);
+    });
+
+    var close = document.createElement('button');
+    close.textContent = 'x';
+    close.style.cssText = 'padding:6px 9px;border:none;border-radius:5px;background:#f00;color:#fff;font-weight:bold;cursor:pointer;';
+    close.onclick = function() { bar.remove(); };
+    bar.appendChild(close);
+
+    document.body.appendChild(bar);
+})();

--- a/reader-snippets/menu-fab.js
+++ b/reader-snippets/menu-fab.js
@@ -1,0 +1,67 @@
+// Floating action buttons that slide in/out with the reader menu.
+// Uses the menu-visibility signals the WebView exposes:
+//   Tsundoku.runtime.menuVisible                 - boolean
+//   window 'tsundoku:menuvisibilitychange'       - CustomEvent, detail.visible / detail.menuVisible
+//   --tsundoku-safe-top / --tsundoku-safe-bottom - reader menu bar heights (+ system bars) in px
+// The column is bounded by both safe-area vars, so it sits in the free band between the top app bar
+// and the bottom bar.
+(function() {
+    var WRAP_ID = 'tsundoku-menu-fab';
+    var old = document.getElementById(WRAP_ID);
+    if (old) old.remove();
+
+    var wrap = document.createElement('div');
+    wrap.id = WRAP_ID;
+    wrap.style.cssText = 'position:fixed;right:12px;z-index:100001;display:flex;flex-direction:column;gap:10px;' +
+        'justify-content:flex-end;align-items:flex-end;' +
+        'top:calc(12px + var(--tsundoku-safe-top, 0px));' +
+        'bottom:calc(16px + var(--tsundoku-safe-bottom, 0px));' +
+        'pointer-events:none;' +
+        'transition:opacity .2s, transform .2s;font-family:monospace;';
+
+    function fab(label, onClick) {
+        var b = document.createElement('button');
+        b.textContent = label;
+        b.style.cssText = 'width:48px;height:48px;border:none;border-radius:50%;background:#0f0;color:#000;' +
+            'font-size:18px;font-weight:bold;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.4);' +
+            'pointer-events:auto;';
+        b.onclick = onClick;
+        return b;
+    }
+
+    wrap.appendChild(fab('↑', function() { window.scrollTo({ top: 0, behavior: 'smooth' }); }));
+    wrap.appendChild(fab('↓', function() {
+        window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+    }));
+    wrap.appendChild(fab('↻', function() {
+        // Trigger a next-chapter append, but only when the app-provided runtime flags say it's
+        // worthwhile (infinite scroll on, not already at the last chapter).
+        var rt = (window.Tsundoku && Tsundoku.runtime) || {};
+        if (!rt.isInfScroll || rt.noMoreChapters) return;
+        if (window.Android && typeof window.Android.loadNextChapter === 'function') {
+            window.Android.loadNextChapter();
+        }
+    }));
+
+    document.body.appendChild(wrap);
+
+    function render(visible) {
+        wrap.style.opacity = visible ? '1' : '0';
+        wrap.style.transform = visible ? 'translateY(0)' : 'translateY(12px)';
+        // Hide (not just fade) so an invisible FAB can't be tapped; wrap stays pointer-events:none
+        // so the empty band never eats taps.
+        wrap.style.visibility = visible ? 'visible' : 'hidden';
+    }
+
+    // Initial state from the runtime flag, then follow the event.
+    render(!!(window.Tsundoku && Tsundoku.runtime && Tsundoku.runtime.menuVisible));
+    // reader-chrome.js emits detail.visible; the reader-event system emits detail.menuVisible.
+    // Both fire under the same name, so read either and fall back to the runtime flag.
+    window.addEventListener('tsundoku:menuvisibilitychange', function(e) {
+        var d = e.detail || {};
+        var visible = d.visible;
+        if (visible === undefined) visible = d.menuVisible;
+        if (visible === undefined) visible = !!(window.Tsundoku && Tsundoku.runtime && Tsundoku.runtime.menuVisible);
+        render(!!visible);
+    });
+})();

--- a/reader-snippets/set-background-image.js
+++ b/reader-snippets/set-background-image.js
@@ -1,0 +1,129 @@
+// Pick an image file, use it as the reader background, and persist it in localStorage.
+// Requires Advanced settings: novelWebViewDevTools ON (exercises onShowFileChooser).
+// The chosen image is downscaled to fit localStorage, then painted onto a fixed full-viewport layer
+// behind the text. Restored on every run, so it survives chapter loads and infinite-scroll appends.
+(function() {
+    var STORAGE_KEY = 'tsundoku:customBg';   // fixed key: overwritten, never accumulates
+    var LAYER_ID = 'tsundoku-custom-bg-layer';
+    var MAX_DIM = 1280;                       // longest edge after downscale
+    var JPEG_QUALITY = 0.82;
+
+    function ensureLayer() {
+        var layer = document.getElementById(LAYER_ID);
+        if (!layer) {
+            layer = document.createElement('div');
+            layer.id = LAYER_ID;
+            layer.style.cssText = 'position:fixed;inset:0;z-index:-1;background-size:cover;' +
+                'background-position:center;background-repeat:no-repeat;pointer-events:none;';
+            document.body.insertBefore(layer, document.body.firstChild);
+        }
+        return layer;
+    }
+
+    function applyDataUrl(dataUrl) {
+        ensureLayer().style.backgroundImage = 'url("' + dataUrl + '")';
+        // Let the picture read through the text background so it isn't fully hidden by the theme.
+        document.documentElement.style.background = 'transparent';
+        if (document.body) document.body.style.background = 'transparent';
+    }
+
+    function restore() {
+        try {
+            var saved = localStorage.getItem(STORAGE_KEY);
+            if (saved) applyDataUrl(saved);
+            return !!saved;
+        } catch (e) { return false; }
+    }
+
+    function clearBg() {
+        try { localStorage.removeItem(STORAGE_KEY); } catch (e) {}
+        var layer = document.getElementById(LAYER_ID);
+        if (layer) layer.remove();
+    }
+
+    // Downscale + re-encode so a multi-MB photo doesn't blow the localStorage quota.
+    function downscaleToDataUrl(srcDataUrl, cb) {
+        var img = new Image();
+        img.onload = function() {
+            var w = img.naturalWidth, h = img.naturalHeight;
+            var scale = Math.min(1, MAX_DIM / Math.max(w, h));
+            var cw = Math.max(1, Math.round(w * scale)), ch = Math.max(1, Math.round(h * scale));
+            var canvas = document.createElement('canvas');
+            canvas.width = cw; canvas.height = ch;
+            canvas.getContext('2d').drawImage(img, 0, 0, cw, ch);
+            try {
+                cb(canvas.toDataURL('image/jpeg', JPEG_QUALITY));
+            } catch (e) {
+                cb(srcDataUrl); // tainted canvas or encode failure: fall back to original
+            }
+        };
+        img.onerror = function() { cb(srcDataUrl); };
+        img.src = srcDataUrl;
+    }
+
+    function persist(dataUrl) {
+        try {
+            localStorage.setItem(STORAGE_KEY, dataUrl);
+            return true;
+        } catch (e) {
+            alert('Could not save background: ' + (e && e.name === 'QuotaExceededError'
+                ? 'image too large for localStorage even after downscale.'
+                : (e && e.message) || e));
+            return false;
+        }
+    }
+
+    function pickImage() {
+        var input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.style.display = 'none';
+        input.onchange = function() {
+            var file = input.files && input.files[0];
+            input.remove();
+            if (!file) return; // chooser cancelled -> filePathCallback resolved with no uri natively
+            var reader = new FileReader();
+            reader.onload = function() {
+                downscaleToDataUrl(reader.result, function(finalUrl) {
+                    applyDataUrl(finalUrl);
+                    persist(finalUrl);
+                });
+            };
+            reader.readAsDataURL(file);
+        };
+        document.body.appendChild(input);
+        input.click(); // triggers native onShowFileChooser
+    }
+
+    var BAR_ID = 'tsundoku-bg-bar';
+    var old = document.getElementById(BAR_ID);
+    if (old) old.remove();
+
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.style.cssText = 'position:fixed;right:8px;z-index:100001;display:flex;gap:6px;' +
+        'bottom:calc(8px + var(--tsundoku-safe-bottom, 0px));' +
+        'background:rgba(0,0,0,0.8);padding:6px;border-radius:8px;font-family:monospace;';
+
+    var pickBtn = document.createElement('button');
+    pickBtn.textContent = 'Pick background';
+    pickBtn.style.cssText = 'padding:6px 10px;border:none;border-radius:5px;background:#0f0;color:#000;font-weight:bold;cursor:pointer;';
+    pickBtn.onclick = pickImage;
+    bar.appendChild(pickBtn);
+
+    var clearBtn = document.createElement('button');
+    clearBtn.textContent = 'Clear';
+    clearBtn.style.cssText = 'padding:6px 10px;border:none;border-radius:5px;background:#ffb300;color:#000;font-weight:bold;cursor:pointer;';
+    clearBtn.onclick = clearBg;
+    bar.appendChild(clearBtn);
+
+    var close = document.createElement('button');
+    close.textContent = 'x';
+    close.style.cssText = 'padding:6px 9px;border:none;border-radius:5px;background:#f00;color:#fff;font-weight:bold;cursor:pointer;';
+    close.onclick = function() { bar.remove(); };
+    bar.appendChild(close);
+
+    document.body.appendChild(bar);
+
+    restore(); // re-apply a previously chosen background on load / after appends
+})();


### PR DESCRIPTION

## Lifecycle / rotation
- **Rotation no longer recreates the activity for novels.** `ReaderActivity` handles
  `onConfigurationChanged` (+ manifest `configChanges`), so a novel viewer keeps its TTS session,
  WebView state, and scroll position. Non-novel viewers still `recreate()`; falls back to
  `manga.isNovel` when the viewer isn't built yet.
- `updateViewer()` no longer tears down a live novel viewer on a non-viewer `state.manga` re-emit
  (e.g. the orientation dialog fetching a fresh manga) — only re-applies orientation.

## Leaks / teardown
- `NovelWebViewViewer.destroy()`: idempotent, removes the attach listener, `cancel()`s (not
  `dismiss()`) any on-screen JS dialog so the pending `JsResult` unblocks the JS thread, then detaches
  and destroys the WebView. `NovelViewer` mirrors the attach-listener removal.
- **Brightness sample-collector leak:** single `brightnessJob`, cancelled before relaunch, so novel/
  manga brightness setters can't stack flow collectors; switching away resyncs manga brightness.
- **proguard:** corrected the `-keep` for the WebView JS interface to its real package (was a latent
  release-build bug where the interface could be stripped/obfuscated).

## Novel history recency
- New `upsertTimeRead` query / `awaitTimeReadOnly`: accumulates read duration **without moving
  `last_read`**. Novels route through it, so the visible-chapter entry owns recency and a leave/pause
  flush can't outrank the chapter being read after a hard kill. Manga keeps `last_read=now`.
- Read-timer flush/restart collapsed into one ordered `flushReadTimerAndRestart()` (fixes the ~0
  duration race); write runs `NonCancellable`; concurrent flushes serialized behind `historyMutex`.

## Autoscroll
- WebView autoscroll is a single in-page `requestAnimationFrame` loop with sub-pixel accumulation
  (replaces the stuttering 50ms Kotlin->JS `scrollBy` timer); pauses when backgrounded, clamps `dt`.
- **Start is verified:** polls the loop's `running` flag and clears `isAutoScrolling` if it never
  started, so the toggle can't stick "on" with no motion. Re-armed after full loads / error page.
- TextView autoscroll uses `scrollBy` (not the re-arming `smoothScrollBy`) with fractional accum.
- Speed pref stored as half-steps -> 0.5 increments (new key, old mixed-scale pref not reused).
- **Seeking stops autoscroll** (a slider seek is an explicit position choice).
- Tap-zone / volume-key / key scrolling routed through one `pageScrollBy` using `window.innerHeight`
  (CSS px), fixing the `container.height` (device px) overshoot that skipped content.

## Infinite scroll (WebView)
- Load state unified into a `DocState` enum (`LOADING`/`LOADING_REAL`/`READY`/`ERROR`), replacing
  three hand-synced booleans (`webChapterContentReady`/`webChapterIsError` kept as derived getters).
- Base loads cancel in-flight `contentJob`/`appendJob` and gate appends until the DOM is committed, so
  an early append can't splice a stale chapter; queue-add and DOM-insert share one `loadedChapterIds`
  guard against duplicate inserts.
- `appendHtmlContent` rebuilds chapter boundaries **synchronously** before the first scroll frame
  (fixes the transient doubled-document position).
- Error/failure loads no longer wedge infinite scroll (`ERROR` keeps ready true; `isError` suppresses
  appending onto the placeholder).
- **Prepend load error no longer replaces the whole document** — surfaced inline (like the append
  path) instead of a full-page error that wiped the multi-chapter view + scroll.
- Scroll persistence waits out late reflow (images/fonts) via a `ResizeObserver` + 400ms settle in
  `scroll-tracking.js`, so `scrollend` off a still-settling height can't save a wrong position.

## TTS / slider
- WebView: `saveTtsProgressForChunk` persists only when backgrounded (foreground progress + slider are
  owned by the per-chapter scroll bridge; WebView TTS reads the whole multi-chapter body).
- TextView: scroll path suppressed for the chapter TTS is speaking (`isTtsDrivingVisibleChapter`), and
  the TTS chunk hook mirrors its percent to the slider — ends the dual-writer race on `last_page_read`.

## WebView devtools (Advanced settings)
- `novelWebViewDevTools` gates a `WebChromeClient` (default off): console-message toast
  (`novelConsoleErrorToast`, sub-gated, LOG/WARN/ERROR), `onJsAlert`/`onJsConfirm`/`onJsPrompt`
  dialogs, and `onShowFileChooser` wired to a `ReaderActivity` launcher registered eagerly.

## Reader chrome no longer overlaps content
- **Novel status bar -> real layout space:** `viewer_container` padded by the overlay height on its
  docked edge while enabled (reserved permanently, not per menu toggle, so the WebView isn't resized
  mid-scroll). Fixes the TextView next-chapter-button cutoff natively.
- **Reader menu bars -> exposed to JS:** measured heights pushed as `--tsundoku-safe-top/bottom`,
  `Tsundoku.runtime.menuVisible`, and a `tsundoku:menuvisibility` event via the `reader-chrome.js`
  asset. Read only inside a `snapshotFlow` with remembered callbacks, no-op guarded, so scroll
  recompositions stay off the per-frame path. `next-chapter-button.js` reads the same bottom var.

## Misc
- `getMangaUrlOrNull` / `getChapterUrlOrNull` return null on throw; `LibraryItem.fullUrl` and
  `DuplicateDetectionScreen` use them instead of hand-rolled base-URL joining.
- `NovelWebViewViewer` memoizes the resolved manga URL (was recomputed twice per load/append).
- Snippet appends re-run only `runOnAppend` snippets; one-shot code stays on the initial load.
- Novel-reader `DocumentBuilder`: per-paragraph `<p>` (never parsed as markup) instead of one `<pre>`,
  so the copy/quote paragraph-index counter sees the same block elements.
- `JsPluginManager`: metadata lookup by a name->file map; corrupt metadata falls back to code
  extraction instead of dropping the plugin. Verbose per-file logging removed.
- Novel reader settings: snippet and regex rows moved to an overflow menu (`NovelPage`).
