### PR TITLE
fix(jsplugin): close delete-then-create race in plugin file replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - MangaBaka tracker fix - Remove old code, create OAuth app [@Rojikku](https://github.com/Rojikku) [#364](https://github.com/tsundoku-otaku/tsundoku/pull/364)
 - Resolve library export urls properly in jssource [@mrissaoussama](https://github.com/mrissaoussama) [#357](https://github.com/tsundoku-otaku/tsundoku/pull/357)
 - Fix rare textview crash [@mrissaoussama](https://github.com/mrissaoussama) [#371](https://github.com/tsundoku-otaku/tsundoku/pull/371)
+- JS plugin delete-then-create race fix [@mrissaoussama](https://github.com/mrissaoussama) [#375](https://github.com/tsundoku-otaku/tsundoku/pull/375)
 - Guard download cache serialization [@mrissaoussama](https://github.com/mrissaoussama) [#346](https://github.com/tsundoku-otaku/tsundoku/pull/346)
 - Paginated library export to prevent potential OOM, added cancel to notif [@mrissaoussama](https://github.com/mrissaoussama) [#270](https://github.com/tsundoku-otaku/tsundoku/pull/270)
 - Correct import stats when app is restarted [@mrissaoussama](https://github.com/mrissaoussama) [#272](https://github.com/tsundoku-otaku/tsundoku/pull/272)

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -779,11 +779,16 @@ class JsPluginManager(
     private fun UniFile.replaceFile(name: String): UniFile? {
         findFile(name)?.delete()
         var attempts = 0
-        while (findFile(name) != null && attempts < 5) {
-            Thread.sleep(20)
+        var delayMs = 20L
+        while (true) {
+            if (findFile(name) == null) {
+                createFile(name)?.let { return it }
+            }
             attempts++
+            if (attempts >= 5) return createFile(name)
+            Thread.sleep(delayMs)
+            delayMs *= 2
         }
-        return createFile(name)
     }
 
     private fun UniFile.readText(): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -778,6 +778,11 @@ class JsPluginManager(
      */
     private fun UniFile.replaceFile(name: String): UniFile? {
         findFile(name)?.delete()
+        var attempts = 0
+        while (findFile(name) != null && attempts < 5) {
+            Thread.sleep(20)
+            attempts++
+        }
         return createFile(name)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/jsplugin/JsPluginManager.kt
@@ -785,7 +785,12 @@ class JsPluginManager(
                 createFile(name)?.let { return it }
             }
             attempts++
-            if (attempts >= 5) return createFile(name)
+            if (attempts >= 5) {
+                logcat(LogPriority.WARN) {
+                    "replaceFile: $name still contested after $attempts retries, creating anyway"
+                }
+                return createFile(name)
+            }
             Thread.sleep(delayMs)
             delayMs *= 2
         }


### PR DESCRIPTION
Some SAF providers reflect a delete asynchronously, so createFile issued right after can still see the old entry and get auto-renamed to "name (1)" instead of replacing it, landing installed plugins as duplicate files on reinstall/update.