### PR TITLE
Handle `<picture>`/`<source>`/`<video>`/`<audio>`  in textview 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Handle picture/source/video/audio tags in text view [@mrissaoussama](https://github.com/mrissaoussama) [#381](https://github.com/tsundoku-otaku/tsundoku/pull/381)
 
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
@@ -166,6 +166,7 @@ internal class NovelTextRenderer(
         return try {
             val doc = org.jsoup.Jsoup.parse(html)
             doc.select("style, script").remove()
+            unwrapPictureSources(doc)
             val targetWidth = activity.resources.displayMetrics.widthPixels
             doc.select("img").forEach { img ->
                 applySrcsetCandidate(img, targetWidth)
@@ -227,6 +228,14 @@ internal class NovelTextRenderer(
 
     companion object {
         private const val CHUNK_TARGET_CHARS = 6_000
+
+        // <source> is void; Html.fromHtml corrupts the rest of the document without one.
+        internal fun unwrapPictureSources(doc: org.jsoup.nodes.Document) {
+            doc.select("picture").forEach { picture ->
+                picture.select("source").remove()
+                picture.unwrap()
+            }
+        }
 
         fun clearTextViewSelection(textView: TextView) {
             val text = textView.text

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRenderer.kt
@@ -230,9 +230,30 @@ internal class NovelTextRenderer(
         private const val CHUNK_TARGET_CHARS = 6_000
 
         // <source> is void; Html.fromHtml corrupts the rest of the document without one.
+        private val DECODABLE_IMAGE_TYPES = setOf(
+            "image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif", "image/bmp",
+        )
+
+        private fun org.jsoup.nodes.Element.isDecodableSource(): Boolean {
+            val type = attr("type").trim().lowercase()
+            return type.isEmpty() || type in DECODABLE_IMAGE_TYPES
+        }
+
         internal fun unwrapPictureSources(doc: org.jsoup.nodes.Document) {
+            doc.select("video source, audio source").remove()
             doc.select("picture").forEach { picture ->
-                picture.select("source").remove()
+                val sources = picture.select("source")
+                val fallbackSrcset = sources.firstOrNull { it.isDecodableSource() && it.hasAttr("srcset") }
+                    ?.attr("srcset")
+                var img = picture.selectFirst("img")
+                if (img == null) {
+                    if (fallbackSrcset != null) {
+                        img = picture.appendElement("img").attr("srcset", fallbackSrcset)
+                    }
+                } else if (!img.hasAttr("srcset") && fallbackSrcset != null) {
+                    img.attr("srcset", fallbackSrcset)
+                }
+                sources.remove()
                 picture.unwrap()
             }
         }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRendererTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRendererTest.kt
@@ -46,4 +46,52 @@ class NovelTextRendererTest {
         assertTrue(doc.select("picture, source").isEmpty())
         assertEquals(listOf("a.jpg", "b.jpg"), doc.select("img").map { it.attr("src") })
     }
+
+    @Test
+    fun `strips source elements out of video and audio tags without unwrapping them`() {
+        val html = """
+            <video controls><source src="a.mp4" type="video/mp4"></video>
+            <audio controls><source src="a.mp3" type="audio/mpeg"></audio>
+        """.trimIndent()
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertTrue(doc.select("source").isEmpty(), "source candidates should be removed")
+        assertTrue(doc.select("video").isNotEmpty(), "video element itself should be kept")
+        assertTrue(doc.select("audio").isNotEmpty(), "audio element itself should be kept")
+    }
+
+    @Test
+    fun `carries a decodable source's srcset onto the fallback img for width selection`() {
+        val html = """
+            <picture>
+                <source srcset="small.jpg 480w, large.jpg 1200w" type="image/jpeg">
+                <img src="fallback.jpg">
+            </picture>
+        """.trimIndent()
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        val img = doc.selectFirst("img")
+        assertEquals("small.jpg 480w, large.jpg 1200w", img?.attr("srcset"))
+    }
+
+    @Test
+    fun `synthesizes an img from a decodable source when no fallback img exists`() {
+        val html = """<picture><source srcset="only.jpg" type="image/jpeg"></picture>"""
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertTrue(doc.select("picture, source").isEmpty())
+        assertEquals("only.jpg", doc.selectFirst("img")?.attr("srcset"))
+    }
+
+    @Test
+    fun `does not synthesize an img when every source is an undecodable format`() {
+        val html = """<picture><source srcset="only.avif" type="image/avif"></picture>"""
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertTrue(doc.select("picture, source, img").isEmpty())
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRendererTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextRendererTest.kt
@@ -1,0 +1,49 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.text.textview
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class NovelTextRendererTest {
+
+    @Test
+    fun `drops source candidates and unwraps the picture element around the fallback img`() {
+        val html = """
+            <section><picture>
+                <source srcset="https://cdn.example.com/cover.jxl" type="image/jxl">
+                <source srcset="https://cdn.example.com/cover.avif" type="image/avif">
+                <img src="https://cdn.example.com/cover.jpg" alt="Cover">
+            </picture></section>
+        """.trimIndent()
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertTrue(doc.select("picture").isEmpty(), "picture wrapper should be removed")
+        assertTrue(doc.select("source").isEmpty(), "source candidates should be removed")
+        val img = doc.selectFirst("img")
+        assertEquals("https://cdn.example.com/cover.jpg", img?.attr("src"))
+        assertEquals("section", img?.parent()?.tagName(), "img should be reparented to picture's own parent")
+    }
+
+    @Test
+    fun `leaves html without a picture element untouched`() {
+        val html = """<div><img src="https://cdn.example.com/plain.jpg"></div>"""
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertEquals("https://cdn.example.com/plain.jpg", doc.selectFirst("img")?.attr("src"))
+    }
+
+    @Test
+    fun `handles multiple picture elements in the same document`() {
+        val html = """
+            <picture><source srcset="a.avif"><img src="a.jpg"></picture>
+            <picture><source srcset="b.avif"><img src="b.jpg"></picture>
+        """.trimIndent()
+        val doc = org.jsoup.Jsoup.parse(html)
+        NovelTextRenderer.unwrapPictureSources(doc)
+
+        assertTrue(doc.select("picture, source").isEmpty())
+        assertEquals(listOf("a.jpg", "b.jpg"), doc.select("img").map { it.attr("src") })
+    }
+}


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
