### PR TITLE
fix(custom-source): editor fields for the paged urls, and stop dropping the card link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Volume keys no longer scroll while menu visible [@mrissaoussama](https://github.com/mrissaoussama) [#345](https://github.com/tsundoku-otaku/tsundoku/pull/345)
+- Custom source: Edit paged urls, keep card link [@mrissaoussama](https://github.com/mrissaoussama) [#356](https://github.com/tsundoku-otaku/tsundoku/pull/356)
 - Pull to refresh spinner will be more patient [@mrissaoussama](https://github.com/mrissaoussama) [#321](https://github.com/tsundoku-otaku/tsundoku/pull/321)
 - Improve massimport - Notification dedupe,v erious fixes [@mrissaoussama](https://github.com/mrissaoussama) [#333](https://github.com/tsundoku-otaku/tsundoku/pull/333)
 - Deleage custom-source image fetch to base httpsource [@mrissaoussama](https://github.com/mrissaoussama) [#331](https://github.com/tsundoku-otaku/tsundoku/pull/331)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -324,6 +324,10 @@ internal fun buildPagedUrlTemplate(template: String, baseUrl: String, page: Int)
         .trimEnd('/', '?', '&')
 }
 
+// A page-2+ template without {page} builds the same url for every page, so treating it as pageable
+// would make browse re-request page 1 until it hits the end of the list it never reaches.
+internal fun String?.isPageTemplate(): Boolean = this?.contains("{page}") == true
+
 internal fun buildPagedSearchUrlTemplate(template: String, baseUrl: String, query: String, page: Int): String {
     return template
         .replace("{baseUrl}", baseUrl)
@@ -764,7 +768,7 @@ class CustomNovelSource(
 
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
-        val pageable = config.popularPagedUrl != null || config.popularUrl.contains("{page}")
+        val pageable = config.popularPagedUrl.isPageTemplate() || config.popularUrl.contains("{page}")
         return parseMangaList(document, config.selectors.popular, pageable)
     }
 
@@ -778,7 +782,7 @@ class CustomNovelSource(
 
     override fun latestUpdatesParse(response: Response): MangasPage {
         val document = response.asJsoup()
-        val pageable = config.latestPagedUrl != null || config.popularPagedUrl != null ||
+        val pageable = config.latestPagedUrl.isPageTemplate() || config.popularPagedUrl.isPageTemplate() ||
             (config.latestUrl ?: config.popularUrl).contains("{page}")
         return parseMangaList(document, config.selectors.latest ?: config.selectors.popular, pageable)
     }
@@ -801,7 +805,7 @@ class CustomNovelSource(
 
     override fun searchMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
-        val pageable = config.searchPagedUrl != null || config.searchUrl.contains("{page}")
+        val pageable = config.searchPagedUrl.isPageTemplate() || config.searchUrl.contains("{page}")
         return parseMangaList(document, config.selectors.search ?: config.selectors.popular, pageable)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -987,6 +987,9 @@ class CustomSourceEditorScreen(
         var searchNextPageSelector by remember {
             mutableStateOf(initialConfig?.selectors?.search?.nextPage ?: "")
         }
+        var popularPagedUrl by remember { mutableStateOf(initialConfig?.popularPagedUrl ?: "") }
+        var latestPagedUrl by remember { mutableStateOf(initialConfig?.latestPagedUrl ?: "") }
+        var searchPagedUrl by remember { mutableStateOf(initialConfig?.searchPagedUrl ?: "") }
         var detailsTitleSelector by remember {
             mutableStateOf(initialConfig?.selectors?.details?.title ?: "")
         }
@@ -1033,6 +1036,9 @@ class CustomSourceEditorScreen(
         }
         var chapterIndexLinkSelector by remember {
             mutableStateOf(initialConfig?.selectors?.chapters?.indexLinkSelector ?: "")
+        }
+        var chapterPagedUrlPattern by remember {
+            mutableStateOf(initialConfig?.selectors?.chapters?.pagedUrlPattern ?: "")
         }
         var chapterUrlPattern by remember {
             mutableStateOf(initialConfig?.selectors?.chapters?.urlPattern ?: "")
@@ -1479,6 +1485,17 @@ class CustomSourceEditorScreen(
                             modifier = Modifier.fillMaxWidth(),
                             placeholder = { Text(stringResource(TDMR.strings.custom_source_pagination_selector_hint)) },
                         )
+                        OutlinedTextField(
+                            value = popularPagedUrl,
+                            onValueChange = { popularPagedUrl = it },
+                            label = { Text(stringResource(TDMR.strings.custom_source_paged_url_popular)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            placeholder = { Text(stringResource(TDMR.strings.custom_source_paged_url_hint)) },
+                            supportingText = {
+                                Text(stringResource(TDMR.strings.custom_source_paged_url_summary))
+                            },
+                        )
                     }
                     if (features.hasLatest && features.latestPagination) {
                         OutlinedTextField(
@@ -1495,6 +1512,17 @@ class CustomSourceEditorScreen(
                             modifier = Modifier.fillMaxWidth(),
                             placeholder = { Text(stringResource(TDMR.strings.custom_source_pagination_selector_hint)) },
                         )
+                        OutlinedTextField(
+                            value = latestPagedUrl,
+                            onValueChange = { latestPagedUrl = it },
+                            label = { Text(stringResource(TDMR.strings.custom_source_paged_url_latest)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            placeholder = { Text(stringResource(TDMR.strings.custom_source_paged_url_hint)) },
+                            supportingText = {
+                                Text(stringResource(TDMR.strings.custom_source_paged_url_summary))
+                            },
+                        )
                     }
                     if (features.hasSearch && features.searchPagination) {
                         OutlinedTextField(
@@ -1510,6 +1538,17 @@ class CustomSourceEditorScreen(
                             },
                             modifier = Modifier.fillMaxWidth(),
                             placeholder = { Text(stringResource(TDMR.strings.custom_source_pagination_selector_hint)) },
+                        )
+                        OutlinedTextField(
+                            value = searchPagedUrl,
+                            onValueChange = { searchPagedUrl = it },
+                            label = { Text(stringResource(TDMR.strings.custom_source_paged_url_search)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            placeholder = { Text(stringResource(TDMR.strings.custom_source_paged_url_search_hint)) },
+                            supportingText = {
+                                Text(stringResource(TDMR.strings.custom_source_paged_url_search_summary))
+                            },
                         )
                     }
 
@@ -1743,6 +1782,19 @@ class CustomSourceEditorScreen(
                                 },
                                 modifier = Modifier.fillMaxWidth(),
                             )
+                            OutlinedTextField(
+                                value = chapterPagedUrlPattern,
+                                onValueChange = { chapterPagedUrlPattern = it },
+                                label = {
+                                    Text(stringResource(TDMR.strings.custom_source_chapter_paged_url))
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                placeholder = { Text("{novelUrl}?page={page}") },
+                                supportingText = {
+                                    Text(stringResource(TDMR.strings.custom_source_chapter_paged_url_summary))
+                                },
+                            )
                         }
                         if (features.chapterListSeparatePage) {
                             OutlinedTextField(
@@ -1858,12 +1910,31 @@ class CustomSourceEditorScreen(
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
+                val missingPageError = stringResource(TDMR.strings.custom_source_paged_url_needs_page)
+                val missingQueryError = stringResource(TDMR.strings.custom_source_paged_url_search_needs_query)
                 @Suppress("ktlint:standard:max-line-length")
                 Button(
                     onClick = {
                         scope.launch {
                             isSaving = true
                             errorMessage = null
+
+                            val pageTemplates = listOf(
+                                popularPagedUrl,
+                                latestPagedUrl,
+                                searchPagedUrl,
+                                chapterPagedUrlPattern,
+                            )
+                            if (pageTemplates.any { it.isNotBlank() && !it.contains("{page}") }) {
+                                errorMessage = missingPageError
+                                isSaving = false
+                                return@launch
+                            }
+                            if (searchPagedUrl.isNotBlank() && !searchPagedUrl.contains("{query}")) {
+                                errorMessage = missingQueryError
+                                isSaving = false
+                                return@launch
+                            }
 
                             val config = buildConfig(
                                 existing = initialConfig,
@@ -1875,6 +1946,9 @@ class CustomSourceEditorScreen(
                                 popularNextPageSelector = popularNextPageSelector,
                                 latestNextPageSelector = latestNextPageSelector,
                                 searchNextPageSelector = searchNextPageSelector,
+                                popularPagedUrl = popularPagedUrl,
+                                latestPagedUrl = latestPagedUrl,
+                                searchPagedUrl = searchPagedUrl,
                                 detailsTitleSelector = detailsTitleSelector,
                                 detailsDescriptionSelector = detailsDescriptionSelector,
                                 detailsCoverSelector = detailsCoverSelector,
@@ -1888,6 +1962,7 @@ class CustomSourceEditorScreen(
                                 chapterNameSelector = chapterNameSelector,
                                 chapterDateSelector = chapterDateSelector,
                                 chapterNextPageSelector = chapterNextPageSelector,
+                                chapterPagedUrlPattern = chapterPagedUrlPattern,
                                 chapterIndexLinkSelector = chapterIndexLinkSelector,
                                 chapterUrlPattern = chapterUrlPattern,
                                 chapterCountSelector = chapterCountSelector,
@@ -2019,6 +2094,9 @@ class CustomSourceEditorScreen(
         popularNextPageSelector: String,
         latestNextPageSelector: String,
         searchNextPageSelector: String,
+        popularPagedUrl: String,
+        latestPagedUrl: String,
+        searchPagedUrl: String,
         detailsTitleSelector: String,
         detailsDescriptionSelector: String,
         detailsCoverSelector: String,
@@ -2032,6 +2110,7 @@ class CustomSourceEditorScreen(
         chapterNameSelector: String,
         chapterDateSelector: String,
         chapterNextPageSelector: String,
+        chapterPagedUrlPattern: String,
         chapterIndexLinkSelector: String,
         chapterUrlPattern: String,
         chapterCountSelector: String,
@@ -2059,9 +2138,13 @@ class CustomSourceEditorScreen(
         val cardTitle = popularTitleSelector.ifBlank { null }
         val cardCover = popularCoverSelector.ifBlank { null }
         val generate = features.chapterGenerateFromPattern
+        // No dedicated link input: keep the one the config already has (wizard-picked or imported),
+        // and fall back to the title selector the way the wizard does for a fresh source.
+        val cardLink = existing?.selectors?.popular?.link ?: cardTitle
         val selectors = eu.kanade.tachiyomi.source.custom.SourceSelectors(
             popular = eu.kanade.tachiyomi.source.custom.MangaListSelectors(
                 list = if (features.hasPopular) popularListSelector else "",
+                link = if (features.hasPopular) cardLink else null,
                 title = if (features.hasPopular) cardTitle else null,
                 cover = if (features.hasPopular) cardCover else null,
                 nextPage = if (features.hasPopular && features.popularPagination) {
@@ -2073,6 +2156,7 @@ class CustomSourceEditorScreen(
             latest = if (features.hasLatest) {
                 eu.kanade.tachiyomi.source.custom.MangaListSelectors(
                     list = popularListSelector,
+                    link = existing?.selectors?.latest?.link ?: cardLink,
                     title = cardTitle,
                     cover = cardCover,
                     nextPage = if (features.latestPagination) latestNextPageSelector.ifBlank { null } else null,
@@ -2083,6 +2167,7 @@ class CustomSourceEditorScreen(
             search = if (features.hasSearch) {
                 eu.kanade.tachiyomi.source.custom.MangaListSelectors(
                     list = popularListSelector,
+                    link = existing?.selectors?.search?.link ?: cardLink,
                     title = cardTitle,
                     cover = cardCover,
                     nextPage = if (features.searchPagination) searchNextPageSelector.ifBlank { null } else null,
@@ -2109,10 +2194,8 @@ class CustomSourceEditorScreen(
                 } else {
                     null
                 },
-                // No dedicated input; preserve the wizard-derived numbered-pagination template only
-                // while chapter-list pagination stays enabled.
                 pagedUrlPattern = if (!generate && features.chapterListPagination) {
-                    existing?.selectors?.chapters?.pagedUrlPattern
+                    chapterPagedUrlPattern.ifBlank { null }
                 } else {
                     null
                 },
@@ -2153,11 +2236,21 @@ class CustomSourceEditorScreen(
             popularUrl = if (features.hasPopular) popularUrl else "",
             latestUrl = if (features.hasLatest) latestUrl.ifBlank { null } else null,
             searchUrl = if (features.hasSearch) searchUrl else "",
-            // Per-section paged URLs are wizard-derived (no field here); keep them only while the
-            // matching section + pagination toggle are both on.
-            popularPagedUrl = if (features.hasPopular && features.popularPagination) base.popularPagedUrl else null,
-            latestPagedUrl = if (features.hasLatest && features.latestPagination) base.latestPagedUrl else null,
-            searchPagedUrl = if (features.hasSearch && features.searchPagination) base.searchPagedUrl else null,
+            popularPagedUrl = if (features.hasPopular && features.popularPagination) {
+                popularPagedUrl.ifBlank { null }
+            } else {
+                null
+            },
+            latestPagedUrl = if (features.hasLatest && features.latestPagination) {
+                latestPagedUrl.ifBlank { null }
+            } else {
+                null
+            },
+            searchPagedUrl = if (features.hasSearch && features.searchPagination) {
+                searchPagedUrl.ifBlank { null }
+            } else {
+                null
+            },
             statusMapping = parseStatusMapping(statusMappingText),
             dateFormat = dateFormat.ifBlank { null },
             headers = parseHeaders(headersText),

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -652,6 +652,17 @@
     <string name="custom_source_chapter_name_selector">Chapter name selector</string>
     <string name="custom_source_chapter_date_selector">Chapter date selector</string>
     <string name="custom_source_chapter_pagination_selector">Chapter list pagination selector</string>
+    <string name="custom_source_paged_url_popular">Popular page 2+ URL</string>
+    <string name="custom_source_paged_url_latest">Latest page 2+ URL</string>
+    <string name="custom_source_paged_url_search">Search page 2+ URL</string>
+    <string name="custom_source_paged_url_hint">https://example.com/page/{page}</string>
+    <string name="custom_source_paged_url_summary">Optional, must contain {page}. For sites where page 2 onwards uses a different URL than page 1. Leave empty to follow the pagination selector instead.</string>
+    <string name="custom_source_paged_url_search_hint">https://example.com/?s={query}&amp;page={page}</string>
+    <string name="custom_source_paged_url_search_summary">Optional, must contain {page} and {query}. For sites where page 2 onwards uses a different URL than page 1. Leave empty to follow the pagination selector instead.</string>
+    <string name="custom_source_paged_url_needs_page">Page URL templates must contain {page}</string>
+    <string name="custom_source_paged_url_search_needs_query">The search page 2+ URL must contain {query}</string>
+    <string name="custom_source_chapter_paged_url">Chapter list page URL</string>
+    <string name="custom_source_chapter_paged_url_summary">Optional, use {novelUrl} and {page}. Preferred over the pagination selector when the site numbers its chapter pages.</string>
     <string name="custom_source_chapter_index_selector">Chapter list link selector (separate page)</string>
     <string name="custom_source_chapter_url_pattern">Chapter URL pattern (use {n})</string>
     <string name="custom_source_chapter_count_selector">Chapter count selector (total)</string>


### PR DESCRIPTION
exposed these fields
  popularPagination   <- popular.nextPage | popularPagedUrl
  latestPagination    <- latest.nextPage  | latestPagedUrl
  searchPagination    <- search.nextPage  | searchPagedUrl
  chapterListPagination <- chapters.nextPage | chapters.pagedUrlPattern
