### PR TITLE
 Isolate custom JS snippet execution and expose action API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Some great improvements to custom sources, including {novelUrl} [@mrissaoussama](https://github.com/mrissaoussama) [#296](https://github.com/tsundoku-otaku/tsundoku/pull/296)
 - Localnovel relative path improvements [@mrissaoussama](https://github.com/mrissaoussama) [#343](https://github.com/tsundoku-otaku/tsundoku/pull/343)
 - Improve performance on library export notifications [@mrissaoussama](https://github.com/mrissaoussama) [#285](https://github.com/tsundoku-otaku/tsundoku/pull/285)
+- Isolate custom JS snippet execution, expose action API [@mrissaoussama](https://github.com/mrissaoussama) [#370](https://github.com/tsundoku-otaku/tsundoku/pull/370)
 - Custom source: Duplicate source under new name/site [@mrissaoussama](https://github.com/mrissaoussama) [#361](https://github.com/tsundoku-otaku/tsundoku/pull/361)
 - Per-field metadata overrides [@mrissaoussama](https://github.com/mrissaoussama) [#308](https://github.com/tsundoku-otaku/tsundoku/pull/308)
 - Edit manga now has an artist field [@mrissaoussama](https://github.com/mrissaoussama) [#278](https://github.com/tsundoku-otaku/tsundoku/pull/278)

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -97,7 +97,9 @@ data class CodeSnippet(
     val id: String = "legacy-${java.util.Objects.hash(title, code)}",
 )
 
-fun safeTitleOf(title: String): String = title.replace(Regex("[^A-Za-z0-9._-]"), "-")
+private val UNSAFE_TITLE_CHARS = Regex("[^A-Za-z0-9._-]")
+
+fun safeTitleOf(title: String): String = title.replace(UNSAFE_TITLE_CHARS, "-")
 
 fun CodeSnippet.safeTitle(): String = safeTitleOf(title)
 
@@ -1126,7 +1128,8 @@ private fun SnippetEditDialog(
     var snippetCode by remember { mutableStateOf(initialSnippet?.code ?: "") }
     var runOnAppend by remember { mutableStateOf(initialSnippet?.runOnAppend ?: false) }
     val codeFocusRequester = remember { FocusRequester() }
-    val isDuplicateTitle = existingSafeTitles.contains(safeTitleOf(snippetTitle.trim()))
+    val trimmedSafeTitle = safeTitleOf(snippetTitle.trim())
+    val isDuplicateTitle = existingSafeTitles.contains(trimmedSafeTitle)
 
     LaunchedEffect(focusCodeFieldByDefault) {
         if (focusCodeFieldByDefault) {
@@ -1146,7 +1149,7 @@ private fun SnippetEditDialog(
                     singleLine = true,
                     isError = isDuplicateTitle,
                     supportingText = if (isDuplicateTitle) {
-                        { Text(stringResource(TDMR.strings.novel_snippet_duplicate_title)) }
+                        { Text(stringResource(TDMR.strings.novel_snippet_duplicate_title, trimmedSafeTitle)) }
                     } else {
                         null
                     },

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -94,9 +94,8 @@ data class CodeSnippet(
     val enabled: Boolean = true,
     // JS only. Default off so one-shot snippets don't re-run on every infinite-scroll append.
     val runOnAppend: Boolean = false,
-    // Stable identity for edit/delete so a list reorder between opening a dialog and confirming it
-    // can't target the wrong entry. Absent from JSON saved before this field existed, in which case
-    // decoding assigns a fresh one -- harmless since those entries had no addressable identity before.
+    // Stable identity for edit/delete/reapply-diffing. Missing from pre-existing JSON, in which
+    // case decoding assigns a fresh one each time.
     val id: String = java.util.UUID.randomUUID().toString(),
 )
 

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -94,10 +94,12 @@ data class CodeSnippet(
     val enabled: Boolean = true,
     // JS only. Default off so one-shot snippets don't re-run on every infinite-scroll append.
     val runOnAppend: Boolean = false,
-    // Stable identity for edit/delete/reapply-diffing. Missing from pre-existing JSON, in which
-    // case decoding assigns a fresh one each time.
-    val id: String = java.util.UUID.randomUUID().toString(),
+    val id: String = "legacy-${java.util.Objects.hash(title, code)}",
 )
+
+fun safeTitleOf(title: String): String = title.replace(Regex("[^A-Za-z0-9._-]"), "-")
+
+fun CodeSnippet.safeTitle(): String = safeTitleOf(title)
 
 @Serializable
 data class RegexReplacement(
@@ -915,6 +917,9 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             initialSnippet = editingCssSnippet,
             focusCodeFieldByDefault = editingCssSnippet != null,
             showRunOnAppend = false,
+            existingSafeTitles = cssSnippets
+                .filterNot { it.id == editingCssSnippet?.id }
+                .mapTo(mutableSetOf()) { it.safeTitle() },
             onDismiss = {
                 showCssDialog = false
                 editingCssSnippet = null
@@ -944,6 +949,9 @@ internal fun ColumnScope.NovelAdvancedTab(screenModel: ReaderSettingsScreenModel
             initialSnippet = editingJsSnippet,
             focusCodeFieldByDefault = editingJsSnippet != null,
             showRunOnAppend = true,
+            existingSafeTitles = jsSnippets
+                .filterNot { it.id == editingJsSnippet?.id }
+                .mapTo(mutableSetOf()) { it.safeTitle() },
             onDismiss = {
                 showJsDialog = false
                 editingJsSnippet = null
@@ -1110,6 +1118,7 @@ private fun SnippetEditDialog(
     initialSnippet: CodeSnippet?,
     focusCodeFieldByDefault: Boolean,
     showRunOnAppend: Boolean,
+    existingSafeTitles: Set<String>,
     onDismiss: () -> Unit,
     onConfirm: (CodeSnippet) -> Unit,
 ) {
@@ -1117,6 +1126,7 @@ private fun SnippetEditDialog(
     var snippetCode by remember { mutableStateOf(initialSnippet?.code ?: "") }
     var runOnAppend by remember { mutableStateOf(initialSnippet?.runOnAppend ?: false) }
     val codeFocusRequester = remember { FocusRequester() }
+    val isDuplicateTitle = existingSafeTitles.contains(safeTitleOf(snippetTitle.trim()))
 
     LaunchedEffect(focusCodeFieldByDefault) {
         if (focusCodeFieldByDefault) {
@@ -1134,6 +1144,12 @@ private fun SnippetEditDialog(
                     onValueChange = { snippetTitle = it },
                     label = { Text(stringResource(TDMR.strings.novel_snippet_title)) },
                     singleLine = true,
+                    isError = isDuplicateTitle,
+                    supportingText = if (isDuplicateTitle) {
+                        { Text(stringResource(TDMR.strings.novel_snippet_duplicate_title)) }
+                    } else {
+                        null
+                    },
                     modifier = Modifier.fillMaxWidth(),
                 )
                 OutlinedTextField(
@@ -1170,18 +1186,17 @@ private fun SnippetEditDialog(
         },
         confirmButton = {
             TextButton(
+                enabled = snippetTitle.isNotBlank() && snippetCode.isNotBlank() && !isDuplicateTitle,
                 onClick = {
-                    if (snippetTitle.isNotBlank() && snippetCode.isNotBlank()) {
-                        onConfirm(
-                            CodeSnippet(
-                                title = snippetTitle.trim(),
-                                code = snippetCode,
-                                enabled = initialSnippet?.enabled ?: true,
-                                runOnAppend = runOnAppend,
-                                id = initialSnippet?.id ?: java.util.UUID.randomUUID().toString(),
-                            ),
-                        )
-                    }
+                    onConfirm(
+                        CodeSnippet(
+                            title = snippetTitle.trim(),
+                            code = snippetCode,
+                            enabled = initialSnippet?.enabled ?: true,
+                            runOnAppend = runOnAppend,
+                            id = initialSnippet?.id ?: java.util.UUID.randomUUID().toString(),
+                        ),
+                    )
                 },
             ) {
                 Text(stringResource(MR.strings.action_save))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -177,6 +177,15 @@ internal object NovelWebViewChapterMeta {
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_IMMERSIVE_KEY = ${context.immersive};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_TTS_STATE_KEY = ${quoteForJson(context.ttsState)};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_LOADING_CHAPTER_KEY = ${context.loadingChapter};
+            window.$TSUNDOKU_OBJECT_NAME.actions = window.$TSUNDOKU_OBJECT_NAME.actions || {
+                nextChapter: function() { Android.requestNextChapter(); },
+                prevChapter: function() { Android.requestPrevChapter(); },
+                startTts: function() { Android.requestStartTts(); },
+                pauseTts: function() { Android.requestPauseTts(); },
+                resumeTts: function() { Android.requestResumeTts(); },
+                stopTts: function() { Android.requestStopTts(); },
+                setProgress: function(percent) { Android.requestSetProgress(percent); },
+            };
         """.trimIndent()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.webkit.WebView
 import androidx.core.net.toUri
 import eu.kanade.presentation.reader.settings.CodeSnippet
+import eu.kanade.presentation.reader.settings.safeTitle
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.NovelProgress
@@ -159,8 +160,6 @@ internal class NovelWebViewStyler(
 
     @Volatile private var cachedFontBytes: Pair<String, ByteArray>? = null
 
-    // Baseline of what's been injected, keyed by snippet id, so a settings-triggered reapply only
-    // re-runs snippets whose code actually changed.
     private var lastAppliedSnippetCode: Map<String, String> = emptyMap()
     private var lastAppliedCustomJs: String? = null
 
@@ -210,9 +209,11 @@ internal class NovelWebViewStyler(
         evaluateJs(js)
     }
 
-    // reapplyChangedOnly: true for a settings-triggered reapply on an already-loaded document, so
-    // only snippets whose code changed since lastAppliedSnippetCode actually run.
-    fun injectScript(isAppend: Boolean = false, reapplyChangedOnly: Boolean = false, buildTsundokuScript: () -> String) {
+    fun injectScript(
+        isAppend: Boolean = false,
+        reapplyChangedOnly: Boolean = false,
+        buildTsundokuScript: () -> String,
+    ) {
         evaluateJs(buildTsundokuScript())
 
         // Appends re-run only runOnAppend snippets; one-shot code stays on the initial load so it
@@ -233,11 +234,7 @@ internal class NovelWebViewStyler(
             emptyList()
         }
 
-        val toRun = if (reapplyChangedOnly) {
-            enabledSnippets.filter { lastAppliedSnippetCode[it.id] != it.code }
-        } else {
-            enabledSnippets
-        }
+        val toRun = snippetsToRun(enabledSnippets, reapplyChangedOnly, lastAppliedSnippetCode)
         if (toRun.isNotEmpty()) evaluateJs(buildSnippetRunnerJs(toRun))
 
         if (!isAppend) {
@@ -245,12 +242,9 @@ internal class NovelWebViewStyler(
         }
     }
 
-    // Each snippet runs as its own real <script> element (not a new Function() call) so a broken
-    // snippet reports its own accurate file/line via sourceURL and can't stop the others from running.
     private fun buildSnippetRunnerJs(snippets: List<CodeSnippet>): String {
         val entries = snippets.mapIndexed { i, s ->
-            val safeName = s.title.ifBlank { "snippet-$i" }
-                .replace(Regex("[^A-Za-z0-9._-]"), "-")
+            val safeName = s.safeTitle().ifBlank { "snippet-$i" }
             "{ name: ${quoteForJson(safeName)}, code: ${quoteForJson(s.code)} }"
         }.joinToString(",\n")
         return """
@@ -319,6 +313,16 @@ internal class NovelWebViewStyler(
                 "h5 { font-size: 0.83em !important; } " +
                 "h6 { font-size: 0.67em !important; }"
             return starOverride to headings
+        }
+
+        internal fun snippetsToRun(
+            enabledSnippets: List<CodeSnippet>,
+            reapplyChangedOnly: Boolean,
+            lastAppliedSnippetCode: Map<String, String>,
+        ): List<CodeSnippet> = if (reapplyChangedOnly) {
+            enabledSnippets.filter { lastAppliedSnippetCode[it.id] != it.code }
+        } else {
+            enabledSnippets
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -237,9 +237,7 @@ internal class NovelWebViewStyler(
         val toRun = snippetsToRun(enabledSnippets, reapplyChangedOnly, lastAppliedSnippetCode)
         if (toRun.isNotEmpty()) evaluateJs(buildSnippetRunnerJs(toRun))
 
-        if (!isAppend) {
-            lastAppliedSnippetCode = enabledSnippets.associate { it.id to it.code }
-        }
+        lastAppliedSnippetCode = nextAppliedSnippetCode(lastAppliedSnippetCode, enabledSnippets)
     }
 
     private fun buildSnippetRunnerJs(snippets: List<CodeSnippet>): String {
@@ -324,5 +322,10 @@ internal class NovelWebViewStyler(
         } else {
             enabledSnippets
         }
+
+        internal fun nextAppliedSnippetCode(
+            lastAppliedSnippetCode: Map<String, String>,
+            enabledSnippets: List<CodeSnippet>,
+        ): Map<String, String> = lastAppliedSnippetCode + enabledSnippets.associate { it.id to it.code }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -159,6 +159,11 @@ internal class NovelWebViewStyler(
 
     @Volatile private var cachedFontBytes: Pair<String, ByteArray>? = null
 
+    // Baseline of what's been injected, keyed by snippet id, so a settings-triggered reapply only
+    // re-runs snippets whose code actually changed.
+    private var lastAppliedSnippetCode: Map<String, String> = emptyMap()
+    private var lastAppliedCustomJs: String? = null
+
     /**
      * Serve the custom font for the sentinel URL referenced by the injected @font-face. Runs on the
      * WebView's worker thread (not the UI thread), so the disk read never stalls the UI. Fonts are
@@ -205,26 +210,62 @@ internal class NovelWebViewStyler(
         evaluateJs(js)
     }
 
-    fun injectScript(isAppend: Boolean = false, buildTsundokuScript: () -> String) {
+    // reapplyChangedOnly: true for a settings-triggered reapply on an already-loaded document, so
+    // only snippets whose code changed since lastAppliedSnippetCode actually run.
+    fun injectScript(isAppend: Boolean = false, reapplyChangedOnly: Boolean = false, buildTsundokuScript: () -> String) {
         evaluateJs(buildTsundokuScript())
 
         // Appends re-run only runOnAppend snippets; one-shot code stays on the initial load so it
         // doesn't fire again on every appended chapter.
         if (!isAppend) {
             val customJs = preferences.novelCustomJs.get()
-            if (customJs.isNotBlank()) evaluateJs(customJs)
+            val shouldRunCustomJs = !reapplyChangedOnly || lastAppliedCustomJs != customJs
+            if (customJs.isNotBlank() && shouldRunCustomJs) evaluateJs(customJs)
+            lastAppliedCustomJs = customJs
         }
 
         val jsSnippetsJson = preferences.novelCustomJsSnippets.get()
-        val enabledSnippetsJs = try {
-            val snippets = Json.decodeFromString<List<CodeSnippet>>(jsSnippetsJson)
-            snippets.filter { it.enabled && (!isAppend || it.runOnAppend) }
-                .joinToString("\n") { it.code }
+        val enabledSnippets = try {
+            Json.decodeFromString<List<CodeSnippet>>(jsSnippetsJson)
+                .filter { it.enabled && (!isAppend || it.runOnAppend) }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR) { "Failed to parse JS snippets: ${e.message}" }
-            ""
+            emptyList()
         }
-        if (enabledSnippetsJs.isNotBlank()) evaluateJs(enabledSnippetsJs)
+
+        val toRun = if (reapplyChangedOnly) {
+            enabledSnippets.filter { lastAppliedSnippetCode[it.id] != it.code }
+        } else {
+            enabledSnippets
+        }
+        if (toRun.isNotEmpty()) evaluateJs(buildSnippetRunnerJs(toRun))
+
+        if (!isAppend) {
+            lastAppliedSnippetCode = enabledSnippets.associate { it.id to it.code }
+        }
+    }
+
+    // Each snippet runs as its own real <script> element (not a new Function() call) so a broken
+    // snippet reports its own accurate file/line via sourceURL and can't stop the others from running.
+    private fun buildSnippetRunnerJs(snippets: List<CodeSnippet>): String {
+        val entries = snippets.mapIndexed { i, s ->
+            val safeName = s.title.ifBlank { "snippet-$i" }
+                .replace(Regex("[^A-Za-z0-9._-]"), "-")
+            "{ name: ${quoteForJson(safeName)}, code: ${quoteForJson(s.code)} }"
+        }.joinToString(",\n")
+        return """
+            (function(){
+                var __snippets = [$entries];
+                var __host = document.head || document.documentElement;
+                for (var __i = 0; __i < __snippets.length; __i++) {
+                    var __el = document.createElement('script');
+                    __el.textContent = __snippets[__i].code +
+                        '\n//# sourceURL=tsundoku-snippet-' + __snippets[__i].name + '.js';
+                    __host.appendChild(__el);
+                    __host.removeChild(__el);
+                }
+            })();
+        """.trimIndent()
     }
 
     fun injectNextChapterButton(hasNextChapter: Boolean) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -837,7 +837,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             preferences = preferences,
             scope = scope,
             onStyleChanged = { styler.injectStyles() },
-            onScriptChanged = { styler.injectScript { buildTsundokuScript() } },
+            onScriptChanged = {
+                // Mid-scroll with >1 chapter loaded is no longer "the initial load", so treat as append.
+                val isAppend = preferences.novelInfiniteScroll.get() && loadedChapterIds.size > 1
+                styler.injectScript(isAppend = isAppend, reapplyChangedOnly = true) { buildTsundokuScript() }
+            },
             onChapterReloadRequested = {
                 // Force a full pipeline re-run so the new prefs take effect.
                 // Plain setChapters() would no-op on an already-loaded chapter.
@@ -2133,6 +2137,41 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 cm.setPrimaryClip(android.content.ClipData.newPlainText("error", text))
                 activity.toast(activity.stringResource(TDMR.strings.novel_error_copied))
             }
+        }
+
+        @JavascriptInterface
+        fun requestNextChapter() {
+            activity.runOnUiThread { activity.loadNextChapter() }
+        }
+
+        @JavascriptInterface
+        fun requestPrevChapter() {
+            activity.runOnUiThread { activity.loadPreviousChapter() }
+        }
+
+        @JavascriptInterface
+        fun requestStartTts() {
+            activity.runOnUiThread { startTts() }
+        }
+
+        @JavascriptInterface
+        fun requestPauseTts() {
+            activity.runOnUiThread { pauseTts() }
+        }
+
+        @JavascriptInterface
+        fun requestResumeTts() {
+            activity.runOnUiThread { resumeTts() }
+        }
+
+        @JavascriptInterface
+        fun requestStopTts() {
+            activity.runOnUiThread { stopTts() }
+        }
+
+        @JavascriptInterface
+        fun requestSetProgress(percent: Int) {
+            activity.runOnUiThread { setProgressPercent(percent) }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -838,7 +838,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             scope = scope,
             onStyleChanged = { styler.injectStyles() },
             onScriptChanged = {
-                // Mid-scroll with >1 chapter loaded is no longer "the initial load", so treat as append.
                 val isAppend = preferences.novelInfiniteScroll.get() && loadedChapterIds.size > 1
                 styler.injectScript(isAppend = isAppend, reapplyChangedOnly = true) { buildTsundokuScript() }
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -2140,7 +2140,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         @JavascriptInterface
         fun requestNextChapter() {
-            activity.runOnUiThread { activity.loadNextChapter() }
+            loadNextChapter()
         }
 
         @JavascriptInterface

--- a/app/src/test/java/eu/kanade/presentation/reader/settings/CodeSnippetTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/reader/settings/CodeSnippetTest.kt
@@ -31,4 +31,37 @@ class CodeSnippetTest {
     fun `new snippet defaults runOnAppend to false`() {
         assertFalse(CodeSnippet(title = "a", code = "x").runOnAppend)
     }
+
+    @Test
+    fun `legacy json missing id gets a deterministic id, same content yields same id`() {
+        val legacy = """[{"title":"a","code":"x","enabled":true}]"""
+        val first = Json.decodeFromString<List<CodeSnippet>>(legacy)[0].id
+        val second = Json.decodeFromString<List<CodeSnippet>>(legacy)[0].id
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `legacy entries with different content get different ids`() {
+        val a = Json.decodeFromString<List<CodeSnippet>>("""[{"title":"a","code":"x"}]""")[0].id
+        val b = Json.decodeFromString<List<CodeSnippet>>("""[{"title":"b","code":"y"}]""")[0].id
+        assertTrue(a != b)
+    }
+
+    @Test
+    fun `id present in json is preserved as-is`() {
+        val json = """[{"title":"a","code":"x","id":"custom-id"}]"""
+        val snippet = Json.decodeFromString<List<CodeSnippet>>(json)[0]
+        assertEquals("custom-id", snippet.id)
+    }
+
+    @Test
+    fun `safeTitle replaces disallowed characters with a dash`() {
+        assertEquals("Fix-Chapter-Title-", safeTitleOf("Fix Chapter Title!"))
+        assertEquals("already_safe-1.2", safeTitleOf("already_safe-1.2"))
+    }
+
+    @Test
+    fun `distinct titles can sanitize to the same safe title`() {
+        assertEquals(safeTitleOf("Fix!"), safeTitleOf("Fix?"))
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStylerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStylerTest.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
 
+import eu.kanade.presentation.reader.settings.CodeSnippet
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -15,7 +17,7 @@ import org.junit.jupiter.api.Test
  */
 class NovelWebViewStylerTest {
 
-    // ── fontOverrideCss ───────────────────────────────────────────────────────
+    // fontOverrideCss
 
     @Test
     fun `reader-priority mode emits font-size inherit in star rule`() {
@@ -73,5 +75,63 @@ class NovelWebViewStylerTest {
         val (star, headings) = NovelWebViewStyler.fontOverrideCss(sourceCssPriority = true, useOriginalFonts = true)
         assertTrue(star.isEmpty())
         assertTrue(headings.isEmpty())
+    }
+
+    // snippetsToRun
+
+    @Test
+    fun `not reapplying runs every enabled snippet regardless of baseline`() {
+        val snippets = listOf(CodeSnippet(title = "a", code = "1", id = "a"))
+        val toRun = NovelWebViewStyler.snippetsToRun(
+            snippets,
+            reapplyChangedOnly = false,
+            lastAppliedSnippetCode = mapOf("a" to "1"),
+        )
+        assertEquals(snippets, toRun)
+    }
+
+    @Test
+    fun `reapply skips a snippet whose code matches the baseline`() {
+        val snippets = listOf(CodeSnippet(title = "a", code = "1", id = "a"))
+        val toRun = NovelWebViewStyler.snippetsToRun(
+            snippets,
+            reapplyChangedOnly = true,
+            lastAppliedSnippetCode = mapOf("a" to "1"),
+        )
+        assertTrue(toRun.isEmpty())
+    }
+
+    @Test
+    fun `reapply runs a snippet whose code changed since the baseline`() {
+        val snippets = listOf(CodeSnippet(title = "a", code = "2", id = "a"))
+        val toRun = NovelWebViewStyler.snippetsToRun(
+            snippets,
+            reapplyChangedOnly = true,
+            lastAppliedSnippetCode = mapOf("a" to "1"),
+        )
+        assertEquals(snippets, toRun)
+    }
+
+    @Test
+    fun `reapply runs a snippet absent from the baseline`() {
+        val snippets = listOf(CodeSnippet(title = "new", code = "1", id = "new"))
+        val toRun = NovelWebViewStyler.snippetsToRun(
+            snippets,
+            reapplyChangedOnly = true,
+            lastAppliedSnippetCode = emptyMap(),
+        )
+        assertEquals(snippets, toRun)
+    }
+
+    @Test
+    fun `reapply only runs the changed snippet among several`() {
+        val unchanged = CodeSnippet(title = "u", code = "1", id = "u")
+        val changed = CodeSnippet(title = "c", code = "2", id = "c")
+        val toRun = NovelWebViewStyler.snippetsToRun(
+            listOf(unchanged, changed),
+            reapplyChangedOnly = true,
+            lastAppliedSnippetCode = mapOf("u" to "1", "c" to "1"),
+        )
+        assertEquals(listOf(changed), toRun)
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStylerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStylerTest.kt
@@ -134,4 +134,29 @@ class NovelWebViewStylerTest {
         )
         assertEquals(listOf(changed), toRun)
     }
+
+    // nextAppliedSnippetCode
+
+    @Test
+    fun `append-mode baseline update lets a later revert be detected as changed`() {
+        var baseline = mapOf("a" to "v1")
+
+        val editedToV2 = listOf(CodeSnippet(title = "a", code = "v2", id = "a"))
+        NovelWebViewStyler.snippetsToRun(editedToV2, reapplyChangedOnly = true, baseline)
+        baseline = NovelWebViewStyler.nextAppliedSnippetCode(baseline, editedToV2)
+
+        val revertedToV1 = listOf(CodeSnippet(title = "a", code = "v1", id = "a"))
+        val toRun = NovelWebViewStyler.snippetsToRun(revertedToV1, reapplyChangedOnly = true, baseline)
+
+        assertEquals(revertedToV1, toRun)
+    }
+
+    @Test
+    fun `nextAppliedSnippetCode preserves entries absent from the current snippet set`() {
+        val baseline = NovelWebViewStyler.nextAppliedSnippetCode(
+            mapOf("oneShot" to "code"),
+            enabledSnippets = listOf(CodeSnippet(title = "append", code = "v2", id = "append")),
+        )
+        assertEquals(mapOf("oneShot" to "code", "append" to "v2"), baseline)
+    }
 }

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -168,6 +168,7 @@
     <string name="novel_no_cssjs">No CSS or JS Snippets are available in this mode</string>
     <string name="novel_snippet_title">Snippet title</string>
     <string name="novel_snippet_code">Code</string>
+    <string name="novel_snippet_duplicate_title">A snippet with this name already exists</string>
     <string name="novel_add_snippet">Add snippet</string>
     <string name="novel_edit_snippet">Edit snippet</string>
     <string name="novel_delete_snippet">Delete snippet</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -168,7 +168,7 @@
     <string name="novel_no_cssjs">No CSS or JS Snippets are available in this mode</string>
     <string name="novel_snippet_title">Snippet title</string>
     <string name="novel_snippet_code">Code</string>
-    <string name="novel_snippet_duplicate_title">A snippet with this name already exists</string>
+    <string name="novel_snippet_duplicate_title">A snippet with the identifier "%1$s" already exists</string>
     <string name="novel_add_snippet">Add snippet</string>
     <string name="novel_edit_snippet">Edit snippet</string>
     <string name="novel_delete_snippet">Delete snippet</string>


### PR DESCRIPTION

- Each JS snippet now runs as its own injected `<script>` element. This helps report accurate lines in the stack, and prevents a mishandled snippet from affecting others.
- New JS functions: 
    ```      
               nextChapter: function()
                prevChapter: function()
                startTts: function() 
                pauseTts: function()
                resumeTts: function() 
                stopTts: function()
                setProgress: function(percent)
 these are accessible from `window.Tsundoku.actions.*`
- Snippets missing an id get a deterministic id from title+code
- sanitize snippet titles and block duplicates at add/save.

