### PR TITLE
Add source groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Option for tag normalization during entry updates [@mrissaoussama](https://github.com/mrissaoussama) [#287](https://github.com/tsundoku-otaku/tsundoku/pull/287)
 - Reader Status Bar [@Rojikku](https://github.com/Rojikku) [#302](https://github.com/tsundoku-otaku/tsundoku/pull/302)
 - RateLimiting revamp + backend [@Rojikku](https://github.com/Rojikku) [#329](https://github.com/tsundoku-otaku/tsundoku/pull/329)
+- Source Groups [@MarcosLorCar](https://github.com/MarcosLorCar) [#378](https://github.com/tsundoku-otaku/tsundoku/pull/378)
 
 
 ### Changed

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -13,14 +13,17 @@ import eu.kanade.domain.manga.interactor.MassImport
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.DeleteSourcePinGroup
 import eu.kanade.domain.source.interactor.GetEnabledNovelSources
 import eu.kanade.domain.source.interactor.GetEnabledSources
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.interactor.GetLanguagesWithSources
 import eu.kanade.domain.source.interactor.GetNovelSourcesWithFavoriteCount
+import eu.kanade.domain.source.interactor.GetSourcePinGroups
 import eu.kanade.domain.source.interactor.GetSourcesWithFavoriteCount
 import eu.kanade.domain.source.interactor.ManageFilterPresets
 import eu.kanade.domain.source.interactor.SetMigrateSorting
+import eu.kanade.domain.source.interactor.SetSourcePinGroups
 import eu.kanade.domain.source.interactor.ToggleIncognito
 import eu.kanade.domain.source.interactor.ToggleLanguage
 import eu.kanade.domain.source.interactor.ToggleSource
@@ -219,10 +222,13 @@ class DomainModule : InjektModule {
         addFactory { GetSourcesWithFavoriteCount(get(), get(), get()) }
         addFactory { GetNovelSourcesWithFavoriteCount(get(), get(), get()) }
         addFactory { GetSourcesWithNonLibraryManga(get()) }
+        addFactory { GetSourcePinGroups(get()) }
         addFactory { SetMigrateSorting(get()) }
+        addFactory { SetSourcePinGroups(get()) }
         addFactory { ToggleLanguage(get()) }
         addFactory { ToggleSource(get()) }
         addFactory { ToggleSourcePin(get()) }
+        addFactory { DeleteSourcePinGroup(get()) }
         addSingletonFactory { TrustExtension(get(), get()) } // Singleton to enable caching of trusted fingerprints
 
         addSingletonFactory { ExtensionStoreService(get(), get(), get()) }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/DeleteSourcePinGroup.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/DeleteSourcePinGroup.kt
@@ -1,0 +1,16 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.core.common.preference.getAndSet
+
+class DeleteSourcePinGroup(
+    private val preferences: SourcePreferences,
+) {
+
+    fun await(group: String) {
+        preferences.groupPinnedSources.getAndSet { entries ->
+            entries.filterNot { it.substringBeforeLast("|") == group }
+                .toSet()
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledNovelSources.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledNovelSources.kt
@@ -21,17 +21,25 @@ class GetEnabledNovelSources(
 ) {
 
     fun subscribe(): Flow<List<Source>> {
-        return combine(
+        val pinStateFlow = combine(
             preferences.pinnedSources.changes(),
+            preferences.groupPinnedSources.changes(),
+        ) { pinnedSourceIds, groupPinnedSources ->
+            pinnedSourceIds to groupPinnedSources
+        }
+
+        return combine(
+            pinStateFlow,
             preferences.enabledLanguages.changes(),
             preferences.disabledSources.changes(),
             preferences.lastUsedSource.changes(),
             repository.getSources(),
-        ) { pinnedSourceIds, enabledLanguages, disabledSources, lastUsedSource, sources ->
+        ) { (pinnedSourceIds, groupPinnedSources), enabledLanguages, disabledSources, lastUsedSource, sources ->
             logcat(LogPriority.DEBUG) {
                 "GetEnabledNovelSources: ${sources.size} total sources, enabledLangs=$enabledLanguages"
             }
             sources
+                .asSequence()
                 .filter { it.lang in enabledLanguages || it.isLocalNovel() }
                 .filterNot { it.id.toString() in disabledSources }
                 .filter { it.isNovelSource || it.isLocalNovel() }
@@ -43,13 +51,18 @@ class GetEnabledNovelSources(
                 )
                 .flatMap {
                     val flag = if ("${it.id}" in pinnedSourceIds) Pins.pinned else Pins.unpinned
-                    val source = it.copy(pin = flag)
+                    val sourceGroups = groupPinnedSources
+                        .filter { entry -> entry.endsWith("|${it.id}") }
+                        .map { entry -> entry.substringBeforeLast("|") }
+                        .toSet()
+                    val source = it.copy(pin = flag, pinnedGroups = sourceGroups)
                     val toFlatten = mutableListOf(source)
                     if (source.id == lastUsedSource) {
                         toFlatten.add(source.copy(isUsedLast = true, pin = source.pin - Pin.Actual))
                     }
                     toFlatten
                 }
+                .toList()
         }
             .distinctUntilChanged()
     }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
@@ -20,13 +20,20 @@ class GetEnabledSources(
 ) {
 
     fun subscribe(): Flow<List<Source>> {
-        return combine(
+        val pinStateFlow = combine(
             preferences.pinnedSources.changes(),
+            preferences.groupPinnedSources.changes(),
+        ) { pinnedSourceIds, groupPinnedSources ->
+            pinnedSourceIds to groupPinnedSources
+        }
+
+        return combine(
+            pinStateFlow,
             preferences.enabledLanguages.changes(),
             preferences.disabledSources.changes(),
             preferences.lastUsedSource.changes(),
             repository.getSources(),
-        ) { pinnedSourceIds, enabledLanguages, disabledSources, lastUsedSource, sources ->
+        ) { (pinnedSourceIds, groupPinnedSources), enabledLanguages, disabledSources, lastUsedSource, sources ->
             sources
                 .filter { it.lang in enabledLanguages || it.isLocal() }
                 .filterNot { it.id.toString() in disabledSources }
@@ -35,7 +42,11 @@ class GetEnabledSources(
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
                 .flatMap {
                     val flag = if ("${it.id}" in pinnedSourceIds) Pins.pinned else Pins.unpinned
-                    val source = it.copy(pin = flag)
+                    val sourceGroups = groupPinnedSources
+                        .filter { entry -> entry.endsWith("|${it.id}") }
+                        .map { entry -> entry.substringBeforeLast("|") }
+                        .toSet()
+                    val source = it.copy(pin = flag, pinnedGroups = sourceGroups)
                     val toFlatten = mutableListOf(source)
                     if (source.id == lastUsedSource) {
                         toFlatten.add(source.copy(isUsedLast = true, pin = source.pin - Pin.Actual))

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
@@ -1,0 +1,21 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.domain.source.model.Source
+
+class GetSourcePinGroups(
+    private val preferences: SourcePreferences,
+) {
+
+    fun execute(source: Source): Pair<List<String>, List<Boolean>> {
+        val allPinGroups = preferences.groupPinnedSources.get()
+            .map { it.substringBeforeLast("|") }
+            .distinct()
+
+        val sourcePinnedGroups = preferences.groupPinnedSources.get()
+            .filter { it.endsWith("|${source.id}") }
+            .map { it.substringBeforeLast("|") }
+
+        return allPinGroups to allPinGroups.map { it in sourcePinnedGroups }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
@@ -11,6 +11,7 @@ class GetSourcePinGroups(
         val allPinGroups = preferences.groupPinnedSources.get()
             .map { it.substringBeforeLast("|") }
             .distinct()
+            .sorted()
 
         val sourcePinnedGroups = preferences.groupPinnedSources.get()
             .filter { it.endsWith("|${source.id}") }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/SetSourcePinGroups.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/SetSourcePinGroups.kt
@@ -1,0 +1,22 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.core.common.preference.getAndSet
+import tachiyomi.domain.source.model.Source
+
+class SetSourcePinGroups(
+    private val preferences: SourcePreferences,
+) {
+
+    fun await(source: Source, groups: Set<String>) {
+        val newEntries = groups.map { "$it|${source.id}" }.toSet()
+
+        val prevEntries = preferences.groupPinnedSources.get().filter {
+            it.substringAfterLast("|") == source.id.toString()
+        }.toSet()
+
+        preferences.groupPinnedSources.getAndSet { entries ->
+            entries.minus(prevEntries).plus(newEntries)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -34,6 +34,14 @@ class SourcePreferences(
 
     val pinnedSources: Preference<Set<String>> = preferenceStore.getStringSet("pinned_catalogues", emptySet())
 
+    /**
+     * Format: { "$group_name|$sourceid" }
+     */
+    val groupPinnedSources: Preference<Set<String>> = preferenceStore.getStringSet(
+        "group_pinned_catalogues",
+        emptySet(),
+    )
+
     val lastUsedSource: Preference<Long> = preferenceStore.getLong(
         Preference.appStateKey("last_catalogue_source"),
         -1,

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -43,6 +43,7 @@ fun GlobalSearchScreen(
                 onSearch = onSearch,
                 hideSourceFilter = false,
                 sourceFilter = state.sourceFilter,
+                pinGroups = state.pinGroups,
                 onChangeSearchFilter = onChangeSearchFilter,
                 onlyShowHasResults = state.onlyShowHasResults,
                 onToggleResults = onToggleResults,

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -1,23 +1,40 @@
 package eu.kanade.presentation.browse
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -46,6 +63,8 @@ fun SourcesScreen(
     contentPadding: PaddingValues,
     onClickItem: (Source, Listing) -> Unit,
     onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
     onLongClickItem: (Source) -> Unit,
 ) {
     when {
@@ -69,7 +88,7 @@ fun SourcesScreen(
                     key = {
                         when (it) {
                             is SourceUiModel.Header -> it.hashCode()
-                            is SourceUiModel.Item -> "source-${it.source.key()}"
+                            is SourceUiModel.Item -> "source-${it.sectionKey}-${it.source.key()}"
                         }
                     },
                 ) { model ->
@@ -78,15 +97,19 @@ fun SourcesScreen(
                             SourceHeader(
                                 modifier = Modifier.animateItem(),
                                 language = model.language,
+                                isGroup = model.isGroup,
                             )
                         }
                         is SourceUiModel.Item -> SourceItem(
                             modifier = Modifier.animateItem(),
                             source = model.source,
                             hasDefaultPreset = model.hasDefaultPreset,
+                            groupSection = model.sectionKey.ifEmpty { null },
                             onClickItem = onClickItem,
                             onLongClickItem = onLongClickItem,
                             onClickPin = onClickPin,
+                            onLongClickPin = onLongClickPin,
+                            onRemoveFromGroup = onRemoveFromGroup,
                         )
                     }
                 }
@@ -99,10 +122,11 @@ fun SourcesScreen(
 private fun SourceHeader(
     language: String,
     modifier: Modifier = Modifier,
+    isGroup: Boolean = false,
 ) {
     val context = LocalContext.current
     Text(
-        text = LocaleHelper.getSourceDisplayName(language, context),
+        text = if (isGroup) language else LocaleHelper.getSourceDisplayName(language, context),
         modifier = modifier
             .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
         style = MaterialTheme.typography.header,
@@ -113,9 +137,12 @@ private fun SourceHeader(
 private fun SourceItem(
     source: Source,
     hasDefaultPreset: Boolean,
+    groupSection: String?,
     onClickItem: (Source, Listing) -> Unit,
     onLongClickItem: (Source) -> Unit,
     onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BaseSourceItem(
@@ -144,8 +171,11 @@ private fun SourceItem(
                 }
             }
             SourcePinButton(
-                isPinned = Pin.Pinned in source.pin,
-                onClick = { onClickPin(source) },
+                source = source,
+                groupSection = groupSection,
+                onClickPin = onClickPin,
+                onLongClickPin = onLongClickPin,
+                onRemoveFromGroup = onRemoveFromGroup,
             )
         },
     )
@@ -153,19 +183,57 @@ private fun SourceItem(
 
 @Composable
 private fun SourcePinButton(
-    isPinned: Boolean,
-    onClick: () -> Unit,
+    source: Source,
+    groupSection: String?,
+    onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
 ) {
-    val icon = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin
-    val tint = if (isPinned) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.onBackground.copy(
-            alpha = SECONDARY_ALPHA,
-        )
+    val isPinned = Pin.Pinned in source.pin
+    val isInGroup = source.pinnedGroups.isNotEmpty()
+    val showGroupIcon = groupSection != null || (isInGroup && !isPinned)
+
+    val icon = when {
+        showGroupIcon -> Icons.AutoMirrored.Filled.Label
+        isPinned -> Icons.Filled.PushPin
+        else -> Icons.Outlined.PushPin
     }
-    val description = if (isPinned) MR.strings.action_unpin else MR.strings.action_pin
-    IconButton(onClick = onClick) {
+    val tint = when {
+        showGroupIcon -> MaterialTheme.colorScheme.secondary
+        isPinned -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onBackground.copy(alpha = SECONDARY_ALPHA)
+    }
+    val description = when {
+        groupSection != null -> MR.strings.action_remove
+        showGroupIcon -> MR.strings.action_pin_groups
+        isPinned -> MR.strings.action_unpin
+        else -> MR.strings.action_pin
+    }
+    // In a group section: remove from that group; grouped elsewhere: open dialog; else: toggle pin.
+    val onClick: () -> Unit = when {
+        groupSection != null -> {
+            { onRemoveFromGroup(source, groupSection) }
+        }
+        showGroupIcon -> {
+            { onLongClickPin(source) }
+        }
+        else -> {
+            { onClickPin(source) }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .minimumInteractiveComponentSize()
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = { onLongClickPin(source) },
+                role = androidx.compose.ui.semantics.Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(bounded = false, radius = 24.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
         Icon(
             imageVector = icon,
             tint = tint,
@@ -178,6 +246,7 @@ private fun SourcePinButton(
 fun SourceOptionsDialog(
     source: Source,
     onClickPin: () -> Unit,
+    onClickPinGroups: () -> Unit,
     onClickDisable: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -192,6 +261,13 @@ fun SourceOptionsDialog(
                     text = stringResource(textId),
                     modifier = Modifier
                         .clickable(onClick = onClickPin)
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                )
+                Text(
+                    text = stringResource(MR.strings.action_pin_groups),
+                    modifier = Modifier
+                        .clickable(onClick = onClickPinGroups)
                         .fillMaxWidth()
                         .padding(vertical = 16.dp),
                 )
@@ -211,7 +287,161 @@ fun SourceOptionsDialog(
     )
 }
 
+@Composable
+fun SourcePinGroupsDialog(
+    source: Source,
+    pinGroups: Pair<List<String>, List<Boolean>>,
+    isPinned: Boolean,
+    onTogglePin: () -> Unit,
+    onConfirm: (Set<String>) -> Unit,
+    onDeleteGroup: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val (initialGroups, initialSelections) = pinGroups
+    val groups = remember {
+        mutableStateListOf<String>().apply { addAll(initialGroups) }
+    }
+    val selectedIndices = remember {
+        mutableStateListOf<Boolean>().apply { addAll(initialSelections) }
+    }
+    var pinned by remember { mutableStateOf(isPinned) }
+    var newGroupName by remember { mutableStateOf("") }
+    var createNewGroup by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        title = {
+            Column {
+                Text(text = source.visualName)
+                Text(
+                    text = stringResource(MR.strings.action_pin_groups),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        text = {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            pinned = !pinned
+                            onTogglePin()
+                        }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = if (pinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = null,
+                        tint = if (pinned) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                    Text(
+                        text = stringResource(if (pinned) MR.strings.action_unpin else MR.strings.action_pin),
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                groups.forEachIndexed { index, group ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                selectedIndices[index] = !selectedIndices[index]
+                            }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = selectedIndices[index],
+                            onCheckedChange = null,
+                        )
+                        Text(
+                            text = group,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 12.dp),
+                        )
+                        IconButton(
+                            onClick = {
+                                onDeleteGroup(group)
+                                groups.removeAt(index)
+                                selectedIndices.removeAt(index)
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Delete,
+                                contentDescription = stringResource(MR.strings.action_delete),
+                            )
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { createNewGroup = !createNewGroup }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = createNewGroup,
+                        onCheckedChange = null,
+                    )
+                    OutlinedTextField(
+                        value = newGroupName,
+                        onValueChange = {
+                            val sanitized = it.replace("|", "")
+                            newGroupName = sanitized
+                            createNewGroup = sanitized.isNotBlank()
+                        },
+                        modifier = Modifier
+                            .padding(start = 12.dp)
+                            .fillMaxWidth(),
+                        placeholder = { Text(text = stringResource(MR.strings.action_add_pin_group)) },
+                        singleLine = true,
+                    )
+                }
+            }
+        },
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val finalGroups = groups
+                        .filterIndexed { index, _ -> selectedIndices[index] }
+                        .toMutableSet()
+
+                    if (createNewGroup && newGroupName.isNotBlank()) {
+                        finalGroups.add(newGroupName.trim())
+                    }
+                    onConfirm(finalGroups)
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+}
+
 sealed interface SourceUiModel {
-    data class Item(val source: Source, val hasDefaultPreset: Boolean = false) : SourceUiModel
-    data class Header(val language: String) : SourceUiModel
+    data class Item(
+        val source: Source,
+        val sectionKey: String = "",
+        val hasDefaultPreset: Boolean = false,
+    ) : SourceUiModel
+    data class Header(
+        val language: String,
+        val isGroup: Boolean = false,
+    ) : SourceUiModel
 }

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -46,6 +46,7 @@ import eu.kanade.tachiyomi.util.system.LocaleHelper
 import tachiyomi.domain.source.model.Pin
 import tachiyomi.domain.source.model.Source
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
 import tachiyomi.presentation.core.components.material.SECONDARY_ALPHA
 import tachiyomi.presentation.core.components.material.padding
@@ -205,7 +206,7 @@ private fun SourcePinButton(
     }
     val description = when {
         groupSection != null -> MR.strings.action_remove
-        showGroupIcon -> MR.strings.action_pin_groups
+        showGroupIcon -> TDMR.strings.action_pin_groups
         isPinned -> MR.strings.action_unpin
         else -> MR.strings.action_pin
     }
@@ -265,7 +266,7 @@ fun SourceOptionsDialog(
                         .padding(vertical = 16.dp),
                 )
                 Text(
-                    text = stringResource(MR.strings.action_pin_groups),
+                    text = stringResource(TDMR.strings.action_pin_groups),
                     modifier = Modifier
                         .clickable(onClick = onClickPinGroups)
                         .fillMaxWidth()
@@ -307,13 +308,46 @@ fun SourcePinGroupsDialog(
     var pinned by remember { mutableStateOf(isPinned) }
     var newGroupName by remember { mutableStateOf("") }
     var createNewGroup by remember { mutableStateOf(false) }
+    var groupPendingDelete by remember { mutableStateOf<String?>(null) }
+
+    groupPendingDelete?.let { group ->
+        AlertDialog(
+            onDismissRequest = { groupPendingDelete = null },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDeleteGroup(group)
+                        val index = groups.indexOf(group)
+                        if (index != -1) {
+                            groups.removeAt(index)
+                            selectedIndices.removeAt(index)
+                        }
+                        groupPendingDelete = null
+                    },
+                ) {
+                    Text(text = stringResource(MR.strings.action_ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { groupPendingDelete = null }) {
+                    Text(text = stringResource(MR.strings.action_cancel))
+                }
+            },
+            title = {
+                Text(text = stringResource(TDMR.strings.delete_pin_group))
+            },
+            text = {
+                Text(text = stringResource(TDMR.strings.delete_pin_group_confirmation, group))
+            },
+        )
+    }
 
     AlertDialog(
         title = {
             Column {
                 Text(text = source.visualName)
                 Text(
-                    text = stringResource(MR.strings.action_pin_groups),
+                    text = stringResource(TDMR.strings.action_pin_groups),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -368,11 +402,7 @@ fun SourcePinGroupsDialog(
                                 .padding(start = 12.dp),
                         )
                         IconButton(
-                            onClick = {
-                                onDeleteGroup(group)
-                                groups.removeAt(index)
-                                selectedIndices.removeAt(index)
-                            },
+                            onClick = { groupPendingDelete = group },
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.Delete,
@@ -403,7 +433,7 @@ fun SourcePinGroupsDialog(
                         modifier = Modifier
                             .padding(start = 12.dp)
                             .fillMaxWidth(),
-                        placeholder = { Text(text = stringResource(MR.strings.action_add_pin_group)) },
+                        placeholder = { Text(text = stringResource(TDMR.strings.action_add_pin_group)) },
                         singleLine = true,
                     )
                 }

--- a/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
@@ -1,5 +1,8 @@
 package eu.kanade.presentation.browse.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -11,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
@@ -24,8 +29,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import tachiyomi.i18n.MR
@@ -42,11 +52,20 @@ fun GlobalSearchToolbar(
     onSearch: (String) -> Unit,
     hideSourceFilter: Boolean,
     sourceFilter: SourceFilter,
+    pinGroups: List<String> = emptyList(),
     onChangeSearchFilter: (SourceFilter) -> Unit,
     onlyShowHasResults: Boolean,
     onToggleResults: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
+    var showGroupRow by remember { mutableStateOf(false) }
+
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (showGroupRow) -90f else 0f,
+        animationSpec = tween(durationMillis = 200),
+        label = "ArrowRotation",
+    )
+
     Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
         Box {
             SearchToolbar(
@@ -73,32 +92,59 @@ fun GlobalSearchToolbar(
                 .padding(horizontal = MaterialTheme.padding.small),
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
         ) {
-            // TODO: make this UX better; it only applies when triggering a new search
             if (!hideSourceFilter) {
+                val isPinnedOrGroup = sourceFilter == SourceFilter.PinnedOnly || sourceFilter is SourceFilter.Group
+                val pinnedLabel = when (sourceFilter) {
+                    is SourceFilter.Group -> sourceFilter.name
+                    else -> stringResource(MR.strings.pinned_sources)
+                }
+                val pinnedIcon = when (sourceFilter) {
+                    is SourceFilter.Group -> Icons.AutoMirrored.Outlined.Label
+                    else -> Icons.Outlined.PushPin
+                }
+
                 FilterChip(
-                    selected = sourceFilter == SourceFilter.PinnedOnly,
-                    onClick = { onChangeSearchFilter(SourceFilter.PinnedOnly) },
+                    selected = isPinnedOrGroup,
+                    onClick = {
+                        if (!isPinnedOrGroup) {
+                            onChangeSearchFilter(SourceFilter.PinnedOnly)
+                        } else if (pinGroups.isNotEmpty()) {
+                            showGroupRow = !showGroupRow
+                        }
+                    },
                     leadingIcon = {
                         Icon(
-                            imageVector = Icons.Outlined.PushPin,
+                            imageVector = pinnedIcon,
                             contentDescription = null,
-                            modifier = Modifier
-                                .size(FilterChipDefaults.IconSize),
+                            modifier = Modifier.size(FilterChipDefaults.IconSize),
                         )
                     },
+                    trailingIcon = if (pinGroups.isNotEmpty()) {
+                        {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowLeft,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(FilterChipDefaults.IconSize)
+                                    .rotate(arrowRotation),
+                            )
+                        }
+                    } else null,
                     label = {
-                        Text(text = stringResource(MR.strings.pinned_sources))
+                        Text(text = pinnedLabel)
                     },
                 )
                 FilterChip(
                     selected = sourceFilter == SourceFilter.All,
-                    onClick = { onChangeSearchFilter(SourceFilter.All) },
+                    onClick = {
+                        onChangeSearchFilter(SourceFilter.All)
+                        showGroupRow = false
+                    },
                     leadingIcon = {
                         Icon(
                             imageVector = Icons.Outlined.DoneAll,
                             contentDescription = null,
-                            modifier = Modifier
-                                .size(FilterChipDefaults.IconSize),
+                            modifier = Modifier.size(FilterChipDefaults.IconSize),
                         )
                     },
                     label = {
@@ -116,14 +162,46 @@ fun GlobalSearchToolbar(
                     Icon(
                         imageVector = Icons.Outlined.FilterList,
                         contentDescription = null,
-                        modifier = Modifier
-                            .size(FilterChipDefaults.IconSize),
+                        modifier = Modifier.size(FilterChipDefaults.IconSize),
                     )
                 },
                 label = {
                     Text(text = stringResource(MR.strings.has_results))
                 },
             )
+        }
+
+        AnimatedVisibility(visible = showGroupRow && pinGroups.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = MaterialTheme.padding.small, vertical = MaterialTheme.padding.extraSmall),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            ) {
+                pinGroups.forEach { group ->
+                    val isGroupSelected = sourceFilter == SourceFilter.Group(group)
+                    FilterChip(
+                        selected = isGroupSelected,
+                        onClick = {
+                            if (isGroupSelected) {
+                                onChangeSearchFilter(SourceFilter.PinnedOnly)
+                            } else {
+                                onChangeSearchFilter(SourceFilter.Group(group))
+                            }
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.Label,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize),
+                            )
+                        },
+                        label = {
+                            Text(text = group)
+                        },
+                    )
+                }
+            }
         }
 
         HorizontalDivider()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesScreenModel.kt
@@ -3,8 +3,11 @@ package eu.kanade.tachiyomi.ui.browse.source
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.interactor.DeleteSourcePinGroup
 import eu.kanade.domain.source.interactor.GetEnabledNovelSources
+import eu.kanade.domain.source.interactor.GetSourcePinGroups
 import eu.kanade.domain.source.interactor.ManageFilterPresets
+import eu.kanade.domain.source.interactor.SetSourcePinGroups
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.presentation.browse.SourceUiModel
@@ -27,6 +30,9 @@ class NovelSourcesScreenModel(
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
     private val manageFilterPresets: ManageFilterPresets = Injekt.get(),
+    private val setSourcePinGroups: SetSourcePinGroups = Injekt.get(),
+    private val getSourcePinGroups: GetSourcePinGroups = Injekt.get(),
+    private val deleteSourcePinGroup: DeleteSourcePinGroup = Injekt.get(),
 ) : StateScreenModel<NovelSourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -71,21 +77,43 @@ class NovelSourcesScreenModel(
                 }
             }
 
-            state.copy(
-                isLoading = false,
-                items = byLang
-                    .flatMap {
-                        listOf(
-                            SourceUiModel.Header(it.key),
-                            *it.value.map { source ->
-                                SourceUiModel.Item(
-                                    source = source,
-                                    hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
-                                )
-                            }.toTypedArray(),
+            val groupNames = sources.flatMap { it.pinnedGroups }.distinct().sorted()
+            val groupSections = groupNames.flatMap { group ->
+                listOf<SourceUiModel>(SourceUiModel.Header(group, isGroup = true)) +
+                    sources.filter { !it.isUsedLast && group in it.pinnedGroups }
+                        .map {
+                            SourceUiModel.Item(
+                                source = it,
+                                sectionKey = group,
+                                hasDefaultPreset = manageFilterPresets.getDefaultPresetState(it.id) != null,
+                            )
+                        }
+            }
+
+            val items = buildList {
+                var groupsInserted = false
+                for ((key, value) in byLang) {
+                    val isSpecial = key == LAST_USED_KEY || key == PINNED_KEY
+                    if (!isSpecial && !groupsInserted) {
+                        addAll(groupSections)
+                        groupsInserted = true
+                    }
+                    add(SourceUiModel.Header(key))
+                    value.forEach { source ->
+                        add(
+                            SourceUiModel.Item(
+                                source = source,
+                                hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
+                            ),
                         )
                     }
-                    .toList(),
+                }
+                if (!groupsInserted) addAll(groupSections)
+            }
+
+            state.copy(
+                isLoading = false,
+                items = items,
             )
         }
     }
@@ -98,8 +126,28 @@ class NovelSourcesScreenModel(
         toggleSourcePin.await(source)
     }
 
+    fun setSourcePinGroups(source: Source, pinGroups: Set<String>) {
+        setSourcePinGroups.await(source, pinGroups)
+    }
+
+    fun removeSourceFromGroup(source: Source, group: String) {
+        setSourcePinGroups.await(source, source.pinnedGroups - group)
+    }
+
+    fun getSourcePinGroups(source: Source): Pair<List<String>, List<Boolean>> {
+        return getSourcePinGroups.execute(source)
+    }
+
+    fun deleteSourcePinGroup(pinGroup: String) {
+        deleteSourcePinGroup.await(pinGroup)
+    }
+
     fun showSourceDialog(source: Source) {
-        mutableState.update { it.copy(dialog = Dialog(source)) }
+        mutableState.update { it.copy(dialog = Dialog.SourceOptions(source)) }
+    }
+
+    fun showPinGroupsDialog(source: Source) {
+        mutableState.update { it.copy(dialog = Dialog.PinGroups(source)) }
     }
 
     fun closeDialog() {
@@ -110,7 +158,10 @@ class NovelSourcesScreenModel(
         data object FailedFetchingSources : Event
     }
 
-    data class Dialog(val source: Source)
+    sealed interface Dialog {
+        data class SourceOptions(val source: Source) : Dialog
+        data class PinGroups(val source: Source) : Dialog
+    }
 
     @Immutable
     data class State(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/NovelSourcesTab.kt
@@ -13,6 +13,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.SourceOptionsDialog
+import eu.kanade.presentation.browse.SourcePinGroupsDialog
 import eu.kanade.presentation.browse.SourcesScreen
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
@@ -21,6 +22,7 @@ import eu.kanade.tachiyomi.ui.browse.source.custom.CustomSourcesScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.NovelGlobalSearchScreen
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import tachiyomi.domain.source.model.Pin
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -51,9 +53,14 @@ fun Screen.novelSourcesTab(): TabContent {
             ),
         ),
         content = { contentPadding, snackbarHostState ->
+            val mappedDialog = when (val d = state.dialog) {
+                is NovelSourcesScreenModel.Dialog.SourceOptions -> SourcesScreenModel.Dialog.SourceOptions(d.source)
+                is NovelSourcesScreenModel.Dialog.PinGroups -> SourcesScreenModel.Dialog.PinGroups(d.source)
+                null -> null
+            }
             SourcesScreen(
                 state = SourcesScreenModel.State(
-                    dialog = state.dialog?.let { SourcesScreenModel.Dialog(it.source) },
+                    dialog = mappedDialog,
                     isLoading = state.isLoading,
                     items = state.items,
                 ),
@@ -65,22 +72,48 @@ fun Screen.novelSourcesTab(): TabContent {
                     screenModel.showSourceDialog(source)
                 },
                 onClickPin = screenModel::togglePin,
+                onLongClickPin = screenModel::showPinGroupsDialog,
+                onRemoveFromGroup = screenModel::removeSourceFromGroup,
             )
 
-            state.dialog?.let { dialog ->
-                val source = dialog.source
-                SourceOptionsDialog(
-                    source = source,
-                    onClickPin = {
-                        screenModel.togglePin(source)
-                        screenModel.closeDialog()
-                    },
-                    onClickDisable = {
-                        screenModel.toggleSource(source)
-                        screenModel.closeDialog()
-                    },
-                    onDismiss = screenModel::closeDialog,
-                )
+            val currentDialog = state.dialog
+
+            if (currentDialog != null) {
+                when (currentDialog) {
+                    is NovelSourcesScreenModel.Dialog.SourceOptions -> {
+                        val source = currentDialog.source
+                        SourceOptionsDialog(
+                            source = source,
+                            onClickPin = {
+                                screenModel.togglePin(source)
+                                screenModel.closeDialog()
+                            },
+                            onClickPinGroups = {
+                                screenModel.showPinGroupsDialog(source)
+                            },
+                            onClickDisable = {
+                                screenModel.toggleSource(source)
+                                screenModel.closeDialog()
+                            },
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                    is NovelSourcesScreenModel.Dialog.PinGroups -> {
+                        val source = currentDialog.source
+                        SourcePinGroupsDialog(
+                            source = source,
+                            pinGroups = screenModel.getSourcePinGroups(source),
+                            isPinned = Pin.Pinned in source.pin,
+                            onTogglePin = { screenModel.togglePin(source) },
+                            onConfirm = { selectedGroups ->
+                                screenModel.setSourcePinGroups(source, selectedGroups)
+                                screenModel.closeDialog()
+                            },
+                            onDeleteGroup = screenModel::deleteSourcePinGroup,
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                }
             }
 
             val internalErrString = stringResource(MR.strings.internal_error)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
@@ -3,8 +3,11 @@ package eu.kanade.tachiyomi.ui.browse.source
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.interactor.DeleteSourcePinGroup
 import eu.kanade.domain.source.interactor.GetEnabledSources
+import eu.kanade.domain.source.interactor.GetSourcePinGroups
 import eu.kanade.domain.source.interactor.ManageFilterPresets
+import eu.kanade.domain.source.interactor.SetSourcePinGroups
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.presentation.browse.SourceUiModel
@@ -27,6 +30,9 @@ class SourcesScreenModel(
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
     private val manageFilterPresets: ManageFilterPresets = Injekt.get(),
+    private val setSourcePinGroups: SetSourcePinGroups = Injekt.get(),
+    private val getSourcePinGroups: GetSourcePinGroups = Injekt.get(),
+    private val deleteSourcePinGroup: DeleteSourcePinGroup = Injekt.get(),
 ) : StateScreenModel<SourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -65,20 +71,43 @@ class SourcesScreenModel(
                 }
             }
 
+            val groupNames = sources.flatMap { it.pinnedGroups }.distinct().sorted()
+            val groupSections = groupNames.flatMap { group ->
+                listOf<SourceUiModel>(SourceUiModel.Header(group, isGroup = true)) +
+                    sources.filter { !it.isUsedLast && group in it.pinnedGroups }
+                        .map {
+                            SourceUiModel.Item(
+                                source = it,
+                                sectionKey = group,
+                                hasDefaultPreset = manageFilterPresets.getDefaultPresetState(it.id) != null,
+                            )
+                        }
+            }
+
+            val items = buildList {
+                var groupsInserted = false
+                for ((key, value) in byLang) {
+                    val isSpecial = key == LAST_USED_KEY || key == PINNED_KEY
+                    if (!isSpecial && !groupsInserted) {
+                        addAll(groupSections)
+                        groupsInserted = true
+                    }
+                    add(SourceUiModel.Header(key))
+                    value.forEach { source ->
+                        add(
+                            SourceUiModel.Item(
+                                source = source,
+                                hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
+                            ),
+                        )
+                    }
+                }
+                if (!groupsInserted) addAll(groupSections)
+            }
+
             state.copy(
                 isLoading = false,
-                items = byLang
-                    .flatMap {
-                        listOf(
-                            SourceUiModel.Header(it.key),
-                            *it.value.map { source ->
-                                SourceUiModel.Item(
-                                    source = source,
-                                    hasDefaultPreset = manageFilterPresets.getDefaultPresetState(source.id) != null,
-                                )
-                            }.toTypedArray(),
-                        )
-                    },
+                items = items,
             )
         }
     }
@@ -91,8 +120,28 @@ class SourcesScreenModel(
         toggleSourcePin.await(source)
     }
 
+    fun setSourcePinGroups(source: Source, pinGroups: Set<String>) {
+        setSourcePinGroups.await(source, pinGroups)
+    }
+
+    fun removeSourceFromGroup(source: Source, group: String) {
+        setSourcePinGroups.await(source, source.pinnedGroups - group)
+    }
+
+    fun getSourcePinGroups(source: Source): Pair<List<String>, List<Boolean>> {
+        return getSourcePinGroups.execute(source)
+    }
+
+    fun deleteSourcePinGroup(pinGroup: String) {
+        deleteSourcePinGroup.await(pinGroup)
+    }
+
     fun showSourceDialog(source: Source) {
-        mutableState.update { it.copy(dialog = Dialog(source)) }
+        mutableState.update { it.copy(dialog = Dialog.SourceOptions(source)) }
+    }
+
+    fun showPinGroupsDialog(source: Source) {
+        mutableState.update { it.copy(dialog = Dialog.PinGroups(source)) }
     }
 
     fun closeDialog() {
@@ -103,7 +152,10 @@ class SourcesScreenModel(
         data object FailedFetchingSources : Event
     }
 
-    data class Dialog(val source: Source)
+    sealed interface Dialog {
+        data class SourceOptions(val source: Source) : Dialog
+        data class PinGroups(val source: Source) : Dialog
+    }
 
     @Immutable
     data class State(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -12,6 +12,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.SourceOptionsDialog
+import eu.kanade.presentation.browse.SourcePinGroupsDialog
 import eu.kanade.presentation.browse.SourcesScreen
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
@@ -19,6 +20,7 @@ import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import tachiyomi.domain.source.model.Pin
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -52,22 +54,48 @@ fun Screen.sourcesTab(): TabContent {
                 },
                 onClickPin = screenModel::togglePin,
                 onLongClickItem = screenModel::showSourceDialog,
+                onLongClickPin = screenModel::showPinGroupsDialog,
+                onRemoveFromGroup = screenModel::removeSourceFromGroup,
             )
 
-            state.dialog?.let { dialog ->
-                val source = dialog.source
-                SourceOptionsDialog(
-                    source = source,
-                    onClickPin = {
-                        screenModel.togglePin(source)
-                        screenModel.closeDialog()
-                    },
-                    onClickDisable = {
-                        screenModel.toggleSource(source)
-                        screenModel.closeDialog()
-                    },
-                    onDismiss = screenModel::closeDialog,
-                )
+            val currentDialog = state.dialog
+
+            if (currentDialog != null) {
+                when (currentDialog) {
+                    is SourcesScreenModel.Dialog.SourceOptions -> {
+                        val source = currentDialog.source
+                        SourceOptionsDialog(
+                            source = source,
+                            onClickPin = {
+                                screenModel.togglePin(source)
+                                screenModel.closeDialog()
+                            },
+                            onClickPinGroups = {
+                                screenModel.showPinGroupsDialog(source)
+                            },
+                            onClickDisable = {
+                                screenModel.toggleSource(source)
+                                screenModel.closeDialog()
+                            },
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                    is SourcesScreenModel.Dialog.PinGroups -> {
+                        val source = currentDialog.source
+                        SourcePinGroupsDialog(
+                            source = source,
+                            pinGroups = screenModel.getSourcePinGroups(source),
+                            isPinned = Pin.Pinned in source.pin,
+                            onTogglePin = { screenModel.togglePin(source) },
+                            onConfirm = { selectedGroups ->
+                                screenModel.setSourcePinGroups(source, selectedGroups)
+                                screenModel.closeDialog()
+                            },
+                            onDeleteGroup = screenModel::deleteSourcePinGroup,
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                }
             }
 
             val internalErrString = stringResource(MR.strings.internal_error)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -20,8 +20,15 @@ class GlobalSearchScreenModel(
     }
 
     override fun getEnabledSources(): List<Source> {
+        val filter = state.value.sourceFilter
         return super.getEnabledSources()
             .filterNot { it.isNovelSource() } // Exclude novel sources from manga global search
-            .filter { state.value.sourceFilter != SourceFilter.PinnedOnly || "${it.id}" in pinnedSources }
+            .filter {
+                when (filter) {
+                    SourceFilter.All -> true
+                    SourceFilter.PinnedOnly -> "${it.id}" in pinnedSources
+                    is SourceFilter.Group -> "${it.id}" in sourceGroups.getOrElse(filter.name) { emptySet() }
+                }
+            }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/NovelGlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/NovelGlobalSearchScreenModel.kt
@@ -20,9 +20,16 @@ class NovelGlobalSearchScreenModel(
     }
 
     override fun getEnabledSources(): List<CatalogueSource> {
+        val filter = state.value.sourceFilter
         return super.getEnabledSources()
             .filterIsInstance<CatalogueSource>()
             .filter { it.isNovelSource() }
-            .filter { state.value.sourceFilter != SourceFilter.PinnedOnly || "${it.id}" in pinnedSources }
+            .filter {
+                when (filter) {
+                    SourceFilter.All -> true
+                    SourceFilter.PinnedOnly -> "${it.id}" in pinnedSources
+                    is SourceFilter.Group -> "${it.id}" in sourceGroups.getOrElse(filter.name) { emptySet() }
+                }
+            }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -48,6 +48,12 @@ abstract class SearchScreenModel(
     private val disabledSources = sourcePreferences.disabledSources.get()
     protected val pinnedSources = sourcePreferences.pinnedSources.get()
 
+    // Group name -> member source ids
+    protected val sourceGroups: Map<String, Set<String>> =
+        sourcePreferences.groupPinnedSources.get()
+            .groupBy({ it.substringBeforeLast("|") }, { it.substringAfterLast("|") })
+            .mapValues { (_, ids) -> ids.toSet() }
+
     private var lastQuery: String? = null
     private var lastSourceFilter: SourceFilter? = null
 
@@ -62,6 +68,7 @@ abstract class SearchScreenModel(
     }
 
     init {
+        mutableState.update { it.copy(pinGroups = sourceGroups.keys.sorted()) }
         screenModelScope.launch {
             preferences.globalSearchFilterState.changes().collectLatest { state ->
                 mutableState.update { it.copy(onlyShowHasResults = state) }
@@ -189,6 +196,7 @@ abstract class SearchScreenModel(
     }
 
     private fun updateItem(source: Source, result: SearchItemResult) {
+        if (source !in getSelectedSources()) return
         updateItems(state.value.items + (source to result))
     }
 
@@ -208,6 +216,7 @@ abstract class SearchScreenModel(
         val from: Manga? = null,
         val searchQuery: String? = null,
         val sourceFilter: SourceFilter = SourceFilter.PinnedOnly,
+        val pinGroups: List<String> = emptyList(),
         val onlyShowHasResults: Boolean = false,
         val items: Map<Source, SearchItemResult> = mapOf(),
         val dialog: Dialog? = null,
@@ -222,9 +231,10 @@ abstract class SearchScreenModel(
     }
 }
 
-enum class SourceFilter {
-    All,
-    PinnedOnly,
+sealed interface SourceFilter {
+    data object All : SourceFilter
+    data object PinnedOnly : SourceFilter
+    data class Group(val name: String) : SourceFilter
 }
 
 sealed interface SearchItemResult {

--- a/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
@@ -9,6 +9,7 @@ data class Source(
     val isNovelSource: Boolean = false,
     val isJsSource: Boolean = false,
     val pin: Pins = Pins.unpinned,
+    val pinnedGroups: Set<String> = emptySet(),
     val isUsedLast: Boolean = false,
 ) {
 

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -38,6 +38,10 @@
     <string name="action_order_by_total_chapters">By total chapters</string>
     <string name="action_order_by_extension">By extension</string>
     <string name="action_edit_alt_titles">Edit alternative titles</string>
+    <string name="action_pin_groups">Source groups</string>
+    <string name="action_add_pin_group">Add source group</string>
+    <string name="delete_pin_group">Delete source group</string>
+    <string name="delete_pin_group_confirmation">Do you wish to delete the source group \"%s\"? This removes it from all sources.</string>
     <string name="pref_category_manga_reader">Manga Reader</string>
     <string name="pref_category_novel_reader">Novel Reader</string>
     <string name="pref_manga_reader_summary">Manga reading mode, display, navigation</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -134,8 +134,6 @@
     <string name="action_disable">Disable</string>
     <string name="action_pin">Pin</string>
     <string name="action_unpin">Unpin</string>
-    <string name="action_pin_groups">Source groups</string>
-    <string name="action_add_pin_group">Add source group</string>
     <string name="action_apply">Apply</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_ok">OK</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -134,6 +134,8 @@
     <string name="action_disable">Disable</string>
     <string name="action_pin">Pin</string>
     <string name="action_unpin">Unpin</string>
+    <string name="action_pin_groups">Source groups</string>
+    <string name="action_add_pin_group">Add source group</string>
     <string name="action_apply">Apply</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_ok">OK</string>


### PR DESCRIPTION
Allows users to categorize sources into custom named groups.

Grouped sources are displayed under their respective group headers in the Sources tab. A new dialog, accessible by long-pressing the pin icon or via the source options, allows users to assign groups to sources and/or create new groups.

Global search is updated with a filter row for these custom groups, enabling users to restrict searches to specific source categories. This new row is accessed by tapping the already selected pin filter chip, and this behaviour only exists when there are any groups existing at all. When this extra row is available, an arrow trailing icon will appear next to the "pinned" label, hinting the expand possibility.

* Add `DeleteSourcePinGroup`, `GetSourcePinGroups`, and `SetSourcePinGroups` interactors
* Support source group preferences using a `$group_name|$sourceId` format
* Update `GetEnabledSources` and `GetEnabledNovelSources` to map group data to the `Source` model
* Update Global Search UI and models to support group-based filtering
* Add `SourcePinGroupsDialog` for creating and managing groups
* Update `SourcesScreen` to display grouped sections
* Add relevant strings for group actions

Closes #372 

### Sources screen
| Source dialog with new option | New group dialog | List with groups |
| ------- | ------- | ------- |
| ![](https://github.com/user-attachments/assets/42cafbbb-5aa2-4c2a-867f-472790636509) | ![](https://github.com/user-attachments/assets/18b9bd54-b5c0-42b1-bda1-5e7c106f7ce7) | ![](https://github.com/user-attachments/assets/56433bab-f12a-4462-97ad-6da8da39f893) |

### Global search
| Have groups | Group filter list expanded | Filtering by group | Filtering by group row collapsed |
| ------- | ------- | ------- | ------- |
| ![](https://github.com/user-attachments/assets/2ab00273-0314-4758-81ad-4ee3ad767f9d) | ![](https://github.com/user-attachments/assets/742f0083-88dd-4582-a3a0-af6d69f3997c) | ![](https://github.com/user-attachments/assets/a63fe6a5-820d-4a0e-be9e-996f90a15629) | ![](https://github.com/user-attachments/assets/cc18dc78-4aaf-4ab3-b25b-313b0db293df) |