### PR TITLE
fix(downloader): show chapter progress in the novel download notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix download queue restart preference [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Better handle old backups, better backup/restore performance [@mrissaoussama](https://github.com/mrissaoussama) [#297](https://github.com/tsundoku-otaku/tsundoku/pull/297)
 - Volume keys no longer scroll while menu visible [@mrissaoussama](https://github.com/mrissaoussama) [#345](https://github.com/tsundoku-otaku/tsundoku/pull/345)
+- Show chapter process in ddownload notification [@mrissaoussama](https://github.com/mrissaoussama) [#376](https://github.com/tsundoku-otaku/tsundoku/pull/3476)
 - Custom source: Edit paged urls, keep card link [@mrissaoussama](https://github.com/mrissaoussama) [#356](https://github.com/tsundoku-otaku/tsundoku/pull/356)
 - Pull to refresh spinner will be more patient [@mrissaoussama](https://github.com/mrissaoussama) [#321](https://github.com/tsundoku-otaku/tsundoku/pull/321)
 - Improve massimport - Notification dedupe,v erious fixes [@mrissaoussama](https://github.com/mrissaoussama) [#333](https://github.com/tsundoku-otaku/tsundoku/pull/333)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -70,7 +70,7 @@ internal class DownloadNotifier(private val context: Context) {
      *
      * @param download download object containing download information.
      */
-    fun onProgressChange(download: Download) {
+    fun onProgressChange(download: Download, chapterProgress: Pair<Int, Int>? = null) {
         with(progressNotificationBuilder) {
             if (!isDownloading) {
                 setSmallIcon(android.R.drawable.stat_sys_download)
@@ -91,10 +91,12 @@ internal class DownloadNotifier(private val context: Context) {
                 )
             }
 
+            val (current, total) = chapterProgress ?: (download.downloadedImages to download.pages!!.size)
+
             val downloadingProgressText = context.stringResource(
                 MR.strings.chapter_downloading_progress,
-                download.downloadedImages,
-                download.pages!!.size,
+                current,
+                total,
             )
 
             if (preferences.hideNotificationContent.get()) {
@@ -111,7 +113,7 @@ internal class DownloadNotifier(private val context: Context) {
                 setContentText(downloadingProgressText)
             }
 
-            setProgress(download.pages!!.size, download.downloadedImages, false)
+            setProgress(total, current, false)
             setOngoing(true)
 
             show(Notifications.ID_DOWNLOAD_CHAPTER_PROGRESS)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -127,6 +127,8 @@ class Downloader(
     // Used to avoid spamming warning notifications during bulk queueing.
     private val hasShownQueueSizeWarning = AtomicBoolean(false)
 
+    private val novelChapterTotals = java.util.concurrent.ConcurrentHashMap<Long, Int>()
+
     /**
      * Whether the downloader is running.
      */
@@ -570,7 +572,11 @@ class Downloader(
             }
                 .collect {
                     // Do when page is downloaded.
-                    notifier.onProgressChange(download)
+                    if (isNovel) {
+                        notifier.onProgressChange(download, novelChapterProgress(download))
+                    } else {
+                        notifier.onProgressChange(download)
+                    }
                 }
 
             // Do after download completes
@@ -984,6 +990,15 @@ class Downloader(
      */
     private fun areAllDownloadsFinished(): Boolean {
         return queueState.value.none { it.status.value <= Download.State.DOWNLOADING.value }
+    }
+
+    private fun novelChapterProgress(download: Download): Pair<Int, Int> {
+        val outstanding = queueState.value.count {
+            it.mangaId == download.mangaId && it.source.isNovelSource()
+        }
+        val total = novelChapterTotals.merge(download.mangaId, outstanding, ::maxOf)!!
+        if (outstanding <= 1) novelChapterTotals.remove(download.mangaId)
+        return (total - outstanding + 1).coerceIn(1, total) to total
     }
 
     private fun addAllToQueue(downloads: List<Download>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -369,6 +369,13 @@ class Downloader(
             if (areAllDownloadsFinished()) {
                 stop()
             }
+        } finally {
+            // Clean up unconditionally (success, error, or early throw before any progress
+            // event) so a chapter that fails before novelChapterProgress ever runs doesn't
+            // leave a stale total behind for this manga.
+            if (download.source.isNovelSource()) {
+                clearNovelChapterTotalIfDone(download.mangaId)
+            }
         }
     }
 
@@ -997,8 +1004,19 @@ class Downloader(
             it.mangaId == download.mangaId && it.source.isNovelSource()
         }
         val total = novelChapterTotals.merge(download.mangaId, outstanding, ::maxOf)!!
-        if (outstanding <= 1) novelChapterTotals.remove(download.mangaId)
         return (total - outstanding + 1).coerceIn(1, total) to total
+    }
+
+    // Called when a novel download job ends, on every path (success, error, or cancellation).
+    // Removes the manga's tracked total once no queued/downloading novel chapters remain for
+    // it, so a stale total can't leak into a later, unrelated download batch.
+    private fun clearNovelChapterTotalIfDone(mangaId: Long) {
+        val hasOutstanding = queueState.value.any {
+            it.mangaId == mangaId &&
+                it.source.isNovelSource() &&
+                it.status.value <= Download.State.DOWNLOADING.value
+        }
+        if (!hasOutstanding) novelChapterTotals.remove(mangaId)
     }
 
     private fun addAllToQueue(downloads: List<Download>) {


### PR DESCRIPTION

A novel chapter is always a single synthetic page (the whole chapter's text), so the notification's page-based progress (downloadedImages / pages.size) was always 1/1 and instead of climbing like manga's page count does. Pass the manga's completed/total chapter count for novel downloads instead, tracked per-manga across the batch.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
