### PR TITLE
epub reader: strip namespace prefixes from OPF documents

### DIFF
--- a/app/src/test/java/mihon/core/archive/EpubReaderNamespacePrefixTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNamespacePrefixTest.kt
@@ -1,0 +1,114 @@
+package mihon.core.archive
+
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubReaderNamespacePrefixTest {
+
+    private fun opf(xml: String) = Jsoup.parse(xml, "", Parser.xmlParser())
+
+    private val prefixedOpf = """
+        <ns0:package xmlns:ns0="http://www.idpf.org/2007/opf" version="2.0">
+        <ns0:metadata>
+            <ns0:meta name="cover" content="cover-image" />
+        </ns0:metadata>
+        <ns0:manifest>
+            <ns0:item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+            <ns0:item id="chapter0001" href="Text/chapter0001.xhtml" media-type="application/xhtml+xml" />
+            <ns0:item id="chapter0002" href="Text/chapter0002.xhtml" media-type="application/xhtml+xml" />
+            <ns0:item id="cover-image" href="Images/cover.webp" media-type="image/webp" />
+        </ns0:manifest>
+        <ns0:spine toc="ncx">
+            <ns0:itemref idref="chapter0001" />
+            <ns0:itemref idref="chapter0002" />
+        </ns0:spine>
+        </ns0:package>
+    """.trimIndent()
+
+    @Test
+    fun `unprefixed opf selectors match nothing before stripping`() {
+        val doc = opf(prefixedOpf)
+
+        assertTrue(doc.select("manifest > item").isEmpty())
+        assertTrue(doc.select("spine > itemref").isEmpty())
+    }
+
+    @Test
+    fun `stripNamespacePrefixes renames tags in place and returns the same document`() {
+        val doc = opf(prefixedOpf)
+
+        val stripped = EpubReader.stripNamespacePrefixes(doc)
+
+        assertTrue(stripped === doc)
+        assertEquals(4, doc.select("manifest > item").size)
+        assertEquals(2, doc.select("spine > itemref").size)
+    }
+
+    @Test
+    fun `extractSpineHrefs resolves ordered xhtml pages after stripping a prefixed opf`() {
+        val doc = EpubReader.stripNamespacePrefixes(opf(prefixedOpf))
+
+        val hrefs = EpubReader.extractSpineHrefs(doc)
+
+        assertEquals(listOf("Text/chapter0001.xhtml", "Text/chapter0002.xhtml"), hrefs)
+    }
+
+    @Test
+    fun `extractSpineHrefs returns nothing for an unstripped prefixed opf`() {
+        val doc = opf(prefixedOpf)
+
+        assertTrue(EpubReader.extractSpineHrefs(doc).isEmpty())
+    }
+
+    @Test
+    fun `findNcxHref resolves the ncx manifest item after stripping`() {
+        val doc = EpubReader.stripNamespacePrefixes(opf(prefixedOpf))
+
+        assertEquals("toc.ncx", EpubReader.findNcxHref(doc))
+    }
+
+    @Test
+    fun `findNavHref is empty when the manifest has no epub3 nav item`() {
+        val doc = EpubReader.stripNamespacePrefixes(opf(prefixedOpf))
+
+        assertEquals("", EpubReader.findNavHref(doc))
+    }
+
+    @Test
+    fun `findNavHref resolves a prefixed epub3 nav manifest item after stripping`() {
+        val navOpf = """
+            <ns0:package xmlns:ns0="http://www.idpf.org/2007/opf" version="3.0">
+            <ns0:manifest>
+                <ns0:item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav" />
+                <ns0:item id="chapter0001" href="Text/chapter0001.xhtml" media-type="application/xhtml+xml" />
+            </ns0:manifest>
+            <ns0:spine>
+                <ns0:itemref idref="chapter0001" />
+            </ns0:spine>
+            </ns0:package>
+        """.trimIndent()
+        val doc = EpubReader.stripNamespacePrefixes(opf(navOpf))
+
+        assertEquals("nav.xhtml", EpubReader.findNavHref(doc))
+    }
+
+    @Test
+    fun `unprefixed opf is unaffected by stripping`() {
+        val plainXml = """
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+            <manifest>
+                <item id="chapter0001" href="Text/chapter0001.xhtml" media-type="application/xhtml+xml" />
+            </manifest>
+            <spine>
+                <itemref idref="chapter0001" />
+            </spine>
+            </package>
+        """.trimIndent()
+        val doc = EpubReader.stripNamespacePrefixes(opf(plainXml))
+
+        assertEquals(listOf("Text/chapter0001.xhtml"), EpubReader.extractSpineHrefs(doc))
+    }
+}

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -118,20 +118,14 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
      * Returns the package document where all the files are listed.
      */
     fun getPackageDocument(ref: String): Document {
-        return getInputStream(ref)!!.use { Jsoup.parse(it, null, "", Parser.xmlParser()) }
+        val doc = getInputStream(ref)!!.use { Jsoup.parse(it, null, "", Parser.xmlParser()) }
+        return stripNamespacePrefixes(doc)
     }
 
     /**
      * Returns all the pages from the epub.
      */
-    fun getPagesFromDocument(document: Document): List<String> {
-        val pages = document.select("manifest > item")
-            .filter { node -> "application/xhtml+xml" == node.attr("media-type") }
-            .associateBy { it.attr("id") }
-
-        val spine = document.select("spine > itemref").map { it.attr("idref") }
-        return spine.mapNotNull { pages[it] }.map { it.attr("href").urlDecoded() }
-    }
+    fun getPagesFromDocument(document: Document): List<String> = extractSpineHrefs(document)
 
     /**
      * Returns all the images contained in every page from the epub.
@@ -282,14 +276,14 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         val opfBasePath = getParentDirectory(ref)
 
         // Try EPUB 3 NAV first
-        val navHref = doc.select("manifest > item[properties*=nav]").attr("href")
+        val navHref = findNavHref(doc)
         if (navHref.isNotEmpty()) {
             val navChapters = parseEpub3Nav(resolveZipPath(opfBasePath, navHref))
             if (navChapters.isNotEmpty()) return navChapters
         }
 
         // Fall back to EPUB 2 NCX
-        val ncxHref = doc.select("manifest > item[media-type='application/x-dtbncx+xml']").attr("href")
+        val ncxHref = findNcxHref(doc)
         if (ncxHref.isNotEmpty()) {
             val ncxChapters = parseEpub2Ncx(resolveZipPath(opfBasePath, ncxHref))
             if (ncxChapters.isNotEmpty()) return ncxChapters
@@ -697,6 +691,41 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                 chapter.copy(title = normalizedTitle)
             }
         }
+
+        /**
+         * Strips namespace prefixes from element tag names (e.g. "ns0:item" -> "item"). Some EPUBs
+         * (commonly produced by Python's xml.etree.ElementTree without a registered default namespace)
+         * qualify every OPF element with an auto-generated prefix instead of the usual unprefixed
+         * default-namespace form. Jsoup's XML parser keeps the prefix as part of the literal tag name,
+         * so plain-tag CSS selectors like "manifest > item" would otherwise match nothing.
+         */
+        fun stripNamespacePrefixes(doc: Document): Document {
+            doc.allElements.forEach { element ->
+                val colonIndex = element.tagName().indexOf(':')
+                if (colonIndex > 0) {
+                    element.tagName(element.tagName().substring(colonIndex + 1))
+                }
+            }
+            return doc
+        }
+
+        /** Resolves the OPF manifest+spine into the ordered list of xhtml page hrefs. */
+        fun extractSpineHrefs(document: Document): List<String> {
+            val pages = document.select("manifest > item")
+                .filter { node -> "application/xhtml+xml" == node.attr("media-type") }
+                .associateBy { it.attr("id") }
+
+            val spine = document.select("spine > itemref").map { it.attr("idref") }
+            return spine.mapNotNull { pages[it] }.map { it.attr("href").let(::urlDecode) }
+        }
+
+        /** Returns the manifest item href for the EPUB 3 NAV document, or empty if absent. */
+        fun findNavHref(document: Document): String =
+            document.select("manifest > item[properties*=nav]").attr("href")
+
+        /** Returns the manifest item href for the EPUB 2 NCX document, or empty if absent. */
+        fun findNcxHref(document: Document): String =
+            document.select("manifest > item[media-type='application/x-dtbncx+xml']").attr("href")
 
         fun computeExportImageId(imagePath: String): String {
             val normalized = imagePath.replace('\\', '/')


### PR DESCRIPTION
- strip namespace prefixes (e.g. "ns0:") from OPF elements to ensure Jsoup selectors like `manifest > item` match tags correctly
- refactor spine, nav, and ncx href extraction into dedicated helper methods
- add unit tests verifying href resolution for both prefixed and unprefixed OPF files

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
