### PR TITLE
refresh entry categories and the updates tab, better batch dl delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Reader Lifecycle and UX fixes [@mrissaoussama](https://github.com/mrissaoussama) [#338](https://github.com/tsundoku-otaku/tsundoku/pull/338)
+- Better batch dl delete, refresh entry categories and updates tab [@mrissaoussama](https://github.com/mrissaoussama) [#358](https://github.com/tsundoku-otaku/tsundoku/pull/358)
 - Custom Source Overhaul [@mrissaoussama](https://github.com/mrissaoussama) [#273](https://github.com/tsundoku-otaku/tsundoku/pull/273)
 - Translations and quotes more organized/portable [@mrissaoussama](https://github.com/mrissaoussama) [#336](https://github.com/tsundoku-otaku/tsundoku/pull/336)
 - A ton of Arabic translations [@OtakuArab](https://github.com/OtakuArab) [#327](https://github.com/tsundoku-otaku/tsundoku/pull/327)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -301,11 +301,21 @@ class DownloadCache(
      * @param manga the manga to remove.
      */
     suspend fun removeManga(manga: Manga) {
+        removeMangas(listOf(manga))
+    }
+
+    /**
+     * Removes several deleted manga from this cache, notifying observers once for the batch
+     */
+    suspend fun removeMangas(mangas: List<Manga>) {
+        if (mangas.isEmpty()) return
         rootDownloadsDirMutex.withLock {
-            val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return
-            val mangaDirName = provider.getMangaDirName(manga.title)
-            if (sourceDir.mangaDirs.containsKey(mangaDirName)) {
-                sourceDir.mangaDirs -= mangaDirName
+            mangas.forEach { manga ->
+                val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return@forEach
+                val mangaDirName = provider.getMangaDirName(manga.title)
+                if (sourceDir.mangaDirs.containsKey(mangaDirName)) {
+                    sourceDir.mangaDirs -= mangaDirName
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -330,18 +330,42 @@ class DownloadManager(
      */
     fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
         launchIO {
-            if (removeQueued) {
-                downloader.removeFromQueue(manga)
-            }
-            provider.findMangaDir(manga.title, source)?.delete()
-            cache.removeManga(manga)
+            deleteMangas(listOf(manga), source, removeQueued)
+        }
+    }
 
-            // Delete source directory if empty
-            val sourceDir = provider.findSourceDir(source)
-            if (sourceDir?.listFiles()?.isEmpty() == true) {
-                sourceDir.delete()
-                cache.removeSource(source)
+    /**
+     * Deletes the directories of several downloaded manga from the same source. Manga belonging to
+     * another source are ignored.
+     */
+    suspend fun deleteMangas(mangas: List<Manga>, source: Source, removeQueued: Boolean = true) {
+        val (fromSource, otherSources) = mangas.partition { it.source == source.id }
+        if (otherSources.isNotEmpty()) {
+            logcat(LogPriority.ERROR) {
+                "Skipped ${otherSources.size} manga not belonging to source ${source.id}"
             }
+        }
+        if (fromSource.isEmpty()) return
+        if (removeQueued) {
+            downloader.removeMangasFromQueue(fromSource)
+        }
+        val sourceDir = provider.findSourceDir(source)
+        val dirsByName = sourceDir?.listFiles().orEmpty()
+            .mapNotNull { file -> file.name?.let { it to file } }
+            .toMap()
+        val deleted = fromSource.filter { manga ->
+            try {
+                dirsByName[provider.getMangaDirName(manga.title)]?.delete()
+                true
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to delete download folder for ${manga.title}" }
+                false
+            }
+        }
+        cache.removeMangas(deleted)
+        if (sourceDir?.listFiles()?.isEmpty() == true) {
+            sourceDir.delete()
+            cache.removeSource(source)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -1028,6 +1028,11 @@ class Downloader(
         removeFromQueueIf { it.mangaId == manga.id }
     }
 
+    fun removeMangasFromQueue(mangas: List<Manga>) {
+        val mangaIds = mangas.mapTo(HashSet()) { it.id }
+        removeFromQueueIf { it.mangaId in mangaIds }
+    }
+
     private fun internalClearQueue() {
         _queueState.update {
             it.forEach { download ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1028,12 +1028,7 @@ class LibraryScreenModel(
             }
 
             if (deleteChapters) {
-                mangas.forEach { manga ->
-                    val source = sourceManager.get(manga.source) as? HttpSource
-                    if (source != null) {
-                        downloadManager.deleteManga(manga, source)
-                    }
-                }
+                deleteDownloadsBySource(mangas)
             }
 
             if (deleteTranslations) {
@@ -1058,6 +1053,13 @@ class LibraryScreenModel(
             if (!deleteFromLibrary && (deleteChapters || deleteTranslations)) {
                 getLibraryManga.notifyChanged()
             }
+        }
+    }
+
+    private suspend fun deleteDownloadsBySource(mangas: List<Manga>) {
+        mangas.groupBy { it.source }.forEach { (sourceId, sourceMangas) ->
+            val source = sourceManager.get(sourceId) as? HttpSource ?: return@forEach
+            downloadManager.deleteMangas(sourceMangas, source)
         }
     }
 
@@ -1092,10 +1094,7 @@ class LibraryScreenModel(
                 }
 
                 if (deleteChapters) {
-                    mangas.forEach { manga ->
-                        val source = sourceManager.get(manga.source) as? HttpSource ?: return@forEach
-                        downloadManager.deleteManga(manga, source)
-                    }
+                    deleteDownloadsBySource(mangas)
                 }
 
                 if (deleteTranslations) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -240,6 +240,15 @@ class MangaScreenModel(
                 }
         }
 
+        screenModelScope.launchIO {
+            getCategories.subscribe(mangaId)
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { categories ->
+                    updateSuccessState { it.copy(categories = categories) }
+                }
+        }
+
         observeDownloads()
 
         screenModelScope.launchIO {
@@ -247,6 +256,7 @@ class MangaScreenModel(
             val chaptersDeferred = async { getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true) }
             val availableScanlatorsDeferred = async { getAvailableScanlators.await(mangaId) }
             val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
+            val categoriesDeferred = async { getCategories.await(mangaId) }
 
             val manga = mangaDeferred.await()
             val chapters = chaptersDeferred.await()
@@ -270,6 +280,9 @@ class MangaScreenModel(
                     chapters = chapterListItems,
                     availableScanlators = availableScanlatorsDeferred.await(),
                     excludedScanlators = excludedScanlatorsDeferred.await(),
+                    // Read here as well as subscribed: the subscription's first emission lands
+                    // before this state exists, and updateSuccessState drops it.
+                    categories = categoriesDeferred.await(),
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters.get(),
@@ -292,12 +305,6 @@ class MangaScreenModel(
 
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
-
-            // Load categories if in library (similarNovels loaded on demand when dialog is shown)
-            if (manga.favorite) {
-                val categories = getCategories.await(manga.id)
-                updateSuccessState { it.copy(categories = categories) }
-            }
         }
     }
 


### PR DESCRIPTION

Manga screen now shows applied categories without having to revisit the screen.
Made batch novel delete downloaded chapters faster.
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
