### PR TITLE
Feat/quick migrate remove skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - ALt title import when tracking, case insensitive dupe check [@mrissaoussama](https://github.com/mrissaoussama) [#305](https://github.com/tsundoku-otaku/tsundoku/pull/305)
 - Mass import improvements and resume counting [@mrissaoussama](https://github.com/mrissaoussama) [#288](https://github.com/tsundoku-otaku/tsundoku/pull/288)
 - EPUBC ToC Subsection Fix [@mrissaoussama](https://github.com/mrissaoussama) [#315](https://github.com/tsundoku-otaku/tsundoku/pull/315)
+- Added option to migrate skipped quick migrate entries [@mrissaoussama](https://github.com/mrissaoussama) [#315](https://github.com/tsundoku-otaku/tsundoku/pull/362)
 - Append clipboard added in edit quotes [@Rojikku](https://github.com/Rojikku) [#301](https://github.com/tsundoku-otaku/tsundoku/pull/301)
 - Customsource improvements and url build fixes [@mrissaoussama](https://github.com/mrissaoussama) [#322](https://github.com/tsundoku-otaku/tsundoku/pull/322)
 - Prevent duplicate custom sources [@mrissaoussama](https://github.com/mrissaoussama) [#294](https://github.com/tsundoku-otaku/tsundoku/pull/294)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -203,6 +203,16 @@ class DownloadCache(
     }
 
     /**
+     * Suspends until the cache has been populated at least once. [renewCache] only schedules the
+     * scan, so a caller that treats a zero count as "nothing downloaded" has to wait for it -
+     * otherwise it reads an empty cache and concludes there is nothing on disk.
+     */
+    suspend fun awaitReady() {
+        renewCache()
+        renewalJob?.join()
+    }
+
+    /**
      * Returns downloaded chapter counts for multiple manga with a single cache refresh.
      */
     fun getDownloadCounts(mangaList: List<Manga>): Map<Long, Int> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -203,13 +203,15 @@ class DownloadCache(
     }
 
     /**
-     * Suspends until the cache has been populated at least once. [renewCache] only schedules the
-     * scan, so a caller that treats a zero count as "nothing downloaded" has to wait for it -
-     * otherwise it reads an empty cache and concludes there is nothing on disk.
+     * Populates the cache if needed and suspends until that scan ends. [renewCache] only schedules
+     * it, so a caller that reads a zero count as "nothing downloaded" has to wait. Returns false if
+     * the scan was cancelled or failed, i.e. the counts cannot be trusted.
      */
-    suspend fun awaitReady() {
+    suspend fun awaitReady(): Boolean {
         renewCache()
-        renewalJob?.join()
+        val job = renewalJob
+        job?.join()
+        return job?.isCancelled != true
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -286,9 +286,11 @@ class DownloadManager(
         return cache.getDownloadCounts(mangaList)
     }
 
-    /** Waits for the download cache's first scan, for callers that act on a count of zero. */
-    suspend fun awaitDownloadCacheReady() {
-        cache.awaitReady()
+    /** Returns false if the scan did not complete, i.e. a count of zero means nothing. */
+    suspend fun awaitDownloadCacheReady(): Boolean = cache.awaitReady()
+
+    fun invalidateDownloadCache() {
+        cache.invalidateCache()
     }
 
     fun cancelQueuedDownloads(downloads: List<Download>) {
@@ -451,9 +453,16 @@ class DownloadManager(
      * only renames within the same parent, so this copies the tree then deletes the original. Denies
      * the move if the destination already holds downloads.
      *
+     * @param invalidateCache rebuild the download index after the move. Pass false when moving many
+     * manga in a row and invalidate once at the end: each rebuild restarts the full SAF scan.
      * @return true if the move succeeded or there was nothing to move.
      */
-    suspend fun moveMangaToNewSource(manga: Manga, oldSource: Source, newSource: Source): Boolean {
+    suspend fun moveMangaToNewSource(
+        manga: Manga,
+        oldSource: Source,
+        newSource: Source,
+        invalidateCache: Boolean = true,
+    ): Boolean {
         if (oldSource.id == newSource.id) return true
         val oldFolder = provider.findMangaDir(manga.title, oldSource) ?: return true
 
@@ -473,11 +482,11 @@ class DownloadManager(
             // otherwise the non-empty-destination guard above would block every future retry.
             logcat(LogPriority.ERROR) { "Copy incomplete moving downloads for ${manga.title}; reverting" }
             deleteRecursive(destFolder)
-            cache.invalidateCache()
+            if (invalidateCache) cache.invalidateCache()
             return false
         }
         deleteRecursive(oldFolder)
-        cache.invalidateCache()
+        if (invalidateCache) cache.invalidateCache()
         return true
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -286,6 +286,11 @@ class DownloadManager(
         return cache.getDownloadCounts(mangaList)
     }
 
+    /** Waits for the download cache's first scan, for callers that act on a count of zero. */
+    suspend fun awaitDownloadCacheReady() {
+        cache.awaitReady()
+    }
+
     fun cancelQueuedDownloads(downloads: List<Download>) {
         removeFromDownloadQueue(downloads.map { it.toDomainChapter() })
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -490,6 +490,15 @@ class DownloadManager(
         return true
     }
 
+    /**
+     * Whether [source] holds a non-empty download folder for [mangaTitle]. Enumerates the source
+     * directory, so prefer [getDownloadCounts] where the cache can answer.
+     */
+    fun hasDownloadedChapters(mangaTitle: String, source: Source): Boolean {
+        val dir = provider.findMangaDir(mangaTitle, source) ?: return false
+        return !dir.listFiles().isNullOrEmpty()
+    }
+
     // Returns true only if every child copied; a false result must prevent deleting the source.
     private fun copyContentsRecursive(src: UniFile, dest: UniFile): Boolean {
         var ok = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -36,6 +36,7 @@ import mihon.feature.migration.config.MigrationConfigScreen
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
@@ -160,7 +161,9 @@ data class MigrateMangaScreen(
                     targetSourceName = dialog.targetSourceName,
                     totalCount = dialog.totalCount,
                     skipCount = dialog.skipCount,
-                    onConfirm = { screenModel.executeQuickMigrate(dialog.targetSourceId, it) },
+                    onConfirm = { categoryName, removeSkipped ->
+                        screenModel.executeQuickMigrate(dialog.targetSourceId, categoryName, removeSkipped)
+                    },
                     onDismissRequest = { screenModel.dismissDialog() },
                 )
             }
@@ -175,7 +178,15 @@ data class MigrateMangaScreen(
                     }
                     is MigrationMangaEvent.QuickMigrateComplete -> {
                         context.toast(
-                            context.stringResource(MR.strings.quick_migrate_complete, event.count),
+                            if (event.removedCount > 0) {
+                                context.stringResource(
+                                    TDMR.strings.quick_migrate_complete_removed,
+                                    event.count,
+                                    event.removedCount,
+                                )
+                            } else {
+                                context.stringResource(MR.strings.quick_migrate_complete, event.count)
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -143,64 +143,69 @@ class MigrateMangaScreenModel(
                     .mapTo(mutableSetOf()) { it.url }
                 val targets = quickMigrateTargets(selectedManga, targetFavoriteUrls)
                 val migratedIds = mutableListOf<Long>()
-                // Nothing to move: skip the download cache scan, which is a full SAF enumeration.
                 if (targets.isEmpty()) {
                     mutableState.update { it.copy(dialog = null, selection = emptySet()) }
                     _events.send(MigrationMangaEvent.QuickMigrateComplete(0))
                     return@launchIO
                 }
-                // Every entry on this screen belongs to [sourceId], and all of them move to the same
-                // target, so the source pair and the "what actually has data on disk" lookups are
-                // hoisted out of the loop. Each one is a SAF directory enumeration; per entry they
-                // dominate the run for a large selection, and most entries have nothing to move.
+
                 val oldSource = sourceManager.getOrStub(sourceId)
                 val newSource = sourceManager.getOrStub(targetSourceId)
-                val titles = targets.map { it.first.title }
-                // A count of zero decides that an entry has nothing to move, so the cache has to be
-                // populated first; unscanned, it reports zero for everything and downloads would be
-                // left behind under the old source name with the row already flipped. The count only
-                // covers chapter directories and cbz/zip archives, which is every layout a finished
-                // download uses, so nothing but an interrupted download's _tmp directory is skipped.
-                downloadManager.awaitDownloadCacheReady()
-                val downloadCounts = downloadManager.getDownloadCounts(targets.map { it.first })
+                val targetTitles = targets.mapTo(mutableSetOf()) { it.first.title }
+
+                val countsUsable = downloadManager.awaitDownloadCacheReady()
+                val downloadCounts = if (countsUsable) {
+                    downloadManager.getDownloadCounts(targets.map { it.first })
+                } else {
+                    emptyMap()
+                }
+
+                val queuedMangaIds = downloadManager.queueState.value.mapTo(mutableSetOf()) { it.mangaId }
+
                 val withTranslations = runCatching {
-                    translatedChapterRepository.filterNovelsWithTranslations(oldSource.toString(), titles)
-                }.getOrDefault(emptySet())
+                    translatedChapterRepository.filterNovelsWithTranslations(oldSource.toString(), targetTitles)
+                }.onFailure {
+                    logcat(LogPriority.ERROR, it) { "Failed to list translations on quick migrate" }
+                }.getOrNull()
                 val withQuotes = runCatching {
-                    quoteManager.filterNovelsWithQuotes(oldSource.toString(), titles)
-                }.getOrDefault(emptySet())
-                // Written in chunks rather than one update per entry: each write is its own
-                // transaction that invalidates the library cache and wakes every query listener.
+                    quoteManager.filterNovelsWithQuotes(oldSource.toString(), targetTitles)
+                }.onFailure {
+                    logcat(LogPriority.ERROR, it) { "Failed to list quotes on quick migrate" }
+                }.getOrNull()
                 val pendingUpdates = mutableListOf<MangaUpdate>()
                 val pendingIds = mutableListOf<Long>()
                 suspend fun flushUpdates(force: Boolean) {
                     if (pendingUpdates.isEmpty() || (!force && pendingUpdates.size < UPDATE_CHUNK_SIZE)) return
-                    // awaitAll reports a failed transaction with false rather than throwing, and the
-                    // whole chunk fails together, so a failed chunk must not count as migrated: its
-                    // rows still point at the old source, files already moved or not.
-                    val written = updateManga.awaitAll(pendingUpdates.toList())
-                    if (!written) {
+                    val chunk = pendingUpdates.toList()
+                    val chunkIds = pendingIds.toList()
+                    pendingUpdates.clear()
+                    pendingIds.clear()
+
+                    if (updateManga.awaitAll(chunk)) {
+                        migratedIds.addAll(chunkIds)
+                    } else {
                         logcat(LogPriority.ERROR) {
-                            "Quick migrate: failed to write a chunk of ${pendingUpdates.size} entries"
+                            "Quick migrate: failed to write a chunk of ${chunk.size} entries"
                         }
                     }
-                    pendingUpdates.clear()
-                    if (written) migratedIds.addAll(pendingIds)
-                    pendingIds.clear()
                 }
+                var attemptedDownloadMove = false
                 for ((manga, newUrl) in targets) {
                     try {
                         // Relocate source-keyed data (downloads/translations/quotes) BEFORE flipping the
                         // DB source, so a crash in between can't leave files under the old source name
-                        // while the DB already points at the new one (orphaned data). Only preserves
-                        // data for same-URL migrations (e.g. JS->KT); different-site moves change
-                        // chapter URLs and won't line up.
+                        // while the DB already points at the new one. Only preserves data for same-URL
+                        // migrations (e.g. JS->KT); different-site moves change chapter URLs.
                         // moveMangaToNewSource reports non-crash failures (destination collision,
-                        // partial copy) via a false return, not an exception, so branch on the value:
+                        // partial copy) with false rather than an exception, so branch on the value:
                         // leave the manga on its old source rather than flipping the DB onto downloads
                         // that never moved. It can be retried once the conflict is resolved.
-                        val downloadsMoved = (downloadCounts[manga.id] ?: 0) == 0 || runCatching {
-                            downloadManager.moveMangaToNewSource(manga, oldSource, newSource)
+                        val hasDownloads = !countsUsable ||
+                            (downloadCounts[manga.id] ?: 0) > 0 ||
+                            manga.id in queuedMangaIds
+                        if (hasDownloads) attemptedDownloadMove = true
+                        val downloadsMoved = !hasDownloads || runCatching {
+                            downloadManager.moveMangaToNewSource(manga, oldSource, newSource, invalidateCache = false)
                         }.onFailure {
                             logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" }
                         }.getOrDefault(false)
@@ -210,7 +215,7 @@ class MigrateMangaScreenModel(
                             }
                             continue
                         }
-                        if (manga.title in withTranslations) {
+                        if (withTranslations == null || manga.title in withTranslations) {
                             runCatching {
                                 translatedChapterRepository.moveNovel(
                                     oldSource.toString(),
@@ -222,7 +227,7 @@ class MigrateMangaScreenModel(
                                 logcat(LogPriority.ERROR, it) { "Failed to move translations on quick migrate" }
                             }
                         }
-                        if (manga.title in withQuotes) {
+                        if (withQuotes == null || manga.title in withQuotes) {
                             runCatching {
                                 quoteManager.moveNovel(
                                     oldSource.toString(),
@@ -242,6 +247,9 @@ class MigrateMangaScreenModel(
                     }
                 }
                 flushUpdates(force = true)
+                // One rebuild for the whole run instead of one per relocated entry, each of which
+                // deletes the on-disk index and restarts the full SAF scan.
+                if (attemptedDownloadMove) downloadManager.invalidateDownloadCache()
                 val migrated = migratedIds.size
 
                 if (migratedIds.isNotEmpty() && trackPreferences.migrationTriggersSourceTracker.get()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -135,27 +135,39 @@ class MigrateMangaScreenModel(
         }
     }
 
-    fun executeQuickMigrate(targetSourceId: Long, categoryName: String?) {
+    fun executeQuickMigrate(targetSourceId: Long, categoryName: String?, removeSkipped: Boolean) {
         screenModelScope.launchIO {
             try {
                 val selectedManga = state.value.titles.filter { it.id in state.value.selection }
-                val targetFavoriteUrls = getFavorites.subscribe(targetSourceId).first()
-                    .mapTo(mutableSetOf()) { it.url }
+                val targetFavorites = getFavorites.subscribe(targetSourceId).first()
+                val targetFavoriteUrls = targetFavorites.mapTo(mutableSetOf()) { it.url }
                 val targets = quickMigrateTargets(selectedManga, targetFavoriteUrls)
+                val skipped = if (removeSkipped) {
+                    quickMigrateSkipped(selectedManga, targetFavoriteUrls)
+                } else {
+                    emptyList()
+                }
                 val migratedIds = mutableListOf<Long>()
-                if (targets.isEmpty()) {
+                if (targets.isEmpty() && skipped.isEmpty()) {
                     mutableState.update { it.copy(dialog = null, selection = emptySet()) }
-                    _events.send(MigrationMangaEvent.QuickMigrateComplete(0))
+                    _events.send(MigrationMangaEvent.QuickMigrateComplete(0, 0))
                     return@launchIO
                 }
 
                 val oldSource = sourceManager.getOrStub(sourceId)
                 val newSource = sourceManager.getOrStub(targetSourceId)
                 val targetTitles = targets.mapTo(mutableSetOf()) { it.first.title }
+                // The entry that stays behind for a skipped one, matched the same way the skip was:
+                // on the normalized url, not the title, which the two can disagree on.
+                val keptByUrl = targetFavorites.associateBy { it.url }
+                val keptForSkipped = skipped.associate { it.id to keptByUrl[normalizeQuickMigrateUrl(it.url)] }
 
                 val countsUsable = downloadManager.awaitDownloadCacheReady()
                 val downloadCounts = if (countsUsable) {
-                    downloadManager.getDownloadCounts(targets.map { it.first })
+                    downloadManager.getDownloadCounts(
+                        (targets.map { it.first } + skipped + keptForSkipped.values.filterNotNull())
+                            .distinctBy { it.id },
+                    )
                 } else {
                     emptyMap()
                 }
@@ -190,6 +202,16 @@ class MigrateMangaScreenModel(
                     }
                 }
                 var attemptedDownloadMove = false
+                val removal = relocateAndRemoveSkipped(
+                    skipped = skipped,
+                    keptForSkipped = keptForSkipped,
+                    oldSource = oldSource,
+                    newSource = newSource,
+                    downloadCounts = downloadCounts,
+                    countsUsable = countsUsable,
+                    queuedMangaIds = queuedMangaIds,
+                )
+                if (removal.touchedDownloads) attemptedDownloadMove = true
                 for ((manga, newUrl) in targets) {
                     try {
                         // Relocate source-keyed data (downloads/translations/quotes) BEFORE flipping the
@@ -279,7 +301,7 @@ class MigrateMangaScreenModel(
                 }
 
                 mutableState.update { it.copy(dialog = null, selection = emptySet()) }
-                _events.send(MigrationMangaEvent.QuickMigrateComplete(migrated))
+                _events.send(MigrationMangaEvent.QuickMigrateComplete(migrated, removal.removed))
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR, e) { "Quick migrate execute failed" }
                 mutableState.update { it.copy(dialog = null) }
@@ -287,6 +309,107 @@ class MigrateMangaScreenModel(
             }
         }
     }
+
+    /**
+     * Hands a skipped entry's data to the entry that stays and then takes the skipped one out of the
+     * library, in the same chunks the migration writes with.
+     *
+     * A skipped entry is one the target source already has, so its downloads, translations and
+     * quotes are relocated exactly like a migrated entry's, under the kept entry's title, which is
+     * where that entry looks for them. The old copy is deleted only when the kept one already holds
+     * downloads of its own: every other relocation failure leaves the only copy on disk.
+     */
+    private suspend fun relocateAndRemoveSkipped(
+        skipped: List<Manga>,
+        keptForSkipped: Map<Long, Manga?>,
+        oldSource: Source,
+        newSource: Source,
+        downloadCounts: Map<Long, Int>,
+        countsUsable: Boolean,
+        queuedMangaIds: Set<Long>,
+    ): SkippedRemoval {
+        if (skipped.isEmpty()) return SkippedRemoval(removed = 0, touchedDownloads = false)
+        val titles = skipped.mapTo(mutableSetOf()) { it.title }
+        val withTranslations = runCatching {
+            translatedChapterRepository.filterNovelsWithTranslations(oldSource.toString(), titles)
+        }.onFailure {
+            logcat(LogPriority.ERROR, it) { "Failed to list translations for skipped entries" }
+        }.getOrNull()
+        val withQuotes = runCatching {
+            quoteManager.filterNovelsWithQuotes(oldSource.toString(), titles)
+        }.onFailure {
+            logcat(LogPriority.ERROR, it) { "Failed to list quotes for skipped entries" }
+        }.getOrNull()
+
+        var removed = 0
+        var touchedDownloads = false
+        skipped.chunked(UPDATE_CHUNK_SIZE).forEach { chunk ->
+            chunk.forEach { manga ->
+                val kept = keptForSkipped[manga.id]
+                val keptTitle = kept?.title ?: manga.title
+                val hasDownloads = !countsUsable ||
+                    (downloadCounts[manga.id] ?: 0) > 0 ||
+                    manga.id in queuedMangaIds
+                if (hasDownloads) {
+                    touchedDownloads = true
+                    val keptHasDownloads = if (countsUsable && kept != null) {
+                        (downloadCounts[kept.id] ?: 0) > 0
+                    } else {
+                        downloadManager.hasDownloadedChapters(keptTitle, newSource)
+                    }
+                    if (keptHasDownloads) {
+                        downloadManager.deleteManga(manga, oldSource)
+                    } else {
+                        runCatching {
+                            if (keptTitle != manga.title) {
+                                downloadManager.renameManga(manga, keptTitle)
+                            }
+                            downloadManager.moveMangaToNewSource(
+                                manga.copy(title = keptTitle),
+                                oldSource,
+                                newSource,
+                                invalidateCache = false,
+                            )
+                        }.onFailure {
+                            logcat(LogPriority.ERROR, it) { "Failed to move downloads for a skipped entry" }
+                        }
+                    }
+                }
+                if (withTranslations == null || manga.title in withTranslations) {
+                    runCatching {
+                        translatedChapterRepository.moveNovel(
+                            oldSource.toString(),
+                            manga.title,
+                            newSource.toString(),
+                            keptTitle,
+                        )
+                    }.onFailure {
+                        logcat(LogPriority.ERROR, it) { "Failed to move translations for a skipped entry" }
+                    }
+                }
+                if (withQuotes == null || manga.title in withQuotes) {
+                    runCatching {
+                        quoteManager.moveNovel(
+                            oldSource.toString(),
+                            manga.title,
+                            newSource.toString(),
+                            keptTitle,
+                        )
+                    }.onFailure {
+                        logcat(LogPriority.ERROR, it) { "Failed to move quotes for a skipped entry" }
+                    }
+                }
+            }
+            if (updateManga.awaitAll(chunk.map { MangaUpdate(id = it.id, favorite = false) })) {
+                removed += chunk.size
+            } else {
+                logcat(LogPriority.ERROR) { "Failed to remove a chunk of ${chunk.size} skipped entries" }
+            }
+        }
+        return SkippedRemoval(removed = removed, touchedDownloads = touchedDownloads)
+    }
+
+    private data class SkippedRemoval(val removed: Int, val touchedDownloads: Boolean)
 
     @Immutable
     data class State(
@@ -322,7 +445,7 @@ class MigrateMangaScreenModel(
 
 sealed interface MigrationMangaEvent {
     data object FailedFetchingFavorites : MigrationMangaEvent
-    data class QuickMigrateComplete(val count: Int) : MigrationMangaEvent
+    data class QuickMigrateComplete(val count: Int, val removedCount: Int = 0) : MigrationMangaEvent
 }
 
 // Small enough that a crash leaves at most this many entries with their files already relocated
@@ -345,3 +468,9 @@ internal fun quickMigrateTargets(
         val newUrl = normalizeQuickMigrateUrl(manga.url)
         if (newUrl in existingFavoriteUrls) null else manga to newUrl
     }
+
+/** The other half of [quickMigrateTargets]: the entries the target source already has. */
+internal fun quickMigrateSkipped(
+    selected: List<Manga>,
+    existingFavoriteUrls: Set<String>,
+): List<Manga> = selected.filter { normalizeQuickMigrateUrl(it.url) in existingFavoriteUrls }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -141,11 +141,55 @@ class MigrateMangaScreenModel(
                 val selectedManga = state.value.titles.filter { it.id in state.value.selection }
                 val targetFavoriteUrls = getFavorites.subscribe(targetSourceId).first()
                     .mapTo(mutableSetOf()) { it.url }
+                val targets = quickMigrateTargets(selectedManga, targetFavoriteUrls)
                 val migratedIds = mutableListOf<Long>()
-                for ((manga, newUrl) in quickMigrateTargets(selectedManga, targetFavoriteUrls)) {
+                // Nothing to move: skip the download cache scan, which is a full SAF enumeration.
+                if (targets.isEmpty()) {
+                    mutableState.update { it.copy(dialog = null, selection = emptySet()) }
+                    _events.send(MigrationMangaEvent.QuickMigrateComplete(0))
+                    return@launchIO
+                }
+                // Every entry on this screen belongs to [sourceId], and all of them move to the same
+                // target, so the source pair and the "what actually has data on disk" lookups are
+                // hoisted out of the loop. Each one is a SAF directory enumeration; per entry they
+                // dominate the run for a large selection, and most entries have nothing to move.
+                val oldSource = sourceManager.getOrStub(sourceId)
+                val newSource = sourceManager.getOrStub(targetSourceId)
+                val titles = targets.map { it.first.title }
+                // A count of zero decides that an entry has nothing to move, so the cache has to be
+                // populated first; unscanned, it reports zero for everything and downloads would be
+                // left behind under the old source name with the row already flipped. The count only
+                // covers chapter directories and cbz/zip archives, which is every layout a finished
+                // download uses, so nothing but an interrupted download's _tmp directory is skipped.
+                downloadManager.awaitDownloadCacheReady()
+                val downloadCounts = downloadManager.getDownloadCounts(targets.map { it.first })
+                val withTranslations = runCatching {
+                    translatedChapterRepository.filterNovelsWithTranslations(oldSource.toString(), titles)
+                }.getOrDefault(emptySet())
+                val withQuotes = runCatching {
+                    quoteManager.filterNovelsWithQuotes(oldSource.toString(), titles)
+                }.getOrDefault(emptySet())
+                // Written in chunks rather than one update per entry: each write is its own
+                // transaction that invalidates the library cache and wakes every query listener.
+                val pendingUpdates = mutableListOf<MangaUpdate>()
+                val pendingIds = mutableListOf<Long>()
+                suspend fun flushUpdates(force: Boolean) {
+                    if (pendingUpdates.isEmpty() || (!force && pendingUpdates.size < UPDATE_CHUNK_SIZE)) return
+                    // awaitAll reports a failed transaction with false rather than throwing, and the
+                    // whole chunk fails together, so a failed chunk must not count as migrated: its
+                    // rows still point at the old source, files already moved or not.
+                    val written = updateManga.awaitAll(pendingUpdates.toList())
+                    if (!written) {
+                        logcat(LogPriority.ERROR) {
+                            "Quick migrate: failed to write a chunk of ${pendingUpdates.size} entries"
+                        }
+                    }
+                    pendingUpdates.clear()
+                    if (written) migratedIds.addAll(pendingIds)
+                    pendingIds.clear()
+                }
+                for ((manga, newUrl) in targets) {
                     try {
-                        val oldSource = sourceManager.getOrStub(manga.source)
-                        val newSource = sourceManager.getOrStub(targetSourceId)
                         // Relocate source-keyed data (downloads/translations/quotes) BEFORE flipping the
                         // DB source, so a crash in between can't leave files under the old source name
                         // while the DB already points at the new one (orphaned data). Only preserves
@@ -155,7 +199,7 @@ class MigrateMangaScreenModel(
                         // partial copy) via a false return, not an exception, so branch on the value:
                         // leave the manga on its old source rather than flipping the DB onto downloads
                         // that never moved. It can be retried once the conflict is resolved.
-                        val downloadsMoved = runCatching {
+                        val downloadsMoved = (downloadCounts[manga.id] ?: 0) == 0 || runCatching {
                             downloadManager.moveMangaToNewSource(manga, oldSource, newSource)
                         }.onFailure {
                             logcat(LogPriority.ERROR, it) { "Failed to move downloads on quick migrate" }
@@ -166,28 +210,38 @@ class MigrateMangaScreenModel(
                             }
                             continue
                         }
-                        runCatching {
-                            translatedChapterRepository.moveNovel(
-                                oldSource.toString(),
-                                manga.title,
-                                newSource.toString(),
-                                manga.title,
-                            )
-                        }.onFailure { logcat(LogPriority.ERROR, it) { "Failed to move translations on quick migrate" } }
-                        runCatching {
-                            quoteManager.moveNovel(
-                                oldSource.toString(),
-                                manga.title,
-                                newSource.toString(),
-                                manga.title,
-                            )
-                        }.onFailure { logcat(LogPriority.ERROR, it) { "Failed to move quotes on quick migrate" } }
-                        updateManga.await(MangaUpdate(id = manga.id, source = targetSourceId, url = newUrl))
-                        migratedIds.add(manga.id)
+                        if (manga.title in withTranslations) {
+                            runCatching {
+                                translatedChapterRepository.moveNovel(
+                                    oldSource.toString(),
+                                    manga.title,
+                                    newSource.toString(),
+                                    manga.title,
+                                )
+                            }.onFailure {
+                                logcat(LogPriority.ERROR, it) { "Failed to move translations on quick migrate" }
+                            }
+                        }
+                        if (manga.title in withQuotes) {
+                            runCatching {
+                                quoteManager.moveNovel(
+                                    oldSource.toString(),
+                                    manga.title,
+                                    newSource.toString(),
+                                    manga.title,
+                                )
+                            }.onFailure {
+                                logcat(LogPriority.ERROR, it) { "Failed to move quotes on quick migrate" }
+                            }
+                        }
+                        pendingUpdates.add(MangaUpdate(id = manga.id, source = targetSourceId, url = newUrl))
+                        pendingIds.add(manga.id)
+                        flushUpdates(force = false)
                     } catch (_: Exception) {
                         // Skip entries that fail to update; the rest still migrate.
                     }
                 }
+                flushUpdates(force = true)
                 val migrated = migratedIds.size
 
                 if (migratedIds.isNotEmpty() && trackPreferences.migrationTriggersSourceTracker.get()) {
@@ -262,6 +316,10 @@ sealed interface MigrationMangaEvent {
     data object FailedFetchingFavorites : MigrationMangaEvent
     data class QuickMigrateComplete(val count: Int) : MigrationMangaEvent
 }
+
+// Small enough that a crash leaves at most this many entries with their files already relocated
+// but their row not yet flipped, large enough to keep the transaction count down on a bulk migrate.
+private const val UPDATE_CHUNK_SIZE = 200
 
 /** Leading-slash normalization matching how source urls are stored. */
 internal fun normalizeQuickMigrateUrl(url: String): String = if (url.startsWith("/")) url else "/$url"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/QuickMigrateDialogs.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/QuickMigrateDialogs.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.source.CatalogueSource
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
@@ -115,11 +116,12 @@ fun QuickMigrateConfirmDialog(
     targetSourceName: String,
     totalCount: Int,
     skipCount: Int,
-    onConfirm: (String?) -> Unit,
+    onConfirm: (String?, Boolean) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     var createCategory by remember { mutableStateOf(true) }
     var categoryName by remember { mutableStateOf("$sourceName - $targetSourceName") }
+    var removeSkipped by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -141,6 +143,28 @@ fun QuickMigrateConfirmDialog(
                         color = MaterialTheme.colorScheme.error,
                         modifier = Modifier.padding(top = 8.dp),
                     )
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp)
+                            .clickable { removeSkipped = !removeSkipped },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = removeSkipped,
+                            onCheckedChange = { removeSkipped = it },
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Column {
+                            Text(text = stringResource(TDMR.strings.quick_migrate_remove_skipped))
+                            Text(
+                                text = stringResource(TDMR.strings.quick_migrate_remove_skipped_summary),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
                 }
 
                 Row(
@@ -172,7 +196,7 @@ fun QuickMigrateConfirmDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(if (createCategory) categoryName else null) }) {
+            TextButton(onClick = { onConfirm(if (createCategory) categoryName else null, removeSkipped) }) {
                 Text(text = stringResource(MR.strings.migrate))
             }
         },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -97,6 +97,21 @@ class QuoteManager(private val context: Context) {
     }
 
     /**
+     * Of [novelTitles], the ones that actually have a quotes file under [sourceName]. Lists the
+     * source directory once instead of probing per title, which matters for bulk operations:
+     * every probe is a SAF lookup that enumerates the directory again.
+     */
+    fun filterNovelsWithQuotes(sourceName: String, novelTitles: Collection<String>): Set<String> {
+        if (novelTitles.isEmpty()) return emptySet()
+        val existing = findSourceDir(sourceName)
+            ?.takeIf { it.isDirectory }
+            ?.listFiles()
+            ?.mapNotNullTo(mutableSetOf()) { it.name }
+            ?: return emptySet()
+        return novelTitles.filterTo(mutableSetOf()) { getNovelFileName(it) in existing }
+    }
+
+    /**
      * Save quotes for a novel
      */
     fun saveQuotes(sourceName: String, novelTitle: String, quotes: List<Quote>): Boolean =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/quote/QuoteManager.kt
@@ -97,9 +97,8 @@ class QuoteManager(private val context: Context) {
     }
 
     /**
-     * Of [novelTitles], the ones that actually have a quotes file under [sourceName]. Lists the
-     * source directory once instead of probing per title, which matters for bulk operations:
-     * every probe is a SAF lookup that enumerates the directory again.
+     * Of [novelTitles], the ones that have a quotes file under [sourceName]. Lists the source
+     * directory once, where probing per title is a SAF enumeration of it per probe.
      */
     fun filterNovelsWithQuotes(sourceName: String, novelTitles: Collection<String>): Set<String> {
         if (novelTitles.isEmpty()) return emptySet()

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModelTest.kt
@@ -43,5 +43,23 @@ class MigrateMangaScreenModelTest {
         val selected = listOf(manga(1, "a"), manga(2, "b"))
 
         assertEquals(2, quickMigrateTargets(selected, emptySet()).size)
+        assertEquals(emptyList<Manga>(), quickMigrateSkipped(selected, emptySet()))
+    }
+
+    @Test
+    fun `skipped is exactly what targets leaves out`() {
+        val selected = listOf(
+            manga(1, "series/a"),
+            manga(2, "/series/b"),
+            manga(3, "series/c"),
+        )
+        val existing = setOf("/series/b", "/series/c")
+
+        val targets = quickMigrateTargets(selected, existing)
+        val skipped = quickMigrateSkipped(selected, existing)
+
+        assertEquals(listOf(1L), targets.map { it.first.id })
+        assertEquals(listOf(2L, 3L), skipped.map { it.id })
+        assertEquals(selected.size, targets.size + skipped.size)
     }
 }

--- a/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/translation/TranslatedChapterRepositoryImpl.kt
@@ -593,6 +593,19 @@ class TranslatedChapterRepositoryImpl(
         Unit
     }
 
+    override suspend fun filterNovelsWithTranslations(
+        sourceName: String,
+        novelTitles: Collection<String>,
+    ): Set<String> = withContext(Dispatchers.IO) {
+        if (novelTitles.isEmpty()) return@withContext emptySet()
+        val existing = translationsDir.findFile(sourceDirName(sourceName))
+            ?.takeIf { it.isDirectory }
+            ?.listFiles()
+            ?.mapNotNullTo(mutableSetOf()) { it.name }
+            ?: return@withContext emptySet()
+        novelTitles.filterTo(mutableSetOf()) { novelDirName(it) in existing }
+    }
+
     // SAF renameTo only renames within the same parent, so a cross-source move is copy-then-delete.
     // Returns true only if every child copied; a false result must prevent deleting the source.
     private fun copyContentsRecursive(src: UniFile, dest: UniFile): Boolean {

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -104,9 +104,8 @@ interface TranslatedChapterRepository {
     suspend fun moveNovel(oldSourceName: String, oldTitle: String, newSourceName: String, newTitle: String)
 
     /**
-     * Of [novelTitles], the ones that actually have translations under [sourceName]. Lists the
-     * source directory once instead of probing per title, which matters for bulk operations:
-     * every probe is a SAF lookup that enumerates the directory again.
+     * Of [novelTitles], the ones that have translations under [sourceName]. Lists the source
+     * directory once, where probing per title is a SAF enumeration of it per probe.
      */
     suspend fun filterNovelsWithTranslations(sourceName: String, novelTitles: Collection<String>): Set<String>
 

--- a/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/repository/TranslatedChapterRepository.kt
@@ -104,6 +104,13 @@ interface TranslatedChapterRepository {
     suspend fun moveNovel(oldSourceName: String, oldTitle: String, newSourceName: String, newTitle: String)
 
     /**
+     * Of [novelTitles], the ones that actually have translations under [sourceName]. Lists the
+     * source directory once instead of probing per title, which matters for bulk operations:
+     * every probe is a SAF lookup that enumerates the directory again.
+     */
+    suspend fun filterNovelsWithTranslations(sourceName: String, novelTitles: Collection<String>): Set<String>
+
+    /**
      * Delete all translations.
      */
     suspend fun deleteAll()

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -862,6 +862,10 @@
     <string name="db_maintenance_already_running">Database maintenance is already running</string>
     <string name="db_maintenance_started">Database maintenance started &#8212; check notifications for progress</string>
 
+    <string name="quick_migrate_remove_skipped">Remove skipped entries</string>
+    <string name="quick_migrate_remove_skipped_summary">Their downloads, translations and quotes move to the copy that stays</string>
+    <string name="quick_migrate_complete_removed">Quick migrated %1$d entries, removed %2$d</string>
+
     <string name="action_sort_source_name">Source name</string>
     <string name="pref_show_manga_source_name">Show source name in manga details</string>
     <string name="pref_show_manga_source_name_summary">Display source name under status on manga details screen</string>


### PR DESCRIPTION
Add option to remove skipped entries when using quick migrate
downloads, translations ect are also moved for skipped entries if they exist