### PR TITLE
fix(backup): scope library refresh to restored manga, migrate legacy isnovel per blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
+- Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Pull to refresh spinner will be more patient [@mrissaoussama](https://github.com/mrissaoussama) [#321](https://github.com/tsundoku-otaku/tsundoku/pull/321)
 - Deleage custom-source image fetch to base httpsource [@mrissaoussama](https://github.com/mrissaoussama) [#331](https://github.com/tsundoku-otaku/tsundoku/pull/331)
 - Disable text selection; fix textview crash on select spam [@mrissaoussama](https://github.com/mrissaoussama) [#311](https://github.com/tsundoku-otaku/tsundoku/pull/311)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
@@ -31,7 +31,8 @@ class BackupFileValidator(
             reader.read(uri) { fieldNumber, data ->
                 when (fieldNumber) {
                     1 -> {
-                        val manga = parser.decodeFromByteArray(BackupManga.serializer(), data)
+                        val migrated = BackupProtoMigration.migrateManga(data)
+                        val manga = parser.decodeFromByteArray(BackupManga.serializer(), migrated)
                         manga.tracking.forEach { trackerIds.add(it.syncId.toLong()) }
                     }
                     101 -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoMigration.kt
@@ -30,6 +30,28 @@ internal object BackupProtoMigration {
         else -> null
     }
 
+    // For per-blob decode sites that bypass migrateLegacyIsNovel. Presence check first so a
+    // current-schema blob (the common case) skips the deep copy.
+    fun migrateManga(body: ByteArray): ByteArray = try {
+        if (!subMessageHasLegacyVarint(body, 0, body.size, MANGA_LEGACY_IS_NOVEL_FIELD)) {
+            body
+        } else {
+            migrateSubMessage(body, MANGA_LEGACY_IS_NOVEL_FIELD)
+        }
+    } catch (_: Exception) {
+        body
+    }
+
+    fun migrateExtensionStore(body: ByteArray): ByteArray = try {
+        if (!subMessageHasLegacyVarint(body, 0, body.size, EXTENSION_STORE_LEGACY_IS_NOVEL_FIELD)) {
+            body
+        } else {
+            migrateSubMessage(body, EXTENSION_STORE_LEGACY_IS_NOVEL_FIELD)
+        }
+    } catch (_: Exception) {
+        body
+    }
+
     fun migrateLegacyIsNovel(input: ByteArray): ByteArray {
         return try {
             if (!hasLegacyIsNovel(input)) return input

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.backup.restore
 import android.content.Context
 import android.net.Uri
 import eu.kanade.tachiyomi.data.backup.BackupNotifier
+import eu.kanade.tachiyomi.data.backup.BackupProtoMigration
 import eu.kanade.tachiyomi.data.backup.BackupProtoReader
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
@@ -53,6 +54,7 @@ class BackupRestorer(
     private var restoreAmount = 0
     private val restoreProgress = AtomicInt(0)
     private val errors = CopyOnWriteArrayList<Pair<Date, String>>()
+    private val restoredMangaIds = CopyOnWriteArrayList<Long>()
 
     /**
      * Mapping of source ID to source name from backup data
@@ -64,7 +66,12 @@ class BackupRestorer(
 
         restoreFromFile(uri, options)
 
-        if (options.libraryEntries || options.categories) {
+        if (options.libraryEntries && restoredMangaIds.isNotEmpty()) {
+            try {
+                getLibraryManga.refreshForcedScoped(restoredMangaIds.distinct())
+            } catch (_: Exception) {
+            }
+        } else if (options.libraryEntries || options.categories) {
             try {
                 getLibraryManga.refreshForced()
             } catch (_: Exception) {
@@ -152,7 +159,12 @@ class BackupRestorer(
                 105 -> backupSourcePreferences.add(
                     parser.decodeFromByteArray(BackupSourcePreferences.serializer(), data),
                 )
-                106 -> backupExtensionStores.add(parser.decodeFromByteArray(BackupExtensionStore.serializer(), data))
+                106 -> backupExtensionStores.add(
+                    parser.decodeFromByteArray(
+                        BackupExtensionStore.serializer(),
+                        BackupProtoMigration.migrateExtensionStore(data),
+                    ),
+                )
             }
         }
 
@@ -176,18 +188,21 @@ class BackupRestorer(
             if (fieldNumber != 1) return@read
             ensureActive()
 
-            val backupManga = parser.decodeFromByteArray(BackupManga.serializer(), data)
+            val backupManga = parser.decodeFromByteArray(
+                BackupManga.serializer(),
+                BackupProtoMigration.migrateManga(data),
+            )
             if ((!backupManga.isNovel && options.includeManga) || (backupManga.isNovel && options.includeNovels)) {
                 try {
-                    mangaRestorer.restore(backupManga, backupCategories)
+                    restoredMangaIds.add(mangaRestorer.restore(backupManga, backupCategories))
                 } catch (e: Exception) {
                     val sourceName = sourceMapping[backupManga.source] ?: backupManga.source.toString()
                     errors.add(Date() to "${backupManga.title} [$sourceName]: ${e.message}")
                 }
             }
 
-            restoreProgress.incrementAndFetch()
-            notifier.showRestoreProgress(backupManga.title, restoreProgress.load(), restoreAmount, isSync)
+            val progress = restoreProgress.incrementAndFetch()
+            notifier.showRestoreProgress(backupManga.title, progress, restoreAmount, isSync)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -62,7 +62,8 @@ class MangaRestorer(
     suspend fun restore(
         backupManga: BackupManga,
         backupCategories: List<BackupCategory>,
-    ) {
+    ): Long {
+        var mangaId = 0L
         database.transaction {
             val dbManga = findExistingManga(backupManga)
             val manga = backupManga.getMangaImpl()
@@ -81,7 +82,9 @@ class MangaRestorer(
                 tracks = backupManga.tracking,
                 excludedScanlators = backupManga.excludedScanlators,
             )
+            mangaId = restoredManga.id
         }
+        return mangaId
     }
 
     /**

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -2010,6 +2010,16 @@ class MangaRepositoryImpl(
         }
     }
 
+    override suspend fun refreshLibraryCacheForMangas(mangaIds: List<Long>) {
+        if (mangaIds.isEmpty()) return
+        logcat(LogPriority.INFO) {
+            "MangaRepositoryImpl.refreshLibraryCacheForMangas: Recomputing aggregates for ${mangaIds.size} manga"
+        }
+        database.transaction {
+            database.mangasQueries.recomputeAggregatesForMangas(mangaIds)
+        }
+    }
+
     /**
      * Canonical tag normalization: split each entry on `,` / `;` (sources may merge tags), trim,
      * title-case each word, drop blanks, dedupe case-insensitively keeping first occurrence. Shared

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -880,6 +880,54 @@ SET
     )
 WHERE _id = :mangaId;
 
+recomputeAggregatesForMangas:
+UPDATE mangas
+SET
+    total_count = coalesce((
+        SELECT count(*)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0),
+    read_count = coalesce((
+        SELECT sum(chapters.read)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0),
+    latest_upload = coalesce((
+        SELECT max(chapters.date_upload)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0),
+    chapter_fetched_at = coalesce((
+        SELECT max(chapters.date_fetch)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0),
+    last_read = coalesce((
+        SELECT max(history.last_read)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        LEFT JOIN history ON chapters._id = history.chapter_id
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0),
+    bookmark_count = coalesce((
+        SELECT sum(chapters.bookmark)
+        FROM chapters
+        LEFT JOIN excluded_scanlators ON chapters.manga_id = excluded_scanlators.manga_id
+            AND chapters.scanlator = excluded_scanlators.scanlator
+        WHERE chapters.manga_id = mangas._id AND excluded_scanlators.scanlator IS NULL
+    ), 0)
+WHERE _id IN :mangaIds;
+
 recomputeAllAggregates:
 UPDATE mangas
 SET

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -135,6 +135,18 @@ class GetLibraryManga(
     }
 
     /**
+     * Like [refreshForced] but recomputes aggregates for only the given manga instead of the
+     * whole favorites table.
+     */
+    suspend fun refreshForcedScoped(mangaIds: List<Long>): List<LibraryManga> {
+        if (mangaIds.isNotEmpty()) {
+            mangaRepository.refreshLibraryCacheForMangas(mangaIds)
+        }
+        refreshInternal(force = true, recompute = false)
+        return _libraryState.value
+    }
+
+    /**
      * Apply category updates to the in-memory library list without a full DB refresh.
      * This keeps UI responsive for small, targeted changes.
      */
@@ -367,7 +379,7 @@ class GetLibraryManga(
         }
     }
 
-    private suspend fun refreshInternal(force: Boolean) {
+    private suspend fun refreshInternal(force: Boolean, recompute: Boolean = force) {
         mutex.withLock {
             val now = System.currentTimeMillis()
             if (!force && (now - lastRefreshTime) < minRefreshIntervalMs) {
@@ -381,7 +393,7 @@ class GetLibraryManga(
 
             val paginated = paginationEnabled
             if (!paginated) {
-                if (force) {
+                if (recompute) {
                     logcat(LogPriority.INFO) { "GetLibraryManga: Rebuilding library_cache table (forced)" }
                     mangaRepository.refreshLibraryCache()
                 } else {

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -261,6 +261,11 @@ interface MangaRepository {
     suspend fun refreshLibraryCacheForManga(mangaId: Long)
 
     /**
+     * Refresh the library cache for a batch of manga, scoped by id instead of the whole favorites table.
+     */
+    suspend fun refreshLibraryCacheForMangas(mangaIds: List<Long>)
+
+    /**
      * Invalidate the in-memory library cache.
      * Forces the next getLibraryManga() call to re-query the database.
      * Use this before forced refreshes to ensure fresh data.


### PR DESCRIPTION
- Backup restore now recomputes library aggregates only for the manga actually restored (new recomputeAggregatesForMangas query + refreshForcedScoped), instead of recomputing the entire favorites table on every restore. Falls back to a full refresh when categories are restored too, or when nothing was tracked.
- Applies the legacy isNovel proto migration (field 112/8 > 8000) at the per-blob decode sites in BackupFileValidator and BackupRestorer, which previously bypassed it and could misdecode old backup files.
