### PR TITLE
fix(epub): preserve dc namespace prefix when stripping OPF prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Download ahead download states should no longer get stale values [@mrissaoussama](https://github.com/mrissaoussama) [#289](https://github.com/tsundoku-otaku/tsundoku/pull/289)
 - Fix per-tab extension update badge [@mrissaoussama](https://github.com/mrissaoussama) [#277](https://github.com/tsundoku-otaku/tsundoku/pull/277)
 - Prevent google translate returning literal null [@mrissaoussama](https://github.com/mrissaoussama) [#312](https://github.com/tsundoku-otaku/tsundoku/pull/312)
+- EPUB: Preserve DC namespace prefix when stripping OPF prefixes [@mrissaoussama](https://github.com/mrissaoussama) [#344](https://github.com/tsundoku-otaku/tsundoku/pull/344)
 - Remove invisible characters from filenames to prevent dl index issues [@mrissaoussama](https://github.com/mrissaoussama) [#307](https://github.com/tsundoku-otaku/tsundoku/pull/307)
 - Novel reader orientation and TTS highlight fix [@mrissaoussama](https://github.com/mrissaoussama) [#310](https://github.com/tsundoku-otaku/tsundoku/pull/310)
 - Fix library setting loading and tags [@mrissaoussama](https://github.com/mrissaoussama) [#291](https://github.com/tsundoku-otaku/tsundoku/pull/291)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/ParseEpubPreview.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/ParseEpubPreview.kt
@@ -69,7 +69,7 @@ class ParseEpubPreview {
                 val chapter = SChapter.create()
                 epubReader.fillMetadata(manga, chapter)
 
-                val metadataTitle = manga.title.takeIf { it.isNotBlank() }
+                val metadataTitle = runCatching { manga.title }.getOrNull()?.takeIf { it.isNotBlank() }
                 val title = metadataTitle
                     ?: chapter.name.takeIf { it.isNotBlank() }
                     ?: fileName.removeSuffix(".epub")

--- a/app/src/test/java/mihon/core/archive/EpubReaderNamespacePrefixTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNamespacePrefixTest.kt
@@ -96,6 +96,51 @@ class EpubReaderNamespacePrefixTest {
     }
 
     @Test
+    fun `stripNamespacePrefixes preserves dc prefix so metadata stays queryable`() {
+        val dcOpf = """
+            <package xmlns="http://www.idpf.org/2007/opf"
+                     xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+            <metadata>
+                <dc:title>My Novel</dc:title>
+                <dc:creator>Some Author</dc:creator>
+            </metadata>
+            <manifest>
+                <item id="chapter0001" href="Text/chapter0001.xhtml" media-type="application/xhtml+xml" />
+            </manifest>
+            <spine>
+                <itemref idref="chapter0001" />
+            </spine>
+            </package>
+        """.trimIndent()
+        val doc = EpubReader.stripNamespacePrefixes(opf(dcOpf))
+
+        assertEquals("My Novel", doc.getElementsByTag("dc:title").firstOrNull()?.text())
+        assertEquals("Some Author", doc.getElementsByTag("dc:creator").firstOrNull()?.text())
+        assertEquals(1, doc.select("manifest > item").size)
+    }
+
+    @Test
+    fun `stripNamespacePrefixes leaves plain metadata reachable when dc is auto-prefixed`() {
+        val prefixedDcOpf = """
+            <ns0:package xmlns:ns0="http://www.idpf.org/2007/opf" version="2.0">
+            <ns0:metadata>
+                <ns1:title xmlns:ns1="http://purl.org/dc/elements/1.1/">Prefixed Novel</ns1:title>
+            </ns0:metadata>
+            <ns0:manifest>
+                <ns0:item id="chapter0001" href="Text/chapter0001.xhtml" media-type="application/xhtml+xml" />
+            </ns0:manifest>
+            <ns0:spine>
+                <ns0:itemref idref="chapter0001" />
+            </ns0:spine>
+            </ns0:package>
+        """.trimIndent()
+        val doc = EpubReader.stripNamespacePrefixes(opf(prefixedDcOpf))
+
+        assertEquals("Prefixed Novel", doc.select("metadata > title").firstOrNull()?.text())
+        assertEquals(1, doc.select("manifest > item").size)
+    }
+
+    @Test
     fun `unprefixed opf is unaffected by stripping`() {
         val plainXml = """
             <package xmlns="http://www.idpf.org/2007/opf" version="2.0">

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -698,11 +698,13 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
          * qualify every OPF element with an auto-generated prefix instead of the usual unprefixed
          * default-namespace form. Jsoup's XML parser keeps the prefix as part of the literal tag name,
          * so plain-tag CSS selectors like "manifest > item" would otherwise match nothing.
+         *
+         * "dc:" is kept because [fillMetadata] queries Dublin Core metadata by prefixed tag name.
          */
         fun stripNamespacePrefixes(doc: Document): Document {
             doc.allElements.forEach { element ->
                 val colonIndex = element.tagName().indexOf(':')
-                if (colonIndex > 0) {
+                if (colonIndex > 0 && !element.tagName().startsWith("dc:", ignoreCase = true)) {
                     element.tagName(element.tagName().substring(colonIndex + 1))
                 }
             }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/metadata/EpubReaderExtensions.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/metadata/EpubReaderExtensions.kt
@@ -16,6 +16,9 @@ fun EpubReader.fillMetadata(manga: SManga, chapter: SChapter) {
     val doc = getPackageDocument(ref)
     var title = doc.getElementsByTag("dc:title").firstOrNull()?.text()
     if (title.isNullOrBlank()) {
+        title = doc.select("metadata > title").firstOrNull()?.text()
+    }
+    if (title.isNullOrBlank()) {
         title = doc.select("docTitle").firstOrNull()?.text()
     }
 
@@ -23,16 +26,18 @@ fun EpubReader.fillMetadata(manga: SManga, chapter: SChapter) {
         title = doc.select("meta[name=title]").firstOrNull()?.attr("content")
     }
     val publisher = doc.getElementsByTag("dc:publisher").firstOrNull()
+        ?: doc.select("metadata > publisher").firstOrNull()
     val creator = doc.getElementsByTag("dc:creator").firstOrNull()
+        ?: doc.select("metadata > creator").firstOrNull()
     var description = doc.getElementsByTag("dc:description").firstOrNull()?.text()
     if (description.isNullOrBlank()) {
-        description = doc.select("dc\\:description").firstOrNull()?.text()
+        description = doc.select("dc\\:description, metadata > description").firstOrNull()?.text()
     }
     val normalizedDescription = normalizeHtmlDescription(description)
 
     val subjects = doc.getElementsByTag("dc:subject").map { it.text() }
     val mappedSubjects = if (subjects.isEmpty()) {
-        doc.select("dc\\:subject").map { it.text() }
+        doc.select("dc\\:subject, metadata > subject").map { it.text() }
     } else {
         subjects
     }
@@ -47,6 +52,7 @@ fun EpubReader.fillMetadata(manga: SManga, chapter: SChapter) {
     }
 
     var date = doc.getElementsByTag("dc:date").firstOrNull()
+        ?: doc.select("metadata > date").firstOrNull()
     if (date == null) {
         date = doc.select("meta[property=dcterms:modified]").firstOrNull()
     }


### PR DESCRIPTION
stripNamespacePrefixes stripped every element prefix, including the Dublin Core "dc:" prefix that fillMetadata queries by name (dc:title, dc:creator, ...). Normal EPUBs use dc: for all metadata, so after the strip getElementsByTag("dc:title") matched nothing, manga.title was never set, and the import preview crashed reading the uninitialized lateinit title ("lateinit property title has not been initialized").

Preserve dc: in stripNamespacePrefixes, add local-name metadata fallbacks in fillMetadata for EPUBs that auto-prefix dc (etree), and guard the title read in ParseEpubPreview so a genuinely title-less EPUB falls back to the file name instead of crashing.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
