### PR TITLE
fix(source-url): scope leading-slash normalization to JsSource/Customsource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Prevent crash with setting search on duplicate key [@mrissaoussama](https://github.com/mrissaoussama) [#383](https://github.com/tsundoku-otaku/tsundoku/pull/383)
 - Fix importing new LNreader backups, all novels in DB come favorited [@mrissaoussama](https://github.com/mrissaoussama) [#388](https://github.com/tsundoku-otaku/tsundoku/pull/388)
+- Scope leading-slash normalization [@mrissaoussama](https://github.com/mrissaoussama) [#384](https://github.com/tsundoku-otaku/tsundoku/pull/384)
 
 
 ### Other

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -651,7 +651,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                                     scope.launch {
                                         isRemoving = true
                                         val result = Injekt.get<MangaRepository>()
-                                            .removePotentialDuplicates(removeDupDoubleSlashes)
+                                            .removePotentialDuplicates(removeDupDoubleSlashes, allowedNormalizeSourceIds())
                                         isRemoving = false
                                         if (result.first > 0) {
                                             removedDuplicates = result.second

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -296,6 +296,12 @@ object SettingsAdvancedScreen : SearchableSettings {
         )
     }
 
+    private fun allowedNormalizeSourceIds(): Set<Long> =
+        Injekt.get<tachiyomi.domain.source.service.SourceManager>().getAll()
+            .filter { it is eu.kanade.tachiyomi.jsplugin.source.JsSource || it is eu.kanade.tachiyomi.source.custom.CustomNovelSource }
+            .map { it.id }
+            .toSet()
+
     @Composable
     private fun getDataGroup(): Preference.PreferenceGroup {
         val context = LocalContext.current
@@ -504,7 +510,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                 title = { Text(text = "Normalize manga URLs") },
                 text = {
                     Column {
-                        Text(text = "This will clean up manga URLs in your library:")
+                        Text(text = "This will clean up manga URLs from JS-plugin and custom sources:")
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(text = "• Remove trailing slashes")
                         Text(text = "• Remove URL fragments (#...)")
@@ -524,7 +530,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                         onClick = {
                             scope.launch {
                                 val result = Injekt.get<tachiyomi.domain.manga.repository.MangaRepository>()
-                                    .normalizeAllUrlsAdvanced(removeDoubleSlashes)
+                                    .normalizeAllUrlsAdvanced(removeDoubleSlashes, allowedNormalizeSourceIds())
                                 duplicateUrls = result.second
                                 if (duplicateUrls.isNotEmpty()) {
                                     showDuplicatesDialog = true
@@ -624,7 +630,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                                     scope.launch {
                                         isRemoving = true
                                         val result = Injekt.get<MangaRepository>()
-                                            .normalizeAllUrlsAdvanced(removeDupDoubleSlashes)
+                                            .normalizeAllUrlsAdvanced(removeDupDoubleSlashes, allowedNormalizeSourceIds())
                                         isRemoving = false
 
                                         duplicateUrls = result.second

--- a/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/massimport/MassImportJob.kt
@@ -971,10 +971,7 @@ class MassImportJob(private val context: Context, workerParams: WorkerParameters
             if (resolvedManga != null) {
                 try {
                     if (resolvedManga.url.isNotEmpty()) {
-                        finalUrl = resolvedManga.url
-                        if (!finalUrl.startsWith("/") && !finalUrl.startsWith("http")) {
-                            finalUrl = "/$finalUrl"
-                        }
+                        finalUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, resolvedManga.url)
                     }
                 } catch (_: UninitializedPropertyAccessException) {
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaViewModel.kt
@@ -132,15 +132,17 @@ class MigrateMangaViewModel(
         viewModelScope.launchIO {
             try {
                 val selectedManga = state.value.titles.filter { it.id in state.value.selection }
+                val targetSource = sourceManager.getOrStub(targetSourceId)
                 val targetFavoriteUrls = getFavorites.subscribe(targetSourceId).first()
                     .mapTo(mutableSetOf()) { it.url }
-                val skipCount = selectedManga.size - quickMigrateTargets(selectedManga, targetFavoriteUrls).size
+                val skipCount = selectedManga.size -
+                    quickMigrateTargets(selectedManga, targetFavoriteUrls, targetSource).size
                 mutableState.update {
                     it.copy(
                         dialog = Dialog.QuickMigrateConfirm(
                             targetSourceId = targetSourceId,
                             sourceName = sourceManager.getOrStub(sourceId).nameWithTypeTag(),
-                            targetSourceName = sourceManager.getOrStub(targetSourceId).nameWithTypeTag(),
+                            targetSourceName = targetSource.nameWithTypeTag(),
                             totalCount = selectedManga.size,
                             skipCount = skipCount,
                         ),
@@ -157,11 +159,12 @@ class MigrateMangaViewModel(
         viewModelScope.launchIO {
             try {
                 val selectedManga = state.value.titles.filter { it.id in state.value.selection }
+                val newSource = sourceManager.getOrStub(targetSourceId)
                 val targetFavorites = getFavorites.subscribe(targetSourceId).first()
                 val targetFavoriteUrls = targetFavorites.mapTo(mutableSetOf()) { it.url }
-                val targets = quickMigrateTargets(selectedManga, targetFavoriteUrls)
+                val targets = quickMigrateTargets(selectedManga, targetFavoriteUrls, newSource)
                 val skipped = if (removeSkipped) {
-                    quickMigrateSkipped(selectedManga, targetFavoriteUrls)
+                    quickMigrateSkipped(selectedManga, targetFavoriteUrls, newSource)
                 } else {
                     emptyList()
                 }
@@ -173,12 +176,13 @@ class MigrateMangaViewModel(
                 }
 
                 val oldSource = sourceManager.getOrStub(sourceId)
-                val newSource = sourceManager.getOrStub(targetSourceId)
                 val targetTitles = targets.mapTo(mutableSetOf()) { it.first.title }
                 // The entry that stays behind for a skipped one, matched the same way the skip was:
                 // on the normalized url, not the title, which the two can disagree on.
                 val keptByUrl = targetFavorites.associateBy { it.url }
-                val keptForSkipped = skipped.associate { it.id to keptByUrl[normalizeQuickMigrateUrl(it.url)] }
+                val keptForSkipped = skipped.associate {
+                    it.id to keptByUrl[normalizeQuickMigrateUrl(it.url, newSource)]
+                }
 
                 val countsUsable = downloadManager.awaitDownloadCacheReady()
                 val downloadCounts = if (countsUsable) {
@@ -470,8 +474,9 @@ sealed interface MigrationMangaEvent {
 // but their row not yet flipped, large enough to keep the transaction count down on a bulk migrate.
 private const val UPDATE_CHUNK_SIZE = 200
 
-/** Leading-slash normalization matching how source urls are stored. */
-internal fun normalizeQuickMigrateUrl(url: String): String = if (url.startsWith("/")) url else "/$url"
+/** Leading-slash normalization matching how source urls are stored, for [targetSource]'s convention. */
+internal fun normalizeQuickMigrateUrl(url: String, targetSource: Source): String =
+    eu.kanade.tachiyomi.util.source.normalizeSourcePath(targetSource, url)
 
 /**
  * Pairs each selectable manga with its normalized target url, dropping the ones already favorited on
@@ -481,9 +486,10 @@ internal fun normalizeQuickMigrateUrl(url: String): String = if (url.startsWith(
 internal fun quickMigrateTargets(
     selected: List<Manga>,
     existingFavoriteUrls: Set<String>,
+    targetSource: Source,
 ): List<Pair<Manga, String>> =
     selected.mapNotNull { manga ->
-        val newUrl = normalizeQuickMigrateUrl(manga.url)
+        val newUrl = normalizeQuickMigrateUrl(manga.url, targetSource)
         if (newUrl in existingFavoriteUrls) null else manga to newUrl
     }
 
@@ -491,4 +497,5 @@ internal fun quickMigrateTargets(
 internal fun quickMigrateSkipped(
     selected: List<Manga>,
     existingFavoriteUrls: Set<String>,
-): List<Manga> = selected.filter { normalizeQuickMigrateUrl(it.url) in existingFavoriteUrls }
+    targetSource: Source,
+): List<Manga> = selected.filter { normalizeQuickMigrateUrl(it.url, targetSource) in existingFavoriteUrls }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -473,7 +473,6 @@ class MangaViewModel(
                 val categories = allCategories.filter {
                     it.contentType == contentType || it.contentType == Category.CONTENT_TYPE_ALL
                 }
-                // Normalize URL to ensure leading slash for JsSource/HttpSource
                 state.source?.let { src ->
                     val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
                     if (normalizedUrl != manga.url) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/source/SourceUrlUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/source/SourceUrlUtil.kt
@@ -65,7 +65,7 @@ fun normalizeSourcePath(source: Source, pathOrUrl: String): String {
         return trimmed
     }
     return when (source) {
-        is JsSource, is HttpSource -> if (trimmed.startsWith("/")) trimmed else "/$trimmed"
+        is JsSource, is CustomNovelSource -> if (trimmed.startsWith("/")) trimmed else "/$trimmed"
         else -> trimmed
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModelTest.kt
@@ -1,17 +1,28 @@
 package eu.kanade.tachiyomi.ui.browse.migration.manga
 
+import eu.kanade.tachiyomi.jsplugin.source.JsSource
+import eu.kanade.tachiyomi.source.Source
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import tachiyomi.domain.manga.model.Manga
 
 class MigrateMangaScreenModelTest {
 
+    private val slashSource: Source = mockk<JsSource>(relaxed = true)
+    private val plainSource: Source = mockk<Source>(relaxed = true)
+
     private fun manga(id: Long, url: String) = Manga.create().copy(id = id, url = url)
 
     @Test
-    fun `normalize adds a single leading slash`() {
-        assertEquals("/series/a", normalizeQuickMigrateUrl("series/a"))
-        assertEquals("/series/a", normalizeQuickMigrateUrl("/series/a"))
+    fun `normalize adds a single leading slash for a source that uses the convention`() {
+        assertEquals("/series/a", normalizeQuickMigrateUrl("series/a", slashSource))
+        assertEquals("/series/a", normalizeQuickMigrateUrl("/series/a", slashSource))
+    }
+
+    @Test
+    fun `normalize leaves the url untouched for a plain source`() {
+        assertEquals("series/a", normalizeQuickMigrateUrl("series/a", plainSource))
     }
 
     @Test
@@ -24,7 +35,7 @@ class MigrateMangaScreenModelTest {
         // Target favorite urls are stored normalized (leading slash).
         val existing = setOf("/series/b")
 
-        val targets = quickMigrateTargets(selected, existing)
+        val targets = quickMigrateTargets(selected, existing, slashSource)
 
         assertEquals(listOf(1L, 3L), targets.map { it.first.id })
         assertEquals(listOf("/series/a", "/series/c"), targets.map { it.second })
@@ -35,15 +46,15 @@ class MigrateMangaScreenModelTest {
         val selected = listOf(manga(1, "series/a"))
         val existing = setOf("/series/a")
 
-        assertEquals(emptyList<Pair<Manga, String>>(), quickMigrateTargets(selected, existing))
+        assertEquals(emptyList<Pair<Manga, String>>(), quickMigrateTargets(selected, existing, slashSource))
     }
 
     @Test
     fun `empty favorites keeps every selected entry`() {
         val selected = listOf(manga(1, "a"), manga(2, "b"))
 
-        assertEquals(2, quickMigrateTargets(selected, emptySet()).size)
-        assertEquals(emptyList<Manga>(), quickMigrateSkipped(selected, emptySet()))
+        assertEquals(2, quickMigrateTargets(selected, emptySet(), slashSource).size)
+        assertEquals(emptyList<Manga>(), quickMigrateSkipped(selected, emptySet(), slashSource))
     }
 
     @Test
@@ -55,8 +66,8 @@ class MigrateMangaScreenModelTest {
         )
         val existing = setOf("/series/b", "/series/c")
 
-        val targets = quickMigrateTargets(selected, existing)
-        val skipped = quickMigrateSkipped(selected, existing)
+        val targets = quickMigrateTargets(selected, existing, slashSource)
+        val skipped = quickMigrateSkipped(selected, existing, slashSource)
 
         assertEquals(listOf(1L), targets.map { it.first.id })
         assertEquals(listOf(2L, 3L), skipped.map { it.id })

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -2055,7 +2055,10 @@ class MangaRepositoryImpl(
         }
     }
 
-    override suspend fun removePotentialDuplicates(removeDoubleSlashes: Boolean): Pair<Int, List<Triple<String, String, String>>> {
+    override suspend fun removePotentialDuplicates(
+        removeDoubleSlashes: Boolean,
+        allowedSourceIds: Set<Long>,
+    ): Pair<Int, List<Triple<String, String, String>>> {
         return try {
             var removedCount = 0
             val removedItems = mutableListOf<Triple<String, String, String>>()
@@ -2077,7 +2080,7 @@ class MangaRepositoryImpl(
                         title = title,
                         favorite = favorite,
                     )
-                }.awaitAsList()
+                }.awaitAsList().filter { it.source in allowedSourceIds }
 
                 // First pass: identify which manga would be kept (first occurrence of each normalized URL)
                 allManga.forEach { manga ->

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1973,7 +1973,10 @@ class MangaRepositoryImpl(
         }
     }
 
-    override suspend fun normalizeAllUrlsAdvanced(removeDoubleSlashes: Boolean): Pair<Int, List<MangaRepository.DuplicateUrlInfo>> {
+    override suspend fun normalizeAllUrlsAdvanced(
+        removeDoubleSlashes: Boolean,
+        allowedSourceIds: Set<Long>,
+    ): Pair<Int, List<MangaRepository.DuplicateUrlInfo>> {
         return try {
             var count = 0
             val duplicates = mutableListOf<MangaRepository.DuplicateUrlInfo>()
@@ -1993,7 +1996,7 @@ class MangaRepositoryImpl(
                         title = title,
                         favorite = favorite,
                     )
-                }.awaitAsList()
+                }.awaitAsList().filter { it.source in allowedSourceIds }
 
                 allManga.forEach { manga ->
                     val normalizedUrl = normalizeUrlForMaintenance(manga.url, removeDoubleSlashes)

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -259,12 +259,11 @@ interface MangaRepository {
         val normalizedUrl: String,
     )
 
-    /**
-     * Normalize URLs with advanced options.
-     * @param removeDoubleSlashes whether to also remove double slashes from URLs
-     * @return Pair of (count of normalized URLs, list of skipped duplicates)
-     */
-    suspend fun normalizeAllUrlsAdvanced(removeDoubleSlashes: Boolean): Pair<Int, List<DuplicateUrlInfo>>
+    /** Normalizes URLs for favorites whose source id is in [allowedSourceIds]; others are untouched. */
+    suspend fun normalizeAllUrlsAdvanced(
+        removeDoubleSlashes: Boolean,
+        allowedSourceIds: Set<Long>,
+    ): Pair<Int, List<DuplicateUrlInfo>>
 
     /**
      * Remove (unfavorite) manga that would become duplicates after URL normalization.

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -269,9 +269,13 @@ interface MangaRepository {
      * Remove (unfavorite) manga that would become duplicates after URL normalization.
      * This allows the user to clean up duplicates before running normalization.
      * @param removeDoubleSlashes whether to also consider double slashes when detecting duplicates
+     * @param allowedSourceIds only favorites whose source id is in this set are considered; others are untouched
      * @return Pair of (count of removed duplicates, list of removed items with Triple(title, url, normalizedUrl))
      */
-    suspend fun removePotentialDuplicates(removeDoubleSlashes: Boolean): Pair<Int, List<Triple<String, String, String>>>
+    suspend fun removePotentialDuplicates(
+        removeDoubleSlashes: Boolean,
+        allowedSourceIds: Set<Long>,
+    ): Pair<Int, List<Triple<String, String, String>>>
 
     /**
      * Refresh the library cache table.


### PR DESCRIPTION


normalizeSourcePath forced a leading slash onto any HttpSource url, breaking duplicate/library matching for plain extension sources that don't follow that convention. Restrict it to JsSource and CustomNovelSource.