### PR TITLE
fix(source): fetch details and chapters through getMangaUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)
 - Fix for an Injekt related exception tied to performance improvements, should keep performance [@mrissaoussama](https://github.com/mrissaoussama) [#352](https://github.com/tsundoku-otaku/tsundoku/pull/352)
+- Properly fetch details and chapters through new getMangaUpdate [@mrissaoussama](https://github.com/mrissaoussama) [#363](https://github.com/tsundoku-otaku/tsundoku/pull/363)
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Volume keys no longer scroll while menu visible [@mrissaoussama](https://github.com/mrissaoussama) [#345](https://github.com/tsundoku-otaku/tsundoku/pull/345)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/ImportEpub.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/ImportEpub.kt
@@ -236,11 +236,14 @@ class ImportEpub(
                     ),
                 )
 
-                val networkManga = source.getMangaDetails(manga.toSManga())
-                updateManga.awaitUpdateFromSource(manga, networkManga, manualFetch = true)
-
-                val chapters = source.getChapterList(manga.toSManga())
-                syncChaptersWithSource.await(chapters, manga, source, manualFetch = true)
+                val update = source.getMangaUpdate(
+                    manga.toSManga(),
+                    emptyList(),
+                    fetchDetails = true,
+                    fetchChapters = true,
+                )
+                updateManga.awaitUpdateFromSource(manga, update.manga, manualFetch = true)
+                syncChaptersWithSource.await(update.chapters, manga, source, manualFetch = true)
 
                 val updatedManga = mangaRepository.getMangaById(manga.id)
                 getLibraryManga.addToLibrary(updatedManga.id)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
@@ -59,11 +59,14 @@ class MassImport(
             resolved = runCatching { source.getManga(url) }.getOrNull()
         }
 
-        val sManga = resolved ?: source.getMangaDetails(
+        val sManga = resolved ?: source.getMangaUpdate(
             eu.kanade.tachiyomi.source.model.SManga.create().apply {
                 this.url = inputUrl
             },
-        )
+            emptyList(),
+            fetchDetails = true,
+            fetchChapters = false,
+        ).manga
 
         try {
             val resolvedUrl = runCatching { sManga.url }.getOrNull().orEmpty()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -18,9 +18,6 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkQuery
 import androidx.work.WorkerParameters
-import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
-import eu.kanade.domain.chapter.model.toRefreshContextChapters
-import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.notification.Notifications
@@ -47,12 +44,12 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
 import mihon.domain.chapter.interactor.FilterChaptersForDownload
+import mihon.domain.source.interactor.UpdateMangaFromRemote
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.getAndSet
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.model.NoChaptersException
 import tachiyomi.domain.download.service.NovelDownloadPreferences
@@ -97,11 +94,9 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val downloadManager: DownloadManager = Injekt.get()
     private val getLibraryManga: GetLibraryManga = Injekt.get()
     private val getManga: GetManga = Injekt.get()
-    private val updateManga: UpdateManga = Injekt.get()
-    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
-    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get()
     private val fetchInterval: FetchInterval = Injekt.get()
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get()
+    private val updateMangaFromRemote: UpdateMangaFromRemote = Injekt.get()
     private val novelDownloadPreferences: NovelDownloadPreferences = Injekt.get()
 
     private val notifier = LibraryUpdateNotifier(context)
@@ -476,27 +471,17 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private suspend fun updateManga(manga: Manga, fetchWindow: Pair<Long, Long>): List<Chapter> {
         val source = sourceManager.getOrStub(manga.source)
 
-        // Update manga metadata if needed
-        if (forceFetchDetails || libraryPreferences.autoUpdateMetadata.get()) {
-            val networkManga = source.getMangaDetails(manga.toSManga())
-            updateManga.awaitUpdateFromSource(manga, networkManga, manualFetch = forceFetchDetails)
-        }
+        val update = updateMangaFromRemote(
+            source = source,
+            manga = manga,
+            fetchDetails = forceFetchDetails || libraryPreferences.autoUpdateMetadata.get(),
+            fetchChapters = !skipChapterFetch,
+            manualFetch = forceFetchDetails,
+            fetchWindow = fetchWindow,
+        )
+            .getOrThrow()
 
-        if (skipChapterFetch) return emptyList()
-
-        val existingChapters = getChaptersByMangaId.await(manga.id)
-        val chapters = source.getMangaUpdate(
-            manga.toSManga(),
-            existingChapters.toRefreshContextChapters(),
-            fetchDetails = false,
-            fetchChapters = true,
-        ).chapters
-
-        // Get manga from database to account for if it was removed during the update and
-        // to get latest data so it doesn't get overwritten later on
-        val dbManga = getManga.await(manga.id)?.takeIf { it.favorite } ?: return emptyList()
-
-        return syncChaptersWithSource.await(chapters, dbManga, source, false, fetchWindow)
+        return if (update.manga.favorite) update.newChapters else emptyList()
     }
 
     private suspend fun withUpdateNotification(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -1029,7 +1029,12 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             if (fetchChapters) {
                 try {
                     val sChapters = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
-                        source.getChapterList(manga.toSManga())
+                        source.getMangaUpdate(
+                            manga.toSManga(),
+                            emptyList(),
+                            fetchDetails = false,
+                            fetchChapters = true,
+                        ).chapters
                     } ?: throw java.io.IOException("Timed out fetching chapters for $url")
                     syncChaptersWithSource.await(sChapters, manga.copy(favorite = true), source)
                 } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/custom/CustomNovelSource.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.Serializable
@@ -560,16 +561,37 @@ class CustomNovelSource(
         return super.getSearchManga(page, query, filters)
     }
 
-    override suspend fun getMangaDetails(manga: SManga): SManga {
+    override suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
         baseSource?.let { source ->
-            return rebaseManga(source.getMangaDetails(toBaseSourceManga(manga)))
+            val update = source.getMangaUpdate(
+                toBaseSourceManga(manga),
+                chapters.map { toBaseSourceChapter(it) },
+                fetchDetails = fetchDetails,
+                fetchChapters = fetchChapters,
+            )
+            return SMangaUpdate(
+                manga = if (fetchDetails) rebaseManga(update.manga) else manga,
+                chapters = if (fetchChapters) update.chapters.map { rebaseChapter(it) } else chapters,
+            )
+        }
+        return super.getMangaUpdate(manga, chapters, fetchDetails, fetchChapters)
+    }
+
+    override suspend fun getMangaDetails(manga: SManga): SManga {
+        if (baseSource != null) {
+            return getMangaUpdate(manga, emptyList(), fetchDetails = true, fetchChapters = false).manga
         }
         return super.getMangaDetails(manga)
     }
 
     override suspend fun getChapterList(manga: SManga): List<SChapter> {
-        baseSource?.let { source ->
-            return source.getChapterList(toBaseSourceManga(manga)).map { rebaseChapter(it) }
+        if (baseSource != null) {
+            return getMangaUpdate(manga, emptyList(), fetchDetails = false, fetchChapters = true).chapters
         }
         val chSel = config.selectors.chapters
         if (isNovelSource && !chSel.urlPattern.isNullOrBlank()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -16,14 +16,11 @@ import eu.kanade.core.util.addOrRemove
 import eu.kanade.core.util.insertSeparators
 import eu.kanade.domain.chapter.interactor.GetAvailableScanlators
 import eu.kanade.domain.chapter.interactor.SetReadStatus
-import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
-import eu.kanade.domain.chapter.model.toRefreshContextChapters
 import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.manga.model.chaptersFiltered
 import eu.kanade.domain.manga.model.downloadedFilter
-import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.domain.track.interactor.RefreshTracks
 import eu.kanade.domain.track.interactor.TrackChapter
@@ -48,9 +45,8 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
 import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -61,6 +57,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import mihon.domain.chapter.interactor.FilterChaptersForDownload
+import mihon.domain.source.interactor.UpdateMangaFromRemote
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.core.common.preference.TriState
@@ -130,7 +127,6 @@ class MangaScreenModel(
     private val updateManga: UpdateManga = Injekt.get(),
     private val setCustomMangaInfo: tachiyomi.domain.manga.interactor.SetCustomMangaInfo = Injekt.get(),
     private val updateMangaNotes: tachiyomi.domain.manga.interactor.UpdateMangaNotes = Injekt.get(),
-    private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get(),
     private val getCategories: GetCategories = Injekt.get(),
     private val getTracks: GetTracks = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
@@ -142,6 +138,7 @@ class MangaScreenModel(
     private val translatedChapterRepository: TranslatedChapterRepository = Injekt.get(),
     private val translationService: TranslationService = Injekt.get(),
     private val getLibraryManga: GetLibraryManga = Injekt.get(),
+    private val updateMangaFromRemote: UpdateMangaFromRemote = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -310,10 +307,12 @@ class MangaScreenModel(
     fun fetchAllFromSource(manualFetch: Boolean = true, forceRefresh: Boolean = false) {
         screenModelScope.launch {
             updateSuccessState { it.copy(isRefreshingData = true) }
-            listOf(
-                async { fetchMangaFromSource(manualFetch) },
-                async { fetchChaptersFromSource(manualFetch, forceRefresh) },
-            ).awaitAll()
+            fetchAllFromSource(
+                manualFetch = manualFetch,
+                fetchDetails = true,
+                fetchChapters = true,
+                forceRefresh = forceRefresh,
+            )
             updateSuccessState { it.copy(isRefreshingData = false) }
         }
     }
@@ -322,32 +321,50 @@ class MangaScreenModel(
         manualFetch: Boolean,
         fetchDetails: Boolean,
         fetchChapters: Boolean,
+        forceRefresh: Boolean = false,
     ) {
-        coroutineScope {
-            val tasks = buildList {
-                if (fetchDetails) add(async { fetchMangaFromSource(manualFetch) })
-                if (fetchChapters) add(async { fetchChaptersFromSource(manualFetch) })
-            }
-            tasks.awaitAll()
-        }
-    }
-
-    private suspend fun fetchMangaFromSource(manualFetch: Boolean = false) {
         val state = successState ?: return
         try {
             withIOContext {
                 val host = state.source.rateLimitHost()
                 // The user is actively looking at this screen waiting on the result - don't
                 // make them sit through the same pacing meant for large unattended batch jobs.
-                val networkManga = InteractiveRateLimitBypass.bypassing(host) {
-                    state.source.getMangaDetails(state.manga.toSManga())
+                val update = InteractiveRateLimitBypass.bypassing(host) {
+                    updateMangaFromRemote(
+                        source = state.source,
+                        manga = state.manga,
+                        fetchDetails = fetchDetails,
+                        fetchChapters = fetchChapters,
+                        manualFetch = manualFetch,
+                        forceRefresh = forceRefresh,
+                    )
                 }
-                updateManga.awaitUpdateFromSource(state.manga, networkManga, manualFetch)
+                    .getOrThrow()
+
+                if (manualFetch) {
+                    downloadNewChapters(update.newChapters)
+                }
+
+                if (fetchChapters) {
+                    val allChapters = getMangaAndChapters.awaitChapters(state.manga.id)
+                    getLibraryManga.applyChapterUpdates(
+                        mangaId,
+                        totalChapters = allChapters.size.toLong(),
+                        readCount = allChapters.count { it.read }.toLong(),
+                        bookmarkCount = allChapters.count { it.bookmark }.toLong(),
+                    )
+                }
             }
-        } catch (e: Throwable) {
-            // Ignore errors and continue
-            logcat(LogPriority.ERROR, e)
-            val message = with(context) { e.formattedMessage }
+        } catch (_: CancellationException) {
+            // ignore
+        } catch (e: Exception) {
+            val message = if (e is NoChaptersException) {
+                context.stringResource(MR.strings.no_chapters_error)
+            } else {
+                logcat(LogPriority.ERROR, e)
+                with(context) { e.formattedMessage }
+            }
+
             screenModelScope.launch {
                 snackbarHostState.showSnackbar(message = message)
             }
@@ -775,62 +792,6 @@ class MangaScreenModel(
                 selected = chapter.id in selectedChapterIds,
                 hasTranslation = chapter.id in translatedChapterIds,
             )
-        }
-    }
-
-    /**
-     * Requests an updated list of chapters from the source.
-     */
-    private suspend fun fetchChaptersFromSource(manualFetch: Boolean = false, forceRefresh: Boolean = false) {
-        val state = successState ?: return
-        try {
-            withIOContext {
-                val existingChapters = getMangaAndChapters.awaitChapters(state.manga.id)
-                val passthroughChapters = if (forceRefresh) emptyList() else existingChapters.toRefreshContextChapters()
-                val host = state.source.rateLimitHost()
-                // Same reasoning as fetchMangaFromSource: this is a foreground fetch the user
-                // is waiting on, not a background batch job - skip the per-request pacing.
-                val chapters = InteractiveRateLimitBypass.bypassing(host) {
-                    state.source.getMangaUpdate(
-                        state.manga.toSManga(),
-                        passthroughChapters,
-                        fetchDetails = false,
-                        fetchChapters = true,
-                    )
-                }.chapters
-
-                val newChapters = syncChaptersWithSource.await(
-                    chapters,
-                    state.manga,
-                    state.source,
-                    manualFetch,
-                )
-
-                if (manualFetch) {
-                    downloadNewChapters(newChapters)
-                }
-
-                val allChapters = getMangaAndChapters.awaitChapters(state.manga.id)
-                getLibraryManga.applyChapterUpdates(
-                    mangaId,
-                    totalChapters = allChapters.size.toLong(),
-                    readCount = allChapters.count { it.read }.toLong(),
-                    bookmarkCount = allChapters.count { it.bookmark }.toLong(),
-                )
-            }
-        } catch (e: Throwable) {
-            val message = if (e is NoChaptersException) {
-                context.stringResource(MR.strings.no_chapters_error)
-            } else {
-                logcat(LogPriority.ERROR, e)
-                with(context) { e.formattedMessage }
-            }
-
-            screenModelScope.launch {
-                snackbarHostState.showSnackbar(message = message)
-            }
-            val newManga = mangaRepository.getMangaById(mangaId)
-            updateSuccessState { it.copy(manga = newManga, isRefreshingData = false) }
         }
     }
 
@@ -1497,7 +1458,7 @@ class MangaScreenModel(
         screenModelScope.launchIO {
             val restoredFromSnapshot = setCustomMangaInfo.clear(mangaId)
             if (!restoredFromSnapshot) {
-                fetchMangaFromSource(manualFetch = true)
+                fetchAllFromSource(manualFetch = true, fetchDetails = true, fetchChapters = false)
             }
         }
     }

--- a/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
+++ b/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
@@ -55,10 +55,14 @@ class UpdateMangaFromRemote(
         fetchChapters: Boolean = false,
         manualFetch: Boolean = false,
         fetchWindow: Pair<Long, Long> = Pair(0, 0),
+        forceRefresh: Boolean = false,
     ): Result<RemoteMangaUpdate> {
         return try {
-            val chapters = chapterRepository.getChapterByMangaId(manga.id)
-                .sortedBy { it.sourceOrder }
+            val chapters = if (forceRefresh) {
+                emptyList()
+            } else {
+                chapterRepository.getChapterByMangaId(manga.id).sortedBy { it.sourceOrder }
+            }
             val update = withIOContext {
                 source.getMangaUpdate(
                     manga = manga.toSManga(),
@@ -67,14 +71,20 @@ class UpdateMangaFromRemote(
                     fetchChapters = fetchChapters,
                 )
             }
-            awaitUpdateFromSource(manga, update.manga, manualFetch)
-            val newChapters = syncChaptersWithSource.await(
-                rawSourceChapters = update.chapters,
-                manga = manga,
-                source = source,
-                manualFetch = manualFetch,
-                fetchWindow = fetchWindow,
-            )
+            if (fetchDetails) {
+                awaitUpdateFromSource(manga, update.manga, manualFetch)
+            }
+            val newChapters = if (fetchChapters) {
+                syncChaptersWithSource.await(
+                    rawSourceChapters = update.chapters,
+                    manga = manga,
+                    source = source,
+                    manualFetch = manualFetch,
+                    fetchWindow = fetchWindow,
+                )
+            } else {
+                emptyList()
+            }
             val updatedManga = mangaRepository.getMangaById(manga.id)
 
             Result.success(RemoteMangaUpdate(manga = updatedManga, newChapters = newChapters))

--- a/app/src/test/java/eu/kanade/tachiyomi/source/SourceMangaUpdateCompatTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/source/SourceMangaUpdateCompatTest.kt
@@ -1,0 +1,148 @@
+package eu.kanade.tachiyomi.source
+
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import rx.Observable
+
+private fun details(author: String) = SManga.create().apply {
+    url = "/entry"
+    title = "Entry"
+    this.author = author
+}
+
+/**
+ * Callers only use [Source.getMangaUpdate]. Every extension generation the app still loads has to
+ * come out of that single entry point.
+ */
+class SourceMangaUpdateCompatTest {
+
+    private val manga = SManga.create().apply {
+        url = "/entry"
+        title = "Entry"
+    }
+
+    private fun chapter(url: String) = SChapter.create().apply {
+        this.url = url
+        name = url
+    }
+
+    private abstract class TestSource : CatalogueSource {
+        override val id = 1L
+        override val name = "Test"
+        override val lang = "en"
+        override val supportsLatest = false
+        override suspend fun getPageList(chapter: SChapter): List<Page> = throw UnsupportedOperationException()
+    }
+
+    /** Pre-suspend extension: only the RxJava methods are implemented. */
+    private class RxSource(private val chapters: List<SChapter>) : TestSource() {
+        @Deprecated("Use the combined suspend API instead", ReplaceWith("getMangaUpdate"))
+        override fun fetchMangaDetails(manga: SManga): Observable<SManga> = Observable.just(details("rx"))
+
+        @Deprecated("Use the combined suspend API instead", ReplaceWith("getMangaUpdate"))
+        override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = Observable.just(chapters)
+    }
+
+    /** Novel, JS and local sources: suspend methods, no RxJava, no combined API. */
+    private class SuspendSource(private val chapters: List<SChapter>) : TestSource() {
+        override suspend fun getMangaDetails(manga: SManga): SManga = details("suspend")
+        override suspend fun getChapterList(manga: SManga): List<SChapter> = chapters
+    }
+
+    private class ContextSource : TestSource() {
+        var receivedExisting: List<SChapter>? = null
+        override suspend fun getMangaDetails(manga: SManga): SManga = details("context")
+
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
+        override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+            receivedExisting = context.existingChapters
+            return context.existingChapters
+        }
+    }
+
+    /**
+     * Migrated extension: implements the combined API and throws from every helper it no longer
+     * needs, the way the current extension repo does.
+     */
+    private class CombinedSource(private val chapters: List<SChapter>) : TestSource() {
+        override suspend fun getMangaUpdate(
+            manga: SManga,
+            chapters: List<SChapter>,
+            fetchDetails: Boolean,
+            fetchChapters: Boolean,
+        ) = SMangaUpdate(
+            manga = if (fetchDetails) details("combined") else manga,
+            chapters = if (fetchChapters) this.chapters else chapters,
+        )
+
+        @Deprecated("Use the combined suspend API instead", ReplaceWith("getMangaUpdate"))
+        override fun fetchMangaDetails(manga: SManga): Observable<SManga> = throw UnsupportedOperationException()
+
+        @Deprecated("Use the combined suspend API instead", ReplaceWith("getMangaUpdate"))
+        override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> =
+            throw UnsupportedOperationException()
+    }
+
+    private suspend fun Source.update(
+        existing: List<SChapter> = emptyList(),
+        fetchDetails: Boolean = true,
+        fetchChapters: Boolean = true,
+    ) = getMangaUpdate(manga, existing, fetchDetails, fetchChapters)
+
+    @Test
+    fun `rxjava extension is served through the combined api`() = runBlocking {
+        val update = RxSource(listOf(chapter("/c1"))).update()
+
+        assertEquals("rx", update.manga.author)
+        assertEquals(listOf("/c1"), update.chapters.map { it.url })
+    }
+
+    @Test
+    fun `suspend only extension is served through the combined api`() = runBlocking {
+        val update = SuspendSource(listOf(chapter("/c1"), chapter("/c2"))).update()
+
+        assertEquals("suspend", update.manga.author)
+        assertEquals(listOf("/c1", "/c2"), update.chapters.map { it.url })
+    }
+
+    @Test
+    fun `refresh context extension still receives the existing chapters`() = runBlocking {
+        val source = ContextSource()
+        val existing = listOf(chapter("/c1"))
+
+        val update = source.update(existing = existing)
+
+        assertEquals(existing, source.receivedExisting)
+        assertEquals(existing, update.chapters)
+    }
+
+    @Test
+    fun `migrated extension never falls back to the deprecated helpers`() = runBlocking {
+        val update = CombinedSource(listOf(chapter("/c1"))).update()
+
+        assertEquals("combined", update.manga.author)
+        assertEquals(listOf("/c1"), update.chapters.map { it.url })
+    }
+
+    @Test
+    fun `unrequested halves are passed through untouched`() = runBlocking {
+        val existing = listOf(chapter("/kept"))
+
+        val detailsOnly = SuspendSource(listOf(chapter("/c1"))).update(existing, fetchChapters = false)
+        assertEquals(existing, detailsOnly.chapters)
+        assertEquals("suspend", detailsOnly.manga.author)
+
+        val chaptersOnly = SuspendSource(listOf(chapter("/c1"))).update(existing, fetchDetails = false)
+        assertEquals(listOf("/c1"), chaptersOnly.chapters.map { it.url })
+        assertTrue(chaptersOnly.manga.author == null)
+    }
+}


### PR DESCRIPTION
Fixes issues with sources that use version 1.6, changed almost all `getMangaDetails` / `getChapterList` references to the new api