### PR TITLE
perf: move async component init to App after module import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Guard download cache serialization [@mrissaoussama](https://github.com/mrissaoussama) [#346](https://github.com/tsundoku-otaku/tsundoku/pull/346)
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
+- Fix for an Injekt related exception tied to performance improvements, should keep performance [@mrissaoussama](https://github.com/mrissaoussama) [#352](https://github.com/tsundoku-otaku/tsundoku/pull/352)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Volume keys no longer scroll while menu visible [@mrissaoussama](https://github.com/mrissaoussama) [#345](https://github.com/tsundoku-otaku/tsundoku/pull/345)

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -36,6 +36,7 @@ import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverKeyer
 import eu.kanade.tachiyomi.data.coil.MangaKeyer
 import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
+import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.di.AppModule
 import eu.kanade.tachiyomi.di.PreferenceModule
@@ -48,6 +49,7 @@ import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.animatorDurationScale
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notify
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -60,8 +62,11 @@ import org.conscrypt.Conscrypt
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.Database
+import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.widget.WidgetManager
 import tsundoku.telemetry.TelemetryConfig
@@ -117,6 +122,18 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(PreferenceModule(this))
         Injekt.importModule(AppModule(this))
         Injekt.importModule(DomainModule())
+
+        // Asynchronously init expensive components for a faster cold start. Must run after all
+        // modules are imported
+        Injekt.get<CoroutineScope>().launchIO {
+            Injekt.get<NetworkHelper>()
+
+            Injekt.get<SourceManager>()
+
+            Injekt.get<Database>()
+
+            Injekt.get<DownloadManager>()
+        }
 
         setupNotificationChannels()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -39,7 +39,6 @@ import nl.adaptivity.xmlutil.XmlDeclMode
 import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import tachiyomi.core.common.storage.AndroidStorageFolderProvider
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.data.AlternativeTitlesColumnAdapter
 import tachiyomi.data.Chapters
 import tachiyomi.data.Database
@@ -176,18 +175,5 @@ class AppModule(val app: Application) : InjektModule {
 
         // Font management
         addSingletonFactory { eu.kanade.tachiyomi.data.font.FontManager(app, get(), get()) }
-
-        // Asynchronously init expensive components for a faster cold start. Must run off the main
-        // thread: getMainExecutor() posts back to main, so constructing SourceManager/Database/
-        // DownloadManager there stalled startup (frozen splash, SystemJobService bind timeouts).
-        get<CoroutineScope>().launchIO {
-            get<NetworkHelper>()
-
-            get<SourceManager>()
-
-            get<Database>()
-
-            get<DownloadManager>()
-        }
     }
 }


### PR DESCRIPTION
Move the eager off-main-thread warmup of NetworkHelper, SourceManager, Database and DownloadManager out of AppModule into App.onCreate, running it only after all Injekt modules are imported. This lets eager singletons that resolve cross-module dependencies (e.g. ExtensionManager -> TrustExtension) construct correctly, while still keeping the expensive initialization off the main thread for a faster cold start.
should hopefully fix that exception
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
