### PR TITLE
fix(sources): consistent JS/custom tagging, duplicate-check toggle, migrate direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Guard download cache serialization [@mrissaoussama](https://github.com/mrissaoussama) [#346](https://github.com/tsundoku-otaku/tsundoku/pull/346)
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
+- Consistent JS/custom tagging, fixed duplicate check, add options in library settings [@mrissaoussama](https://github.com/mrissaoussama) [#359](https://github.com/tsundoku-otaku/tsundoku/pull/359)
 - Fix for an Injekt related exception tied to performance improvements, should keep performance [@mrissaoussama](https://github.com/mrissaoussama) [#352](https://github.com/tsundoku-otaku/tsundoku/pull/352)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -131,7 +131,7 @@ class DomainModule : InjektModule {
         addFactory { DeleteCategory(get(), get(), get()) }
 
         addSingletonFactory<MangaRepository> { MangaRepositoryImpl(get()) }
-        addFactory { GetDuplicateLibraryManga(get()) }
+        addFactory { GetDuplicateLibraryManga(get(), get()) }
         addFactory { FindDuplicateNovels(get()) }
         addFactory { SearchMangaMetadata(get()) }
         addFactory { GetFavorites(get()) }

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -43,12 +43,12 @@ class SourcePreferences(
 
     val migrationSortingMode: Preference<SetMigrateSorting.Mode> = preferenceStore.getEnum(
         "pref_migration_sorting",
-        SetMigrateSorting.Mode.ALPHABETICAL,
+        SetMigrateSorting.Mode.TOTAL,
     )
 
     val migrationSortingDirection: Preference<SetMigrateSorting.Direction> = preferenceStore.getEnum(
         "pref_migration_direction",
-        SetMigrateSorting.Direction.ASCENDING,
+        SetMigrateSorting.Direction.DESCENDING,
     )
 
     val hideInLibraryItems: Preference<Boolean> = preferenceStore.getBoolean("browse_hide_in_library_items", false)

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -43,12 +43,12 @@ class SourcePreferences(
 
     val migrationSortingMode: Preference<SetMigrateSorting.Mode> = preferenceStore.getEnum(
         "pref_migration_sorting",
-        SetMigrateSorting.Mode.TOTAL,
+        SetMigrateSorting.Mode.ALPHABETICAL,
     )
 
     val migrationSortingDirection: Preference<SetMigrateSorting.Direction> = preferenceStore.getEnum(
         "pref_migration_direction",
-        SetMigrateSorting.Direction.DESCENDING,
+        SetMigrateSorting.Direction.ASCENDING,
     )
 
     val hideInLibraryItems: Preference<Boolean> = preferenceStore.getBoolean("browse_hide_in_library_items", false)

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -11,6 +11,7 @@ import eu.kanade.presentation.browse.components.GlobalSearchLoadingResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchToolbar
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchItemResult
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
@@ -75,10 +76,9 @@ internal fun GlobalSearchContent(
     ) {
         items.forEach { (source, result) ->
             item(key = source.id) {
+                val name = source.nameWithTypeTag()
                 GlobalSearchResultItem(
-                    title = fromSourceId?.let {
-                        "▶ ${source.name}".takeIf { source.id == fromSourceId }
-                    } ?: source.name,
+                    title = fromSourceId?.let { "▶ $name".takeIf { source.id == fromSourceId } } ?: name,
                     subtitle = LocaleHelper.getLocalizedDisplayName(source.lang),
                     onClick = { onClickSource(source) },
                     modifier = Modifier.animateItem(),

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSourceScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowUpward
@@ -18,22 +17,17 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import eu.kanade.domain.source.interactor.SetMigrateSorting
 import eu.kanade.presentation.browse.components.BaseSourceItem
 import eu.kanade.presentation.browse.components.SourceIcon
-import eu.kanade.tachiyomi.jsplugin.source.JsSource
+import eu.kanade.presentation.browse.components.SourceTypeBadge
 import eu.kanade.tachiyomi.ui.browse.migration.sources.MigrateSourceScreenModel
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import tachiyomi.domain.source.model.Source
-import tachiyomi.domain.source.model.StubSource
-import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.Badge
 import tachiyomi.presentation.core.components.BadgeGroup
@@ -47,8 +41,6 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.presentation.core.theme.header
 import tachiyomi.presentation.core.util.plus
 import tachiyomi.presentation.core.util.secondaryItemAlpha
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 @Composable
 fun MigrateSourceScreen(
@@ -172,10 +164,6 @@ private fun MigrateSourceItem(
             }
         },
         content = { _, sourceLangString ->
-            val isJsSource = remember(source.id) {
-                val resolved = Injekt.get<SourceManager>().get(source.id)
-                resolved is JsSource || (resolved is StubSource && resolved.name.contains("(JS)"))
-            }
             Column(
                 modifier = Modifier
                     .padding(horizontal = MaterialTheme.padding.medium)
@@ -191,21 +179,7 @@ private fun MigrateSourceItem(
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.weight(1f, fill = false),
                     )
-                    if (isJsSource) {
-                        Text(
-                            text = "JS",
-                            modifier = Modifier
-                                .padding(start = 4.dp)
-                                .background(
-                                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
-                                    shape = RoundedCornerShape(4.dp),
-                                )
-                                .padding(horizontal = 4.dp, vertical = 2.dp),
-                            fontSize = 10.sp,
-                            color = MaterialTheme.colorScheme.primary,
-                            style = MaterialTheme.typography.labelSmall,
-                        )
-                    }
+                    SourceTypeBadge(source = source)
                 }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BaseSourceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BaseSourceItem.kt
@@ -1,29 +1,20 @@
 package eu.kanade.presentation.browse.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import eu.kanade.tachiyomi.jsplugin.source.JsSource
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import tachiyomi.domain.source.model.Source
-import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.util.secondaryItemAlpha
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 @Composable
 fun BaseSourceItem(
@@ -54,11 +45,6 @@ private val defaultIcon: @Composable RowScope.(Source) -> Unit = { source ->
 }
 
 private val defaultContent: @Composable RowScope.(Source, String?) -> Unit = { source, sourceLangString ->
-    // Check if this is a JS source
-    val isJsSource = remember(source.id) {
-        Injekt.get<SourceManager>().get(source.id) is JsSource
-    }
-
     Column(
         modifier = Modifier
             .padding(horizontal = MaterialTheme.padding.medium)
@@ -74,21 +60,7 @@ private val defaultContent: @Composable RowScope.(Source, String?) -> Unit = { s
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f, fill = false),
             )
-            if (isJsSource) {
-                Text(
-                    text = "JS",
-                    modifier = Modifier
-                        .padding(start = 4.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
-                            shape = RoundedCornerShape(4.dp),
-                        )
-                        .padding(horizontal = 4.dp, vertical = 2.dp),
-                    fontSize = 10.sp,
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.labelSmall,
-                )
-            }
+            SourceTypeBadge(source = source)
         }
         if (sourceLangString != null) {
             Text(

--- a/app/src/main/java/eu/kanade/presentation/browse/components/SourceTypeBadge.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/SourceTypeBadge.kt
@@ -1,0 +1,44 @@
+package eu.kanade.presentation.browse.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.kanade.tachiyomi.source.SourceTypeTag
+import eu.kanade.tachiyomi.source.typeTag
+import tachiyomi.domain.source.model.Source
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * `JS` / `Custom` marker for a listed source, or nothing for a plain extension. Resolves the loaded
+ * source when there is one and falls back to the marker persisted with the row for a stub.
+ */
+@Composable
+fun SourceTypeBadge(source: Source, modifier: Modifier = Modifier) {
+    val typeTag = remember(source.id) {
+        Injekt.get<SourceManager>().get(source.id)?.typeTag()
+            ?: SourceTypeTag.JS.takeIf { source.isJsSource }
+    } ?: return
+
+    Text(
+        text = typeTag.label,
+        modifier = modifier
+            .padding(start = 4.dp)
+            .background(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        fontSize = 10.sp,
+        color = MaterialTheme.colorScheme.primary,
+        style = MaterialTheme.typography.labelSmall,
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/browse/components/SourceTypeBadge.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/SourceTypeBadge.kt
@@ -17,10 +17,6 @@ import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-/**
- * `JS` / `Custom` marker for a listed source, or nothing for a plain extension. Resolves the loaded
- * source when there is one and falls back to the marker persisted with the row for a stub.
- */
 @Composable
 fun SourceTypeBadge(source: Source, modifier: Modifier = Modifier) {
     val typeTag = remember(source.id) {

--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -85,6 +85,7 @@ fun DuplicateMangaDialog(
     onOpenManga: (manga: Manga) -> Unit,
     onMigrate: (manga: Manga) -> Unit,
     modifier: Modifier = Modifier,
+    canAddAnyway: Boolean = true,
 ) {
     val sourceManager = remember { Injekt.get<SourceManager>() }
     val minHeight = LocalPreferenceMinHeight.current
@@ -135,18 +136,20 @@ fun DuplicateMangaDialog(
                 }
             }
 
-            Column(modifier = horizontalPaddingModifier) {
-                HorizontalDivider()
+            if (canAddAnyway) {
+                Column(modifier = horizontalPaddingModifier) {
+                    HorizontalDivider()
 
-                TextPreferenceWidget(
-                    title = stringResource(MR.strings.action_add_anyway),
-                    icon = Icons.Outlined.Add,
-                    onPreferenceClick = {
-                        onDismissRequest()
-                        onConfirm()
-                    },
-                    modifier = Modifier.clip(CircleShape),
-                )
+                    TextPreferenceWidget(
+                        title = stringResource(MR.strings.action_add_anyway),
+                        icon = Icons.Outlined.Add,
+                        onPreferenceClick = {
+                            onDismissRequest()
+                            onConfirm()
+                        },
+                        modifier = Modifier.clip(CircleShape),
+                    )
+                }
             }
 
             OutlinedButton(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -285,6 +285,13 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
                 ),
             )
+            add(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.checkDuplicateEntryOnAdd,
+                    title = stringResource(TDMR.strings.pref_check_duplicate_on_add),
+                    subtitle = stringResource(TDMR.strings.pref_check_duplicate_on_add_summary),
+                ),
+            )
             if (!isJoined) {
                 add(
                     Preference.PreferenceItem.SwitchPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -15,6 +15,8 @@ import androidx.core.content.ContextCompat
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.source.interactor.SetMigrateSorting
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.category.visualName
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.widget.TriStateListDialog
@@ -54,6 +56,7 @@ object SettingsLibraryScreen : SearchableSettings {
     override fun getPreferences(): List<Preference> {
         val getCategories = remember { Injekt.get<GetCategories>() }
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val sourcePreferences = remember { Injekt.get<SourcePreferences>() }
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
         val isJoined by libraryPreferences.joinedLibrary.changes().collectAsState(
             initial = libraryPreferences.joinedLibrary.get(),
@@ -62,7 +65,7 @@ object SettingsLibraryScreen : SearchableSettings {
         return listOf(
             getCategoriesGroup(LocalNavigator.currentOrThrow, allCategories, libraryPreferences),
             getGlobalUpdateGroup(allCategories, libraryPreferences),
-            getBehaviorGroup(libraryPreferences, isJoined),
+            getBehaviorGroup(libraryPreferences, sourcePreferences, isJoined),
         )
     }
 
@@ -232,6 +235,7 @@ object SettingsLibraryScreen : SearchableSettings {
     @Composable
     private fun getBehaviorGroup(
         libraryPreferences: LibraryPreferences,
+        sourcePreferences: SourcePreferences,
         isJoined: Boolean,
     ): Preference.PreferenceGroup {
         val preferenceItems = buildList {
@@ -290,6 +294,26 @@ object SettingsLibraryScreen : SearchableSettings {
                     preference = libraryPreferences.checkDuplicateEntryOnAdd,
                     title = stringResource(TDMR.strings.pref_check_duplicate_on_add),
                     subtitle = stringResource(TDMR.strings.pref_check_duplicate_on_add_summary),
+                ),
+            )
+            add(
+                Preference.PreferenceItem.ListPreference(
+                    preference = sourcePreferences.migrationSortingMode,
+                    entries = mapOf(
+                        SetMigrateSorting.Mode.ALPHABETICAL to stringResource(MR.strings.action_sort_alpha),
+                        SetMigrateSorting.Mode.TOTAL to stringResource(MR.strings.action_sort_count),
+                    ),
+                    title = stringResource(TDMR.strings.pref_migrate_source_sorting),
+                ),
+            )
+            add(
+                Preference.PreferenceItem.ListPreference(
+                    preference = sourcePreferences.migrationSortingDirection,
+                    entries = mapOf(
+                        SetMigrateSorting.Direction.ASCENDING to stringResource(MR.strings.action_asc),
+                        SetMigrateSorting.Direction.DESCENDING to stringResource(MR.strings.action_desc),
+                    ),
+                    title = stringResource(TDMR.strings.pref_migrate_source_sorting_direction),
                 ),
             )
             if (!isJoined) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -298,6 +298,18 @@ object SettingsLibraryScreen : SearchableSettings {
             )
             add(
                 Preference.PreferenceItem.ListPreference(
+                    preference = libraryPreferences.duplicateSortMode,
+                    entries = mapOf(
+                        LibraryPreferences.DuplicateSortMode.Alphabetical to
+                            stringResource(MR.strings.action_sort_alpha),
+                        LibraryPreferences.DuplicateSortMode.ChapterCount to
+                            stringResource(MR.strings.action_sort_total),
+                    ),
+                    title = stringResource(TDMR.strings.pref_duplicate_sort_mode),
+                ),
+            )
+            add(
+                Preference.PreferenceItem.ListPreference(
                     preference = sourcePreferences.migrationSortingMode,
                     entries = mapOf(
                         SetMigrateSorting.Mode.ALPHABETICAL to stringResource(MR.strings.action_sort_alpha),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.RateLimited
+import eu.kanade.tachiyomi.source.filterUserEnabled
 import eu.kanade.tachiyomi.source.isNovelSource
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences
 import tachiyomi.domain.download.service.NovelDownloadPreferences.Companion.SourceOverride
@@ -390,6 +392,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
             // declared defaults rather than looking like it's not throttled at all.
             val unconfiguredRateLimited = sourceManager.getAll()
                 .filterIsInstance<CatalogueSource>()
+                .filterUserEnabled()
                 .filter { it.isNovelSource() && it is RateLimited && it.id !in savedSourceIds }
                 .map { source -> SourceOverride(sourceId = source.id, enabled = true) }
 
@@ -397,9 +400,12 @@ object SettingsNovelDownloadScreen : SearchableSettings {
                 savedOverrides.map { OverrideRow(it, isSaved = true) } +
                     unconfiguredRateLimited.map { OverrideRow(it, isSaved = false) }
                 )
-                .sortedBy { row ->
-                    sourceManager.get(row.override.sourceId)?.name?.lowercase() ?: "zzz_${row.override.sourceId}"
-                }
+                .sortedWith(
+                    compareBy(String.CASE_INSENSITIVE_ORDER) { row ->
+                        sourceManager.get(row.override.sourceId)?.nameWithTypeTag()
+                            ?: "zzz_${row.override.sourceId}"
+                    },
+                )
         }
 
         AlertDialog(
@@ -427,7 +433,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
                             items(rows, key = { it.override.sourceId }) { row ->
                                 val override = row.override
                                 val source = sourceManager.get(override.sourceId)
-                                val sourceName = source?.name ?: "Unknown (#${override.sourceId})"
+                                val sourceName = source?.nameWithTypeTag() ?: "Unknown (#${override.sourceId})"
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     verticalAlignment = Alignment.CenterVertically,
@@ -511,7 +517,9 @@ object SettingsNovelDownloadScreen : SearchableSettings {
         val sourceManager = remember { Injekt.get<SourceManager>() }
         val novelSources = remember {
             sourceManager.getAll().filterIsInstance<CatalogueSource>()
+                .filterUserEnabled()
                 .filter { it.isNovelSource() }
+                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.nameWithTypeTag() })
         }
 
         var selectedSourceId by remember { mutableStateOf(existing?.sourceId ?: 0L) }
@@ -521,7 +529,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
         var sourceExpanded by remember { mutableStateOf(false) }
 
         val selectedSource = novelSources.find { it.id == selectedSourceId }
-        val selectedSourceName = selectedSource?.name
+        val selectedSourceName = selectedSource?.nameWithTypeTag()
             ?: if (selectedSourceId != 0L) "Source #$selectedSourceId" else "Select source..."
         // An extension can declare its own floor via RateLimited; the user can't configure
         // less delay than that, no matter what they drag the slider to.
@@ -559,7 +567,7 @@ object SettingsNovelDownloadScreen : SearchableSettings {
                         ) {
                             novelSources.forEach { source ->
                                 DropdownMenuItem(
-                                    text = { Text(source.name) },
+                                    text = { Text(source.nameWithTypeTag()) },
                                     onClick = {
                                         selectedSourceId = source.id
                                         sourceExpanded = false

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelDownloadScreen.kt
@@ -516,9 +516,10 @@ object SettingsNovelDownloadScreen : SearchableSettings {
     ) {
         val sourceManager = remember { Injekt.get<SourceManager>() }
         val novelSources = remember {
-            sourceManager.getAll().filterIsInstance<CatalogueSource>()
-                .filterUserEnabled()
-                .filter { it.isNovelSource() }
+            val all = sourceManager.getAll().filterIsInstance<CatalogueSource>().filter { it.isNovelSource() }
+            val enabled = all.filterUserEnabled()
+            val existingSource = existing?.let { override -> all.find { it.id == override.sourceId } }
+            (if (existingSource != null && existingSource !in enabled) enabled + existingSource else enabled)
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.nameWithTypeTag() })
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
@@ -207,6 +207,7 @@ class LNReaderBackupImporter(
                                     lang = "unknown",
                                     name = "$pluginId (Missing)",
                                     isNovel = true,
+                                    isJs = true,
                                 )
                                 pluginIdToSourceId[pluginId] = stubSourceId
                                 logcat(LogPriority.INFO) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -171,9 +171,8 @@ class AndroidSourceManager(
 
     private suspend fun createStubSource(id: Long): StubSource {
         sourceRepository.getStubSource(id)?.let { dbSource ->
-            // Rows written before is_js existed inferred the JS marker from "is a novel source",
-            // which is wrong for novel sources shipped as APK extensions. An id the extension
-            // manager lists can only be an APK extension, so drop the marker and persist the fix.
+            // Rows seeded from is_novel by migration 34 marked Kotlin novel extensions as JS. An id
+            // the extension manager lists is an APK extension, so clear the marker and persist it.
             if (dbSource.isJsSource && extensionManager.getSourceData(id) != null) {
                 val corrected = dbSource.copy(isJsSource = false)
                 registerStubSource(corrected)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -156,7 +156,13 @@ class AndroidSourceManager(
         scope.launch {
             val dbSource = sourceRepository.getStubSource(source.id)
             if (dbSource == source) return@launch
-            sourceRepository.upsertStubSource(source.id, source.lang, source.name, source.isNovelSource)
+            sourceRepository.upsertStubSource(
+                source.id,
+                source.lang,
+                source.name,
+                source.isNovelSource,
+                source.isJsSource,
+            )
             if (dbSource != null) {
                 downloadManager.renameSource(dbSource, source)
             }
@@ -164,8 +170,16 @@ class AndroidSourceManager(
     }
 
     private suspend fun createStubSource(id: Long): StubSource {
-        sourceRepository.getStubSource(id)?.let {
-            return it
+        sourceRepository.getStubSource(id)?.let { dbSource ->
+            // Rows written before is_js existed inferred the JS marker from "is a novel source",
+            // which is wrong for novel sources shipped as APK extensions. An id the extension
+            // manager lists can only be an APK extension, so drop the marker and persist the fix.
+            if (dbSource.isJsSource && extensionManager.getSourceData(id) != null) {
+                val corrected = dbSource.copy(isJsSource = false)
+                registerStubSource(corrected)
+                return corrected
+            }
+            return dbSource
         }
         extensionManager.getSourceData(id)?.let {
             registerStubSource(it)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -43,11 +43,15 @@ fun Source.nameWithTypeTag(): String = typeTag()?.let { "$name (${it.label})" } 
 
 // Custom and local sources have no language toggle of their own (local reports "other"), so they
 // are never filtered out.
-fun <T : Source> List<T>.filterUserEnabled(preferences: SourcePreferences = Injekt.get()): List<T> {
+fun <T : Source> List<T>.filterEnabledLanguages(preferences: SourcePreferences = Injekt.get()): List<T> {
     val enabledLanguages = preferences.enabledLanguages.get()
+    return filter { it is CustomNovelSource || it.isLocal() || it.lang in enabledLanguages }
+}
+
+fun <T : Source> List<T>.filterUserEnabled(preferences: SourcePreferences = Injekt.get()): List<T> {
     val disabledSources = preferences.disabledSources.get()
-    return filter { source ->
-        source is CustomNovelSource || source.isLocal() ||
-            (source.lang in enabledLanguages && "${source.id}" !in disabledSources)
+    return filterEnabledLanguages(preferences).filter {
+        it is CustomNovelSource || it.isLocal() ||
+            "${it.id}" !in disabledSources
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -25,16 +25,13 @@ fun Source.getNameForMangaInfo(): String {
 
 fun Source.isLocalOrStub(): Boolean = isLocal() || this is StubSource
 
-/** How a source is implemented, for lists where sources of different kinds share a name. */
 enum class SourceTypeTag(val label: String) {
     JS("JS"),
     CUSTOM("Custom"),
 }
 
-/**
- * A stubbed source can't be type-checked, so it carries the marker it was registered with instead
- * of guessing from [Source.isNovelSource] - novel sources also ship as Kotlin extensions.
- */
+// A stub carries the marker it was registered with; deriving it from isNovelSource is wrong
+// because novel sources also ship as Kotlin extensions.
 fun Source.typeTag(): SourceTypeTag? = when {
     this is CustomNovelSource -> SourceTypeTag.CUSTOM
     this is JsSource -> SourceTypeTag.JS
@@ -42,14 +39,10 @@ fun Source.typeTag(): SourceTypeTag? = when {
     else -> null
 }
 
-/** Source name with its [typeTag], for pickers and lists where same-named sources coexist. */
 fun Source.nameWithTypeTag(): String = typeTag()?.let { "$name (${it.label})" } ?: name
 
-/**
- * Keeps only the sources the user actually has turned on - language enabled and not hidden - so
- * pickers don't offer extensions that browse and search won't use. Custom and local sources have
- * no language toggle of their own (local reports "other") and are always kept.
- */
+// Custom and local sources have no language toggle of their own (local reports "other"), so they
+// are never filtered out.
 fun <T : Source> List<T>.filterUserEnabled(preferences: SourcePreferences = Injekt.get()): List<T> {
     val enabledLanguages = preferences.enabledLanguages.get()
     val disabledSources = preferences.disabledSources.get()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.jsplugin.source.JsSource
+import eu.kanade.tachiyomi.source.custom.CustomNovelSource
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -16,10 +17,44 @@ fun Source.getNameForMangaInfo(): String {
     return when {
         // For edge cases where user disables a source they got manga of in their library.
         hasOneActiveLanguages && !isInEnabledLanguages -> toString()
-        // Hide the language tag when only one language is used, but always append (JS) for JS sources.
-        hasOneActiveLanguages && isInEnabledLanguages -> if (this is JsSource) "$name (JS)" else name
+        // Hide the language tag when only one language is used, but keep the type tag.
+        hasOneActiveLanguages && isInEnabledLanguages -> nameWithTypeTag()
         else -> toString()
     }
 }
 
 fun Source.isLocalOrStub(): Boolean = isLocal() || this is StubSource
+
+/** How a source is implemented, for lists where sources of different kinds share a name. */
+enum class SourceTypeTag(val label: String) {
+    JS("JS"),
+    CUSTOM("Custom"),
+}
+
+/**
+ * A stubbed source can't be type-checked, so it carries the marker it was registered with instead
+ * of guessing from [Source.isNovelSource] - novel sources also ship as Kotlin extensions.
+ */
+fun Source.typeTag(): SourceTypeTag? = when {
+    this is CustomNovelSource -> SourceTypeTag.CUSTOM
+    this is JsSource -> SourceTypeTag.JS
+    this is StubSource && isJsSource -> SourceTypeTag.JS
+    else -> null
+}
+
+/** Source name with its [typeTag], for pickers and lists where same-named sources coexist. */
+fun Source.nameWithTypeTag(): String = typeTag()?.let { "$name (${it.label})" } ?: name
+
+/**
+ * Keeps only the sources the user actually has turned on - language enabled and not hidden - so
+ * pickers don't offer extensions that browse and search won't use. Custom and local sources have
+ * no language toggle of their own (local reports "other") and are always kept.
+ */
+fun <T : Source> List<T>.filterUserEnabled(preferences: SourcePreferences = Injekt.get()): List<T> {
+    val enabledLanguages = preferences.enabledLanguages.get()
+    val disabledSources = preferences.disabledSources.get()
+    return filter { source ->
+        source is CustomNovelSource || source.isLocal() ||
+            (source.lang in enabledLanguages && "${source.id}" !in disabledSources)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -8,7 +8,6 @@ import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
-import eu.kanade.tachiyomi.source.filterUserEnabled
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.nameWithTypeTag
 import kotlinx.coroutines.channels.Channel
@@ -57,7 +56,6 @@ class MigrateMangaScreenModel(
 
     fun getAvailableSources(filterNovel: Boolean): List<CatalogueSource> {
         return sourceManager.getAll().filterIsInstance<CatalogueSource>()
-            .filterUserEnabled()
             .filter { it.id != sourceId && it.isNovelSource() == filterNovel }
             .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.nameWithTypeTag() })
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -8,7 +8,9 @@ import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.filterUserEnabled
 import eu.kanade.tachiyomi.source.isNovelSource
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -55,8 +57,9 @@ class MigrateMangaScreenModel(
 
     fun getAvailableSources(filterNovel: Boolean): List<CatalogueSource> {
         return sourceManager.getAll().filterIsInstance<CatalogueSource>()
+            .filterUserEnabled()
             .filter { it.id != sourceId && it.isNovelSource() == filterNovel }
-            .sortedBy { it.name }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.nameWithTypeTag() })
     }
 
     init {
@@ -121,8 +124,8 @@ class MigrateMangaScreenModel(
                     it.copy(
                         dialog = Dialog.QuickMigrateConfirm(
                             targetSourceId = targetSourceId,
-                            sourceName = sourceManager.getOrStub(sourceId).name,
-                            targetSourceName = sourceManager.getOrStub(targetSourceId).name,
+                            sourceName = sourceManager.getOrStub(sourceId).nameWithTypeTag(),
+                            targetSourceName = sourceManager.getOrStub(targetSourceId).nameWithTypeTag(),
                             totalCount = selectedManga.size,
                             skipCount = skipCount,
                         ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -8,6 +8,7 @@ import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.track.source.SourceTrackerDispatcher
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.filterEnabledLanguages
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.nameWithTypeTag
 import kotlinx.coroutines.channels.Channel
@@ -56,6 +57,7 @@ class MigrateMangaScreenModel(
 
     fun getAvailableSources(filterNovel: Boolean): List<CatalogueSource> {
         return sourceManager.getAll().filterIsInstance<CatalogueSource>()
+            .filterEnabledLanguages()
             .filter { it.id != sourceId && it.isNovelSource() == filterNovel }
             .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.nameWithTypeTag() })
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/QuickMigrateDialogs.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/QuickMigrateDialogs.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 
@@ -89,7 +90,7 @@ fun QuickMigrateSourcePickerDialog(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Column {
-                            Text(text = source.name, style = MaterialTheme.typography.bodyLarge)
+                            Text(text = source.nameWithTypeTag(), style = MaterialTheme.typography.bodyLarge)
                             Text(
                                 text = source.lang,
                                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceScreenModel.kt
@@ -81,8 +81,8 @@ class MigrateSourceScreenModel(
     data class State(
         val isLoading: Boolean = true,
         val items: List<Pair<Source, Long>> = listOf(),
-        val sortingMode: SetMigrateSorting.Mode = SetMigrateSorting.Mode.TOTAL,
-        val sortingDirection: SetMigrateSorting.Direction = SetMigrateSorting.Direction.DESCENDING,
+        val sortingMode: SetMigrateSorting.Mode = SetMigrateSorting.Mode.ALPHABETICAL,
+        val sortingDirection: SetMigrateSorting.Direction = SetMigrateSorting.Direction.ASCENDING,
     ) {
         val isEmpty = items.isEmpty()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceScreenModel.kt
@@ -81,8 +81,8 @@ class MigrateSourceScreenModel(
     data class State(
         val isLoading: Boolean = true,
         val items: List<Pair<Source, Long>> = listOf(),
-        val sortingMode: SetMigrateSorting.Mode = SetMigrateSorting.Mode.ALPHABETICAL,
-        val sortingDirection: SetMigrateSorting.Direction = SetMigrateSorting.Direction.ASCENDING,
+        val sortingMode: SetMigrateSorting.Mode = SetMigrateSorting.Mode.TOTAL,
+        val sortingDirection: SetMigrateSorting.Direction = SetMigrateSorting.Direction.DESCENDING,
     ) {
         val isEmpty = items.isEmpty()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -36,6 +37,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,6 +53,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -70,6 +73,8 @@ import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.jsplugin.JsPluginManager
 import eu.kanade.tachiyomi.source.custom.CustomSourceConfig
 import eu.kanade.tachiyomi.source.custom.SourceTestResult
+import eu.kanade.tachiyomi.source.isNovelSource
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import kotlinx.coroutines.Dispatchers
@@ -2205,84 +2210,147 @@ private fun BaseSourcePickerDialog(
     data class SourceEntry(
         val sourceId: Long,
         val sourceName: String,
+        val displayName: String,
         val baseUrl: String,
-        val extensionName: String,
         val lang: String,
+        val isNovel: Boolean,
     )
 
-    val novelSources = remember(installedExtensions, jsSources) {
-        val apkSources = installedExtensions.flatMap { ext ->
-            ext.sources.mapNotNull { source ->
-                val httpSource = source as? HttpSource ?: return@mapNotNull null
+    // Built off the main thread: every extension resolves its own baseUrl, and extensions that read
+    // it from their preferences hit a separate SharedPreferences file each, so on a large install
+    // the dialog used to sit blank for seconds before its first frame.
+    val allSources by produceState<List<SourceEntry>?>(null, installedExtensions, jsSources) {
+        value = withContext(Dispatchers.IO) {
+            val apkSources = installedExtensions.flatMap { ext ->
+                ext.sources.mapNotNull { source ->
+                    val httpSource = source as? HttpSource ?: return@mapNotNull null
+                    SourceEntry(
+                        sourceId = httpSource.id,
+                        sourceName = httpSource.name,
+                        displayName = httpSource.nameWithTypeTag(),
+                        baseUrl = httpSource.baseUrl,
+                        lang = httpSource.lang,
+                        isNovel = httpSource.isNovelSource(),
+                    )
+                }
+            }
+
+            val jsEntries = jsSources.mapNotNull { source ->
+                val jsSource = source as? eu.kanade.tachiyomi.jsplugin.source.JsSource ?: return@mapNotNull null
                 SourceEntry(
-                    sourceId = httpSource.id,
-                    sourceName = httpSource.name,
-                    baseUrl = httpSource.baseUrl,
-                    extensionName = ext.name,
-                    lang = httpSource.lang,
+                    sourceId = jsSource.id,
+                    sourceName = jsSource.name,
+                    displayName = jsSource.nameWithTypeTag(),
+                    baseUrl = jsSource.baseUrl,
+                    lang = jsSource.lang,
+                    isNovel = jsSource.isNovelSource(),
                 )
             }
-        }
 
-        val jsEntries = jsSources.mapNotNull { source ->
-            val jsSource = source as? eu.kanade.tachiyomi.jsplugin.source.JsSource ?: return@mapNotNull null
-            SourceEntry(
-                sourceId = jsSource.id,
-                sourceName = jsSource.name,
-                baseUrl = jsSource.baseUrl,
-                extensionName = "[JS] ${jsSource.name}",
-                lang = jsSource.lang,
+            (apkSources + jsEntries).sortedWith(
+                compareBy(String.CASE_INSENSITIVE_ORDER) { it.displayName },
             )
         }
-
-        (apkSources + jsEntries).sortedBy { it.extensionName }
     }
+
+    // Novel and manga extensions are listed together and often share a site name, so the list is
+    // unreadable without a split. Opens on whichever kind the install actually has.
+    var showNovel by remember { mutableStateOf<Boolean?>(null) }
+    val novelCount = allSources?.count { it.isNovel } ?: 0
+    val mangaCount = (allSources?.size ?: 0) - novelCount
+    val novelSelected = showNovel ?: (novelCount > 0 || mangaCount == 0)
+    val entries = allSources?.filter { it.isNovel == novelSelected }
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(TDMR.strings.custom_source_base_on_extension)) },
         text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                if (novelSources.isEmpty()) {
+            when {
+                entries == null -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                novelCount == 0 && mangaCount == 0 -> {
                     Text(
                         text = stringResource(TDMR.strings.custom_source_no_extensions),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                } else {
-                    Text(
-                        text = stringResource(TDMR.strings.custom_source_pick_extension_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                else -> {
+                    Column {
+                        Text(
+                            text = stringResource(TDMR.strings.custom_source_pick_extension_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
 
-                    novelSources.forEach { entry ->
-                        val isSelected = selectedSourceId == entry.sourceId
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 2.dp),
-                            colors = CardDefaults.cardColors(
-                                containerColor = if (isSelected) {
-                                    MaterialTheme.colorScheme.primaryContainer
-                                } else {
-                                    MaterialTheme.colorScheme.surfaceVariant
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            FilterChip(
+                                selected = !novelSelected,
+                                onClick = { showNovel = false },
+                                label = {
+                                    Text(
+                                        stringResource(
+                                            TDMR.strings.custom_source_kind_manga_count,
+                                            mangaCount,
+                                        ),
+                                    )
                                 },
-                            ),
-                            onClick = { onPick(entry.sourceName, entry.sourceId, entry.baseUrl, entry.lang) },
-                        ) {
-                            Column(modifier = Modifier.padding(12.dp)) {
-                                Text(
-                                    text = entry.sourceName,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.Bold,
-                                )
-                                Text(
-                                    text = "${entry.extensionName} · ${entry.lang} · ${entry.baseUrl}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                            )
+                            FilterChip(
+                                selected = novelSelected,
+                                onClick = { showNovel = true },
+                                label = {
+                                    Text(
+                                        stringResource(
+                                            TDMR.strings.custom_source_kind_novel_count,
+                                            novelCount,
+                                        ),
+                                    )
+                                },
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        LazyColumn {
+                            items(entries) { entry ->
+                                val isSelected = selectedSourceId == entry.sourceId
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 2.dp),
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = if (isSelected) {
+                                            MaterialTheme.colorScheme.primaryContainer
+                                        } else {
+                                            MaterialTheme.colorScheme.surfaceVariant
+                                        },
+                                    ),
+                                    onClick = {
+                                        onPick(entry.sourceName, entry.sourceId, entry.baseUrl, entry.lang)
+                                    },
+                                ) {
+                                    Column(modifier = Modifier.padding(12.dp)) {
+                                        Text(
+                                            text = entry.displayName,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.Bold,
+                                        )
+                                        Text(
+                                            text = "${entry.lang} · ${entry.baseUrl}",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -2290,11 +2358,6 @@ private fun BaseSourcePickerDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(MR.strings.action_cancel))
-            }
-        },
-        dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(MR.strings.action_cancel))
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/custom/CustomSourcesScreen.kt
@@ -2216,9 +2216,8 @@ private fun BaseSourcePickerDialog(
         val isNovel: Boolean,
     )
 
-    // Built off the main thread: every extension resolves its own baseUrl, and extensions that read
-    // it from their preferences hit a separate SharedPreferences file each, so on a large install
-    // the dialog used to sit blank for seconds before its first frame.
+    // Off the main thread: extensions that read baseUrl from their preferences hit a separate
+    // SharedPreferences file each, which on a large install blocks the dialog's first frame.
     val allSources by produceState<List<SourceEntry>?>(null, installedExtensions, jsSources) {
         value = withContext(Dispatchers.IO) {
             val apkSources = installedExtensions.flatMap { ext ->
@@ -2253,8 +2252,6 @@ private fun BaseSourcePickerDialog(
         }
     }
 
-    // Novel and manga extensions are listed together and often share a site name, so the list is
-    // unreadable without a split. Opens on whichever kind the install actually has.
     var showNovel by remember { mutableStateOf<Boolean?>(null) }
     val novelCount = allSources?.count { it.isNovel } ?: 0
     val mangaCount = (allSources?.size ?: 0) - novelCount

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -5,9 +5,9 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.cache.LibrarySettingsCache
 import eu.kanade.tachiyomi.data.track.TrackerManager
-import eu.kanade.tachiyomi.jsplugin.source.JsSource
 import eu.kanade.tachiyomi.source.custom.CustomNovelSource
 import eu.kanade.tachiyomi.source.isNovelSource
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
@@ -241,13 +241,7 @@ class LibrarySettingsScreenModel(
                         LibraryScreenModel.LibraryType.Novel -> isNovel
                     }
                     if (shouldInclude) {
-                        // Add suffix for special source types
-                        val displayName = when {
-                            source is JsSource -> "${source.name} (JS)"
-                            isCustom -> "${source.name} (Custom)"
-                            else -> source.name
-                        }
-                        ExtensionInfo(sourceId, displayName, isStub, isNovel, isCustom)
+                        ExtensionInfo(sourceId, source.nameWithTypeTag(), isStub, isNovel, isCustom)
                     } else {
                         null
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/SourcePriorityScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/SourcePriorityScreen.kt
@@ -34,9 +34,9 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.source.service.SourcePreferences
-import eu.kanade.tachiyomi.jsplugin.source.JsSource
 import eu.kanade.tachiyomi.source.CatalogueSource
-import eu.kanade.tachiyomi.source.custom.CustomNovelSource
+import eu.kanade.tachiyomi.source.filterUserEnabled
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -269,27 +269,16 @@ class SourcePriorityScreenModel(
     private fun loadSourceItems() {
         screenModelScope.launch {
             sourceManager.sources.map { it.filterIsInstance<CatalogueSource>() }.collect { catalogueSources ->
-                val enabledLanguages = sourcePreferences.enabledLanguages.get()
-                val disabledSources = sourcePreferences.disabledSources.get()
                 val items = catalogueSources
-                    .filter { source ->
-                        !source.isLocal() && (
-                            source is CustomNovelSource ||
-                                (source.lang in enabledLanguages && "${source.id}" !in disabledSources)
-                            )
-                    }
+                    .filterNot { it.isLocal() }
+                    .filterUserEnabled(sourcePreferences)
                     .map { source ->
-                        val suffix = when (source) {
-                            is CustomNovelSource -> " (Custom)"
-                            is JsSource -> " (JS)"
-                            else -> ""
-                        }
                         SourcePriorityItem(
                             id = source.id,
-                            displayName = "${source.name}$suffix",
+                            displayName = source.nameWithTypeTag(),
                         )
                     }
-                    .sortedBy { it.displayName.lowercase() }
+                    .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.displayName })
                 val hasLocalSource = catalogueSources.any { it.isLocal() }
                 mutableState.update { it.copy(sourceItems = items, hasLocalSource = hasLocalSource) }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -293,7 +293,6 @@ class MangaScreen(
                 MigrateMangaDialog(
                     current = dialog.current,
                     target = dialog.target,
-                    // "Show" opens the other entry, i.e. the one that isn't the manga on screen.
                     onClickTitle = {
                         val other = if (dialog.target.id == successState.manga.id) dialog.current else dialog.target
                         navigator.push(MangaScreen(other.id))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -272,9 +272,10 @@ class MangaScreen(
                 DuplicateMangaDialog(
                     duplicates = dialog.duplicates,
                     onDismissRequest = onDismissRequest,
-                    onConfirm = { screenModel.toggleFavorite(onRemoved = {}, checkDuplicate = false) },
+                    onConfirm = { screenModel.toggleFavorite(onRemoved = {}, skipDuplicateCheck = true) },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
                     onMigrate = { screenModel.showMigrateDialog(it) },
+                    canAddAnyway = dialog.canAddAnyway,
                 )
             }
 
@@ -292,8 +293,11 @@ class MangaScreen(
                 MigrateMangaDialog(
                     current = dialog.current,
                     target = dialog.target,
-                    // Initiated from the context of [dialog.target] so we show [dialog.current].
-                    onClickTitle = { navigator.push(MangaScreen(dialog.current.id)) },
+                    // "Show" opens the other entry, i.e. the one that isn't the manga on screen.
+                    onClickTitle = {
+                        val other = if (dialog.target.id == successState.manga.id) dialog.current else dialog.target
+                        navigator.push(MangaScreen(other.id))
+                    },
                     onDismissRequest = onDismissRequest,
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -402,7 +402,9 @@ class MangaScreenModel(
      */
     fun toggleFavorite(
         onRemoved: () -> Unit,
-        checkDuplicate: Boolean = true,
+        // Set by the duplicates dialog's "Add anyway": the warning has already been shown and
+        // dismissed, so re-running the check would only reopen the same dialog.
+        skipDuplicateCheck: Boolean = false,
     ) {
         val state = successState ?: return
         screenModelScope.launchIO {
@@ -419,12 +421,13 @@ class MangaScreenModel(
                 }
             } else {
                 // Add to library
-                // First, check if duplicate exists if callback is provided
-                if (checkDuplicate) {
+                if (!skipDuplicateCheck) {
                     val duplicates = getDuplicateLibraryManga(manga)
 
                     if (duplicates.isNotEmpty()) {
-                        updateSuccessState { it.copy(dialog = Dialog.DuplicateManga(manga, duplicates)) }
+                        updateSuccessState {
+                            it.copy(dialog = Dialog.DuplicateManga(manga, duplicates, canAddAnyway = true))
+                        }
                         return@launchIO
                     }
                 }
@@ -1357,7 +1360,13 @@ class MangaScreenModel(
         ) : Dialog
         data class DeleteChapters(val chapters: List<Chapter>) : Dialog
         data class RemoveChaptersFromDb(val chapters: List<Chapter>) : Dialog
-        data class DuplicateManga(val manga: Manga, val duplicates: List<MangaWithChapterCount>) : Dialog
+        data class DuplicateManga(
+            val manga: Manga,
+            val duplicates: List<MangaWithChapterCount>,
+            // "Find duplicates" opens this for an entry already in the library, where adding
+            // anyway makes no sense (and toggling favorite would remove it instead).
+            val canAddAnyway: Boolean,
+        ) : Dialog
         data class SimilarNovels(
             val similarNovels: List<MangaWithChapterCount>,
             val categories: List<Category>,
@@ -1437,7 +1446,16 @@ class MangaScreenModel(
 
     fun showMigrateDialog(duplicate: Manga) {
         val manga = successState?.manga ?: return
-        updateSuccessState { it.copy(dialog = Dialog.Migrate(target = manga, current = duplicate)) }
+        // Roles decide which entry is replaced (current) vs kept (target) on "Migrate".
+        val dialog = if (manga.favorite) {
+            // Viewing a library entry and picking another (Find duplicates / Similar novels): migrate
+            // the viewed entry into the picked one, keeping the entry the user picked.
+            Dialog.Migrate(current = manga, target = duplicate)
+        } else {
+            // Adding a new entry that duplicates a library one: keep the new, replace the existing.
+            Dialog.Migrate(current = duplicate, target = manga)
+        }
+        updateSuccessState { it.copy(dialog = dialog) }
     }
 
     /**
@@ -1447,10 +1465,12 @@ class MangaScreenModel(
     fun showFindDuplicatesDialog() {
         val manga = successState?.manga ?: return
         screenModelScope.launchIO {
-            val duplicates = getDuplicateLibraryManga(manga)
+            val duplicates = getDuplicateLibraryManga(manga, force = true)
             withUIContext {
                 if (duplicates.isNotEmpty()) {
-                    updateSuccessState { it.copy(dialog = Dialog.DuplicateManga(manga, duplicates)) }
+                    updateSuccessState {
+                        it.copy(dialog = Dialog.DuplicateManga(manga, duplicates, canAddAnyway = !manga.favorite))
+                    }
                 } else {
                     // Show a snackbar or toast instead of dialog if no duplicates found
                     snackbarHostState.showSnackbar(context.stringResource(MR.strings.duplicate_no_duplicates))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -402,8 +402,6 @@ class MangaScreenModel(
      */
     fun toggleFavorite(
         onRemoved: () -> Unit,
-        // Set by the duplicates dialog's "Add anyway": the warning has already been shown and
-        // dismissed, so re-running the check would only reopen the same dialog.
         skipDuplicateCheck: Boolean = false,
     ) {
         val state = successState ?: return
@@ -1363,8 +1361,7 @@ class MangaScreenModel(
         data class DuplicateManga(
             val manga: Manga,
             val duplicates: List<MangaWithChapterCount>,
-            // "Find duplicates" opens this for an entry already in the library, where adding
-            // anyway makes no sense (and toggling favorite would remove it instead).
+            // False for an entry already in the library, where toggling favorite would remove it.
             val canAddAnyway: Boolean,
         ) : Dialog
         data class SimilarNovels(
@@ -1446,13 +1443,10 @@ class MangaScreenModel(
 
     fun showMigrateDialog(duplicate: Manga) {
         val manga = successState?.manga ?: return
-        // Roles decide which entry is replaced (current) vs kept (target) on "Migrate".
+        // Migrate replaces current and keeps target, so the entry the user picked is the kept one.
         val dialog = if (manga.favorite) {
-            // Viewing a library entry and picking another (Find duplicates / Similar novels): migrate
-            // the viewed entry into the picked one, keeping the entry the user picked.
             Dialog.Migrate(current = manga, target = duplicate)
         } else {
-            // Adding a new entry that duplicates a library one: keep the new, replace the existing.
             Dialog.Migrate(current = duplicate, target = manga)
         }
         updateSuccessState { it.copy(dialog = dialog) }

--- a/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
+++ b/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
@@ -3,6 +3,7 @@ package mihon.feature.migration.config
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyItemScope
@@ -43,10 +44,10 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.browse.components.SourceIcon
+import eu.kanade.presentation.browse.components.SourceTypeBadge
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.source.nameWithTypeTag
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import kotlinx.coroutines.flow.update
@@ -57,7 +58,6 @@ import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.source.model.Source
-import tachiyomi.domain.source.model.hasJsMarker
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -295,8 +295,10 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
                 )
+                SourceTypeBadge(source = source.source)
+                Spacer(modifier = Modifier.weight(1f))
                 if (showLanguage) {
                     Pill(
                         text = LocaleHelper.getShortDisplayName(source.shortLanguage, uppercase = true),
@@ -347,12 +349,9 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                     val source = Source(
                         id = it.id,
                         lang = it.lang,
-                        // Tagged here: the migration target list is where a JS plugin and a Kotlin
-                        // extension of the same site sit next to each other.
-                        name = it.nameWithTypeTag(),
+                        name = it.name,
                         supportsLatest = false,
                         isStub = false,
-                        isJsSource = it.hasJsMarker(),
                     )
                     MigrationSource(
                         source = source,

--- a/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
+++ b/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
@@ -46,6 +46,7 @@ import eu.kanade.presentation.browse.components.SourceIcon
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.source.nameWithTypeTag
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import kotlinx.coroutines.flow.update
@@ -56,6 +57,7 @@ import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.source.model.Source
+import tachiyomi.domain.source.model.hasJsMarker
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -311,11 +313,9 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
     ) : StateScreenModel<ScreenModel.State>(State()) {
 
         private val sourcesComparator = { includedSources: List<Long> ->
-            compareBy<MigrationSource>(
-                { !it.isSelected },
-                { includedSources.indexOf(it.id) },
-                { with(it) { "$name ($shortLanguage)" } },
-            )
+            compareBy<MigrationSource> { !it.isSelected }
+                .thenBy { includedSources.indexOf(it.id) }
+                .thenBy(String.CASE_INSENSITIVE_ORDER) { with(it) { "$name ($shortLanguage)" } }
         }
 
         init {
@@ -347,9 +347,12 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                     val source = Source(
                         id = it.id,
                         lang = it.lang,
-                        name = it.name,
+                        // Tagged here: the migration target list is where a JS plugin and a Kotlin
+                        // extension of the same site sit next to each other.
+                        name = it.nameWithTypeTag(),
                         supportsLatest = false,
                         isStub = false,
+                        isJsSource = it.hasJsMarker(),
                     )
                     MigrationSource(
                         source = source,

--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -77,8 +77,7 @@ internal fun Screen.MigrateMangaDialog(
             Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                // Both entries can be in the library, in which case "Migrate" drops [current] -
-                // spell out the direction rather than leaving the user to guess it.
+                // Both entries can be in the library, so the direction is not implied by the screen.
                 Text(
                     text = "${current.title}  →  ${target.title}",
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -76,6 +77,14 @@ internal fun Screen.MigrateMangaDialog(
             Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
+                // Both entries can be in the library, in which case "Migrate" drops [current] -
+                // spell out the direction rather than leaving the user to guess it.
+                Text(
+                    text = "${current.title}  →  ${target.title}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = MaterialTheme.padding.small),
+                )
                 state.applicableFlags.fastForEach { flag ->
                     LabeledCheckbox(
                         label = stringResource(flag.getLabel()),

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1234,11 +1234,12 @@ class MangaRepositoryImpl(
         id: Long,
         title: String,
         altTitles: List<String>,
+        limit: Long,
     ): List<MangaWithChapterCount> {
         val altTitlesEncoded = altTitles.takeIf {
             it.isNotEmpty()
         }?.let(AlternativeTitlesColumnAdapter::encode).orEmpty()
-        return database.mangasQueries.getDuplicateLibraryManga(id, title, altTitlesEncoded) {
+        return database.mangasQueries.getDuplicateLibraryManga(id, title, altTitlesEncoded, limit) {
                 id,
                 source,
                 url,

--- a/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
@@ -11,6 +11,7 @@ import tachiyomi.data.Database
 import tachiyomi.data.subscribeToDebouncedList
 import tachiyomi.domain.source.model.SourceWithCount
 import tachiyomi.domain.source.model.StubSource
+import tachiyomi.domain.source.model.hasJsMarker
 import tachiyomi.domain.source.repository.SourcePagingSource
 import tachiyomi.domain.source.repository.SourceRepository
 import tachiyomi.domain.source.service.SourceManager
@@ -98,5 +99,6 @@ class SourceRepositoryImpl(
         supportsLatest = false,
         isStub = false,
         isNovelSource = source.isNovelSource(),
+        isJsSource = source.hasJsMarker(),
     )
 }

--- a/data/src/main/java/tachiyomi/data/source/StubSourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/StubSourceRepositoryImpl.kt
@@ -19,8 +19,8 @@ class StubSourceRepositoryImpl(
         return database.sourcesQueries.findOne(id, ::mapStubSource).awaitAsOneOrNull()
     }
 
-    override suspend fun upsertStubSource(id: Long, lang: String, name: String, isNovel: Boolean) {
-        database.sourcesQueries.upsert(id, lang, name, isNovel)
+    override suspend fun upsertStubSource(id: Long, lang: String, name: String, isNovel: Boolean, isJs: Boolean) {
+        database.sourcesQueries.upsert(id, lang, name, isNovel, isJs)
     }
 
     private fun mapStubSource(
@@ -28,5 +28,12 @@ class StubSourceRepositoryImpl(
         lang: String,
         name: String,
         isNovel: Boolean,
-    ): StubSource = StubSource(id = id, lang = lang, name = name, isNovelSource = isNovel)
+        isJs: Boolean,
+    ): StubSource = StubSource(
+        id = id,
+        lang = lang,
+        name = name,
+        isNovelSource = isNovel,
+        isJsSource = isJs,
+    )
 }

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -301,6 +301,7 @@ AND (
                 AND instr(char(31) || lower(M.alternative_titles) || char(31), char(31) || lower(alt.entry) || char(31)) > 0
         ))
 )
+ORDER BY totalCount DESC
 LIMIT 10;
 
 -- Find all duplicate groups with exact title match (case-insensitive, trimmed)

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -301,8 +301,7 @@ AND (
                 AND instr(char(31) || lower(M.alternative_titles) || char(31), char(31) || lower(alt.entry) || char(31)) > 0
         ))
 )
-ORDER BY totalCount DESC
-LIMIT 10;
+LIMIT :limit;
 
 -- Find all duplicate groups with exact title match (case-insensitive, trimmed)
 findDuplicatesExact:

--- a/data/src/main/sqldelight/tachiyomi/data/sources.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/sources.sq
@@ -4,7 +4,8 @@ CREATE TABLE sources(
     _id INTEGER NOT NULL PRIMARY KEY,
     lang TEXT NOT NULL,
     name TEXT NOT NULL,
-    is_novel INTEGER AS Boolean NOT NULL DEFAULT 0
+    is_novel INTEGER AS Boolean NOT NULL DEFAULT 0,
+    is_js INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 findAll:
@@ -17,12 +18,13 @@ FROM sources
 WHERE _id = :id;
 
 upsert:
-INSERT INTO sources(_id, lang, name, is_novel)
-VALUES (:id, :lang, :name, :isNovel)
+INSERT INTO sources(_id, lang, name, is_novel, is_js)
+VALUES (:id, :lang, :name, :isNovel, :isJs)
 ON CONFLICT(_id)
 DO UPDATE
 SET
     lang = :lang,
     name = :name,
-    is_novel = :isNovel
+    is_novel = :isNovel,
+    is_js = :isJs
 WHERE _id = :id;

--- a/data/src/main/sqldelight/tachiyomi/migrations/34.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/34.sqm
@@ -1,0 +1,8 @@
+-- Stubbed sources need to know whether they are a JS plugin, not just whether they are a novel
+-- source: novel sources also ship as Kotlin extensions, and those were rendering as "Name (EN) (JS)"
+-- in update error reports and on-disk directory names.
+ALTER TABLE sources ADD COLUMN is_js INTEGER NOT NULL DEFAULT 0;
+
+-- Existing rows keep the string they have been rendering with; sources correct themselves on the
+-- next registration, when the loaded source reports how it actually renders.
+UPDATE sources SET is_js = is_novel;

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -344,6 +344,9 @@ class LibraryPreferences(
     val mangaReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_manga_read_progress_100", true)
     val novelReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_read_progress_100", true)
 
+    /** Warn about existing library entries (possible duplicates) when adding an entry to the library. */
+    val checkDuplicateEntryOnAdd: Preference<Boolean> = preferenceStore.getBoolean("pref_check_duplicate_on_add", true)
+
     /**
      * Source type priorities for duplicate detection.
      * Stored as semicolon-delimited "TYPE:PRIORITY" pairs, e.g. "JS:3;KT:1;CUSTOM:0;LOCAL:-2;STUB:-5"

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -344,6 +344,11 @@ class LibraryPreferences(
     val mangaReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_manga_read_progress_100", true)
     val novelReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_read_progress_100", true)
 
+    val duplicateSortMode: Preference<DuplicateSortMode> = preferenceStore.getEnum(
+        "pref_duplicate_sort_mode",
+        DuplicateSortMode.Alphabetical,
+    )
+
     val checkDuplicateEntryOnAdd: Preference<Boolean> = preferenceStore.getBoolean("pref_check_duplicate_on_add", true)
 
     /**
@@ -359,6 +364,11 @@ class LibraryPreferences(
     val specificSourcePriorities: Preference<String> = preferenceStore.getString("specific_source_priorities", "")
 
     // endregion
+
+    enum class DuplicateSortMode {
+        Alphabetical,
+        ChapterCount,
+    }
 
     enum class ChapterSwipeAction {
         ToggleRead,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -344,7 +344,6 @@ class LibraryPreferences(
     val mangaReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_manga_read_progress_100", true)
     val novelReadProgress100: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_read_progress_100", true)
 
-    /** Warn about existing library entries (possible duplicates) when adding an entry to the library. */
     val checkDuplicateEntryOnAdd: Preference<Boolean> = preferenceStore.getBoolean("pref_check_duplicate_on_add", true)
 
     /**

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
@@ -10,10 +10,7 @@ class GetDuplicateLibraryManga(
     private val libraryPreferences: LibraryPreferences,
 ) {
 
-    /**
-     * [force] runs the query even with the add-time duplicate check turned off, for the explicit
-     * "Find duplicates" action: that is a request for the check, not a guard on adding.
-     */
+    // "Find duplicates" passes force: it is a request for the check, not a guard on adding.
     suspend operator fun invoke(manga: Manga, force: Boolean = false): List<MangaWithChapterCount> {
         if (!force && !libraryPreferences.checkDuplicateEntryOnAdd.get()) return emptyList()
         return mangaRepository.getDuplicateLibraryManga(manga.id, manga.title.lowercase(), manga.alternativeTitles)

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
@@ -1,6 +1,8 @@
 package tachiyomi.domain.manga.interactor
 
+import tachiyomi.core.common.util.lang.compareToWithCollator
 import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.library.service.LibraryPreferences.DuplicateSortMode
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.repository.MangaRepository
@@ -13,6 +15,25 @@ class GetDuplicateLibraryManga(
     // "Find duplicates" passes force: it is a request for the check, not a guard on adding.
     suspend operator fun invoke(manga: Manga, force: Boolean = false): List<MangaWithChapterCount> {
         if (!force && !libraryPreferences.checkDuplicateEntryOnAdd.get()) return emptyList()
-        return mangaRepository.getDuplicateLibraryManga(manga.id, manga.title.lowercase(), manga.alternativeTitles)
+        val sortByChapterCount = libraryPreferences.duplicateSortMode.get() == DuplicateSortMode.ChapterCount
+        // Ordering is done here, not in SQL: the title predicate is unindexable, so the query is a
+        // scan of every favorite that only stops early once it has LIMIT rows. Ordering by chapter
+        // count has to see every match to pick the largest, alphabetical does not - duplicates share
+        // a title, so which candidates are cut is arbitrary either way.
+        val duplicates = mangaRepository.getDuplicateLibraryManga(
+            manga.id,
+            manga.title.lowercase(),
+            manga.alternativeTitles,
+            limit = if (sortByChapterCount) -1 else DISPLAY_LIMIT,
+        )
+        return if (sortByChapterCount) {
+            duplicates.sortedByDescending { it.chapterCount }.take(DISPLAY_LIMIT.toInt())
+        } else {
+            duplicates.sortedWith { a, b -> a.manga.title.compareToWithCollator(b.manga.title) }
+        }
+    }
+
+    companion object {
+        private const val DISPLAY_LIMIT = 10L
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetDuplicateLibraryManga.kt
@@ -1,14 +1,21 @@
 package tachiyomi.domain.manga.interactor
 
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.repository.MangaRepository
 
 class GetDuplicateLibraryManga(
     private val mangaRepository: MangaRepository,
+    private val libraryPreferences: LibraryPreferences,
 ) {
 
-    suspend operator fun invoke(manga: Manga): List<MangaWithChapterCount> {
+    /**
+     * [force] runs the query even with the add-time duplicate check turned off, for the explicit
+     * "Find duplicates" action: that is a request for the check, not a guard on adding.
+     */
+    suspend operator fun invoke(manga: Manga, force: Boolean = false): List<MangaWithChapterCount> {
+        if (!force && !libraryPreferences.checkDuplicateEntryOnAdd.get()) return emptyList()
         return mangaRepository.getDuplicateLibraryManga(manga.id, manga.title.lowercase(), manga.alternativeTitles)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -125,6 +125,7 @@ interface MangaRepository {
         id: Long,
         title: String,
         altTitles: List<String> = emptyList(),
+        limit: Long,
     ): List<MangaWithChapterCount>
 
     suspend fun findDuplicatesExact(): List<DuplicateGroup>

--- a/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
@@ -7,6 +7,7 @@ data class Source(
     val supportsLatest: Boolean,
     val isStub: Boolean,
     val isNovelSource: Boolean = false,
+    val isJsSource: Boolean = false,
     val pin: Pins = Pins.unpinned,
     val isUsedLast: Boolean = false,
 ) {

--- a/domain/src/main/java/tachiyomi/domain/source/model/SourceMarkers.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/SourceMarkers.kt
@@ -1,0 +1,13 @@
+package tachiyomi.domain.source.model
+
+import eu.kanade.tachiyomi.source.Source
+
+/** Suffix JS plugins and custom novel sources append to their display string. */
+const val JS_SOURCE_MARKER = " (JS)"
+
+/**
+ * Whether a source renders with the JS marker. Asking the source how it renders keeps stubs and
+ * domain models in step with the loaded source without the lower layers knowing its concrete type.
+ * Novel sources also ship as Kotlin extensions, so [Source.isNovelSource] is not the same question.
+ */
+fun Source.hasJsMarker(): Boolean = toString().endsWith(JS_SOURCE_MARKER)

--- a/domain/src/main/java/tachiyomi/domain/source/model/SourceMarkers.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/SourceMarkers.kt
@@ -2,12 +2,8 @@ package tachiyomi.domain.source.model
 
 import eu.kanade.tachiyomi.source.Source
 
-/** Suffix JS plugins and custom novel sources append to their display string. */
 const val JS_SOURCE_MARKER = " (JS)"
 
-/**
- * Whether a source renders with the JS marker. Asking the source how it renders keeps stubs and
- * domain models in step with the loaded source without the lower layers knowing its concrete type.
- * Novel sources also ship as Kotlin extensions, so [Source.isNovelSource] is not the same question.
- */
+// Asked of the source rather than derived from its type, so stubs and domain models stay in step
+// with the loaded source's own rendering.
 fun Source.hasJsMarker(): Boolean = toString().endsWith(JS_SOURCE_MARKER)

--- a/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/StubSource.kt
@@ -9,11 +9,12 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.SMangaUpdate
 
-class StubSource(
+data class StubSource(
     override val id: Long,
     override val lang: String,
     override val name: String,
     override val isNovelSource: Boolean = false,
+    val isJsSource: Boolean = false,
 ) : Source {
 
     private val isInvalid: Boolean = name.isBlank() || lang.isBlank()
@@ -39,12 +40,12 @@ class StubSource(
 
     // Must match the loaded source's toString() so quotes/translations resolve to the same on-disk
     // directory whether the source is currently loaded or only stubbed (plugin not yet loaded).
-    // Installed novel sources are JS plugins, rendering as "Name (LANG) (JS)"; the built-in local
+    // JS plugins and custom novel sources render as "Name (LANG) (JS)"; the built-in local
     // sources (ids 0/1) override toString() to their bare name with no lang/marker.
     override fun toString(): String = when {
         isInvalid -> id.toString()
         id == LOCAL_SOURCE_ID || id == LOCAL_NOVEL_SOURCE_ID -> name
-        isNovelSource -> "$name (${lang.uppercase()}) (JS)"
+        isJsSource -> "$name (${lang.uppercase()})$JS_SOURCE_MARKER"
         else -> "$name (${lang.uppercase()})"
     }
 
@@ -60,6 +61,7 @@ class StubSource(
                 lang = source.lang,
                 name = source.name,
                 isNovelSource = source.isNovelSource(),
+                isJsSource = source.hasJsMarker(),
             )
         }
     }

--- a/domain/src/main/java/tachiyomi/domain/source/repository/StubSourceRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/repository/StubSourceRepository.kt
@@ -8,5 +8,11 @@ interface StubSourceRepository {
 
     suspend fun getStubSource(id: Long): StubSource?
 
-    suspend fun upsertStubSource(id: Long, lang: String, name: String, isNovel: Boolean = false)
+    suspend fun upsertStubSource(
+        id: Long,
+        lang: String,
+        name: String,
+        isNovel: Boolean = false,
+        isJs: Boolean = false,
+    )
 }

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -865,6 +865,8 @@
     <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
 
     <string name="action_sort_source_name">Source name</string>
+    <string name="pref_migrate_source_sorting">Migrate source list sorting</string>
+    <string name="pref_migrate_source_sorting_direction">Migrate source list order</string>
     <string name="pref_check_duplicate_on_add">Check for existing entries when adding to library</string>
     <string name="pref_check_duplicate_on_add_summary">Warn about possible duplicates already in your library before adding</string>
     <string name="pref_show_manga_source_name">Show source name in manga details</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -757,6 +757,8 @@
     <string name="custom_source_url_dialog_title">Enter Website URL</string>
     <string name="custom_source_url_label">Website URL</string>
     <string name="custom_source_start_wizard">Start Setup</string>
+    <string name="custom_source_kind_novel_count">Novel (%1$d)</string>
+    <string name="custom_source_kind_manga_count">Manga (%1$d)</string>
     <string name="custom_source_source_name">Source name</string>
     <string name="custom_source_base_url">Base URL</string>
     <string name="custom_source_pick_from_site">Pick from website</string>
@@ -863,6 +865,8 @@
     <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
 
     <string name="action_sort_source_name">Source name</string>
+    <string name="pref_check_duplicate_on_add">Check for existing entries when adding to library</string>
+    <string name="pref_check_duplicate_on_add_summary">Warn about possible duplicates already in your library before adding</string>
     <string name="pref_show_manga_source_name">Show source name in manga details</string>
     <string name="pref_show_manga_source_name_summary">Display source name under status on manga details screen</string>
     <string name="pref_experimental_library_pagination">Experimental: paginate library (reduce memory)</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -865,6 +865,7 @@
     <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
 
     <string name="action_sort_source_name">Source name</string>
+    <string name="pref_duplicate_sort_mode">Duplicate list order</string>
     <string name="pref_migrate_source_sorting">Migrate source list sorting</string>
     <string name="pref_migrate_source_sorting_direction">Migrate source list order</string>
     <string name="pref_check_duplicate_on_add">Check for existing entries when adding to library</string>


### PR DESCRIPTION
Centralize how js sources appear in lists (consistent JS tag)
Fix extensions appearing as js tags by mistake in update job notification

In mangascreen, find duplicates dialog, migrate option removed the *target* entry from library, not current. 

Add option in library settings to skip checking for duplicate entries when adding an entry.
Add option in library settings to sort by chapter count in the migrate dialog

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
