### PR TITLE
feat(novel-webview): expose reader events and runtime state to JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Deprecate RefreshContext for 1.6 [@Rojikku](https://github.com/Rojikku) [#325](https://github.com/tsundoku-otaku/tsundoku/pull/325)
+- Exposed reader events and runtime state to JS [@mrissaoussama](https://github.com/mrissaoussama) [#350](https://github.com/tsundoku-otaku/tsundoku/pull/350)
 - jsplugins should surface fetch errors [@mrissaoussama](https://github.com/mrissaoussama) [#293](https://github.com/tsundoku-otaku/tsundoku/pull/293)
 - Improve extension repo URL format parsing [@mrissaoussama](https://github.com/mrissaoussama) [#316](https://github.com/tsundoku-otaku/tsundoku/pull/316)
 - Optimize bulk data clearing and chapter removal [@mrissaoussama](https://github.com/mrissaoussama) [#313](https://github.com/tsundoku-otaku/tsundoku/pull/313)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1207,6 +1207,7 @@ class ReaderActivity : BaseActivity() {
         } else if (readerPreferences.fullscreen.get()) {
             windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
         }
+        (viewModel.state.value.viewer as? NovelWebViewViewer)?.onMenuVisibilityChanged(visible)
     }
 
     private fun startBackgroundTtsIfEnabled() {
@@ -1505,6 +1506,7 @@ class ReaderActivity : BaseActivity() {
     private fun loadNextChapterInternal() {
         lifecycleScope.launch {
             viewModel.loadNextChapter()
+            (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("next")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
             val isNovelViewer = viewModel.state.value.viewer is NovelViewer ||
                 viewModel.state.value.viewer is NovelWebViewViewer
@@ -1523,6 +1525,7 @@ class ReaderActivity : BaseActivity() {
         stopNovelTtsForManualNav()
         lifecycleScope.launch {
             viewModel.loadPreviousChapter()
+            (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("prev")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
             val isNovelViewer = viewModel.state.value.viewer is NovelViewer ||
                 viewModel.state.value.viewer is NovelWebViewViewer

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -24,6 +24,16 @@ internal object NovelWebViewChapterMeta {
     const val TSUNDOKU_IS_INF_SCROLL_KEY = "isInfScroll"
     const val TSUNDOKU_TEXT_SELECTION_BLOCKED_KEY = "textSelectionBlocked"
     const val TSUNDOKU_FORCED_LOWERCASE_KEY = "forcedLowercase"
+    const val TSUNDOKU_MENU_VISIBLE_KEY = "menuVisible"
+    const val TSUNDOKU_IMMERSIVE_KEY = "immersive"
+    const val TSUNDOKU_TTS_STATE_KEY = "ttsState"
+    const val TSUNDOKU_LOADING_CHAPTER_KEY = "loadingChapter"
+
+    // Event names dispatched on `window` so plugins/snippets can subscribe with addEventListener.
+    const val EVENT_MENU_VISIBILITY = "tsundoku:menuvisibilitychange"
+    const val EVENT_CHAPTER_NAVIGATE = "tsundoku:chapternavigate"
+    const val EVENT_CHAPTER_LOADING = "tsundoku:chapterloading"
+    const val EVENT_TTS_STATE = "tsundoku:ttsstatechange"
 
     fun String.jsEscape(): String =
         this.replace("\\", "\\\\")
@@ -119,6 +129,10 @@ internal object NovelWebViewChapterMeta {
         val isInfiniteScroll: Boolean,
         val textSelectionBlocked: Boolean,
         val forcedLowercase: Boolean,
+        val menuVisible: Boolean = false,
+        val immersive: Boolean = false,
+        val ttsState: String = "stopped",
+        val loadingChapter: Boolean = false,
     )
 
     fun buildTsundokuScript(context: TsundokuScriptContext): String {
@@ -135,6 +149,10 @@ internal object NovelWebViewChapterMeta {
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_IS_INF_SCROLL_KEY = ${context.isInfiniteScroll};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_TEXT_SELECTION_BLOCKED_KEY = ${context.textSelectionBlocked};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_FORCED_LOWERCASE_KEY = ${context.forcedLowercase};
+            window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_MENU_VISIBLE_KEY = ${context.menuVisible};
+            window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_IMMERSIVE_KEY = ${context.immersive};
+            window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_TTS_STATE_KEY = ${quoteForJson(context.ttsState)};
+            window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_LOADING_CHAPTER_KEY = ${context.loadingChapter};
         """.trimIndent()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -647,6 +647,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                         isLoadingRealChapter = false
                         // Real content rendered; TTS may now read the body.
                         webChapterContentReady = true
+                        dispatchLoadingChapter(false)
                         if (pendingTtsAutoStartOnLoad) {
                             pendingTtsAutoStartOnLoad = false
                             startTts()
@@ -1223,8 +1224,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             })();
         """.trimIndent()
 
+        dispatchLoadingChapter(true)
         evaluateJavascriptSafe(js) {
             styler.injectScript { buildTsundokuScript() }
+            dispatchLoadingChapter(false)
         }
 
         // A chapter was appended, so the end-of-novel verdict is stale.
@@ -1271,6 +1274,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // the loading-indicator page (which also fires onPageFinished with url="about:blank").
         isLoadingRealChapter = true
         webChapterContentReady = false
+        dispatchLoadingChapter(true)
         // New document: hold scroll callbacks and clear the baseline so a stale flush can't write
         // the previous chapter's percent here, restoreScrollPosition seeds the real value.
         isRestoringScroll = true
@@ -1299,6 +1303,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             isInfiniteScroll = preferences.novelInfiniteScroll.get(),
             textSelectionBlocked = !preferences.novelTextSelectable.get(),
             forcedLowercase = preferences.novelForceTextLowercase.get(),
+            menuVisible = activity.viewModel.state.value.menuVisible,
+            immersive = !activity.viewModel.state.value.menuVisible,
+            ttsState = currentTtsState(),
+            loadingChapter = !webChapterContentReady,
         )
         return NovelWebViewChapterMeta.buildTsundokuScript(context)
     }
@@ -1309,6 +1317,64 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private fun updateChapterMetaJs() {
         val js = buildTsundokuScript()
         evaluateJavascriptSafe("(function(){$js})();", null)
+    }
+
+    private fun currentTtsState(): String = when {
+        ttsController.isPaused() -> "paused"
+        ttsController.isTtsAutoPlay || ttsController.isSpeaking() || ttsController.isStarting() -> "playing"
+        else -> "stopped"
+    }
+
+    // Updates the runtime state via [assignments] (JS statements against `t.runtime`) and fires a
+    // CustomEvent on `window` so novel-source plugins and user snippets can react. See the EVENT_*
+    // and *_KEY constants in NovelWebViewChapterMeta. No-ops safely when the WebView isn't ready.
+    private fun dispatchTsundokuEvent(eventName: String, assignments: String, detailJson: String) {
+        val obj = NovelWebViewChapterMeta.TSUNDOKU_OBJECT_NAME
+        evaluateJavascriptSafe(
+            """
+            (function(){
+              var t = window.$obj = window.$obj || {};
+              t.runtime = t.runtime || {};
+              $assignments
+              try { window.dispatchEvent(new CustomEvent('$eventName', { detail: $detailJson })); } catch (e) {}
+            })();
+            """.trimIndent(),
+            null,
+        )
+    }
+
+    fun onMenuVisibilityChanged(visible: Boolean) {
+        dispatchTsundokuEvent(
+            NovelWebViewChapterMeta.EVENT_MENU_VISIBILITY,
+            "t.runtime.${NovelWebViewChapterMeta.TSUNDOKU_MENU_VISIBLE_KEY} = $visible; " +
+                "t.runtime.${NovelWebViewChapterMeta.TSUNDOKU_IMMERSIVE_KEY} = ${!visible};",
+            "{ menuVisible: $visible, immersive: ${!visible} }",
+        )
+    }
+
+    fun onChapterNavigate(direction: String) {
+        dispatchTsundokuEvent(
+            NovelWebViewChapterMeta.EVENT_CHAPTER_NAVIGATE,
+            "",
+            "{ direction: '$direction' }",
+        )
+    }
+
+    private fun dispatchLoadingChapter(loading: Boolean) {
+        dispatchTsundokuEvent(
+            NovelWebViewChapterMeta.EVENT_CHAPTER_LOADING,
+            "t.runtime.${NovelWebViewChapterMeta.TSUNDOKU_LOADING_CHAPTER_KEY} = $loading;",
+            "{ loading: $loading }",
+        )
+    }
+
+    private fun dispatchTtsState() {
+        val state = currentTtsState()
+        dispatchTsundokuEvent(
+            NovelWebViewChapterMeta.EVENT_TTS_STATE,
+            "t.runtime.${NovelWebViewChapterMeta.TSUNDOKU_TTS_STATE_KEY} = '$state';",
+            "{ state: '$state' }",
+        )
     }
 
     private fun showLoadingIndicator(message: String = "Loading...") {
@@ -2149,6 +2215,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
+        dispatchTtsState()
         if (!webChapterContentReady) {
             // Loading indicator still up; reading the body now would speak the placeholder
             // and auto-advance. Defer; onPageFinished starts TTS once content is rendered.
@@ -2187,6 +2254,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         isLoadingRealChapter = false
         ttsController.stop()
         handoffState = TtsHandoffState.Idle
+        dispatchTtsState()
     }
 
     fun pauseTts() {
@@ -2194,10 +2262,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             "TTS (WebView): pauseTts called ts=${System.currentTimeMillis()} currentChapterIndex=$currentChapterIndex, ttsCurrentChunkIndex=${ttsController.ttsCurrentChunkIndex}, ttsResumeChunkIndex=${ttsController.ttsResumeChunkIndex}, ttsPlaybackChapterIndex=${ttsController.ttsPlaybackChapterIndex}, ttsPlaybackChapterId=${ttsController.ttsPlaybackChapterId}"
         }
         ttsController.pause()
+        dispatchTtsState()
     }
 
     fun resumeTts() {
         ttsController.resume()
+        dispatchTtsState()
     }
 
     fun ttsNextParagraph() {
@@ -2249,6 +2319,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         ttsController.pendingStartRequest = null
         ttsController.isTtsAutoPlay = true
+        dispatchTtsState()
         if (!webChapterContentReady) {
             // Still loading; defer so onPageFinished re-runs the viewport start once content is in.
             ttsController.pendingStartRequest = TtsController.StartRequest.VIEWPORT

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
@@ -200,6 +200,33 @@ class NovelWebViewChapterMetaTest {
         assertTrue(script.contains(".isInfScroll"))
         assertTrue(script.contains(".textSelectionBlocked"))
         assertTrue(script.contains(".forcedLowercase"))
+        assertTrue(script.contains(".menuVisible"))
+        assertTrue(script.contains(".immersive"))
+        assertTrue(script.contains(".ttsState"))
+        assertTrue(script.contains(".loadingChapter"))
+    }
+
+    @Test
+    fun `buildTsundokuScript seeds the new runtime state`() {
+        val script = NovelWebViewChapterMeta.buildTsundokuScript(
+            NovelWebViewChapterMeta.TsundokuScriptContext(
+                novelUrl = null,
+                currentChapter = null,
+                chaptersInOrder = emptyList(),
+                isEditingMode = false,
+                isInfiniteScroll = false,
+                textSelectionBlocked = false,
+                forcedLowercase = false,
+                menuVisible = true,
+                immersive = false,
+                ttsState = "playing",
+                loadingChapter = true,
+            ),
+        )
+        assertTrue(script.contains(".menuVisible = true"))
+        assertTrue(script.contains(".immersive = false"))
+        assertTrue(script.contains(".ttsState = \"playing\""))
+        assertTrue(script.contains(".loadingChapter = true"))
     }
 
     @Test


### PR DESCRIPTION
Add runtime state and window CustomEvents so novel-source plugins and user snippets can react to reader activity in the WebView viewer:

- window.Tsundoku.runtime.menuVisible / .immersive, event tsundoku:menuvisibilitychange
- event tsundoku:chapternavigate with detail.direction ('next' | 'prev')
- window.Tsundoku.runtime.loadingChapter, event tsundoku:chapterloading
- window.Tsundoku.runtime.ttsState ('stopped' | 'playing' | 'paused'), event tsundoku:ttsstatechange
