### PR TITLE
 Share HTML asset-rewrite logic between the chapter embedder and local novels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Handle picture/source/video/audio tags in text view [@mrissaoussama](https://github.com/mrissaoussama) [#381](https://github.com/tsundoku-otaku/tsundoku/pull/381)
 - avoid list copies during backup restore [@mrissaoussama](https://github.com/mrissaoussama) [#389](https://github.com/tsundoku-otaku/tsundoku/pull/389)
 - Improve UI filter panel with scroll, apply library filters [@mrissaoussama](https://github.com/mrissaoussama) [#382](https://github.com/tsundoku-otaku/tsundoku/pull/382)
+- Asset-rewrite logic uses relative paths for chapter embedder/local novels [@mrissaoussama](https://github.com/mrissaoussama) [#385](https://github.com/tsundoku-otaku/tsundoku/pull/385)
 
 ### Fixed
 - Prevent crash with setting search on duplicate key [@mrissaoussama](https://github.com/mrissaoussama) [#383](https://github.com/tsundoku-otaku/tsundoku/pull/383)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.hippo.unifile.UniFile
 import logcat.LogPriority
 import mihon.core.archive.ArchiveReader
-import mihon.core.archive.rewriteResolvedAssetRefs
+import mihon.core.archive.rewriteResolvedAssetRefsOnce
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
@@ -215,7 +215,7 @@ class ChapterContentReader(
     }
 
     private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
-        rewriteResolvedAssetRefs(text, fileExists)
+        rewriteResolvedAssetRefsOnce(text, fileExists)
 
     companion object {
         private val IMAGE_EXTENSIONS = listOf(".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".avif")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.hippo.unifile.UniFile
 import logcat.LogPriority
 import mihon.core.archive.ArchiveReader
-import mihon.core.archive.rewriteResolvedAssetRefsOnce
+import mihon.core.archive.rewriteResolvedAssetRefs
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
@@ -215,7 +215,7 @@ class ChapterContentReader(
     }
 
     private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
-        rewriteResolvedAssetRefsOnce(text, fileExists)
+        rewriteResolvedAssetRefs(text, fileExists)
 
     companion object {
         private val IMAGE_EXTENSIONS = listOf(".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".avif")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.hippo.unifile.UniFile
 import logcat.LogPriority
 import mihon.core.archive.ArchiveReader
+import mihon.core.archive.HtmlAssetRewriter
+import mihon.core.archive.relativeAssetScheme
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
@@ -213,6 +215,8 @@ class ChapterContentReader(
         }
     }
 
+    private fun rewriteAssetRefs(text: String): String = HtmlAssetRewriter.rewriteHtml(text, ::relativeAssetScheme)
+
     companion object {
         private val IMAGE_EXTENSIONS = listOf(".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".avif")
     }
@@ -244,7 +248,7 @@ class ChapterContentReader(
             if (i < files.size - 1) sb.append("\n\n")
         }
         val content = sb.toString()
-        return content.ifBlank { null }
+        return content.ifBlank { null }?.let(::rewriteAssetRefs)
     }
 
     /**
@@ -293,6 +297,7 @@ class ChapterContentReader(
                     entries.sortedBy { it.first }
                         .joinToString("\n\n") { it.second }
                         .ifEmpty { null }
+                        ?.let(::rewriteAssetRefs)
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/ChapterContentReader.kt
@@ -4,8 +4,7 @@ import android.content.Context
 import com.hippo.unifile.UniFile
 import logcat.LogPriority
 import mihon.core.archive.ArchiveReader
-import mihon.core.archive.HtmlAssetRewriter
-import mihon.core.archive.relativeAssetScheme
+import mihon.core.archive.rewriteResolvedAssetRefs
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
@@ -215,7 +214,8 @@ class ChapterContentReader(
         }
     }
 
-    private fun rewriteAssetRefs(text: String): String = HtmlAssetRewriter.rewriteHtml(text, ::relativeAssetScheme)
+    private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
+        rewriteResolvedAssetRefs(text, fileExists)
 
     companion object {
         private val IMAGE_EXTENSIONS = listOf(".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".avif")
@@ -248,7 +248,7 @@ class ChapterContentReader(
             if (i < files.size - 1) sb.append("\n\n")
         }
         val content = sb.toString()
-        return content.ifBlank { null }?.let(::rewriteAssetRefs)
+        return content.ifBlank { null }?.let { rewriteAssetRefs(it) { name -> dir.findFile(name) != null } }
     }
 
     /**
@@ -264,17 +264,18 @@ class ChapterContentReader(
             val pfd = context.contentResolver.openFileDescriptor(uri, "r") ?: return null
             pfd.use { descriptor ->
                 ArchiveReader(descriptor).use { reader ->
-                    // First pass: collect content file names
+                    // First pass: collect content file names and entry base names.
                     val contentFileNames = mutableListOf<String>()
+                    val entryBaseNames = mutableSetOf<String>()
                     reader.useEntries { seq ->
                         seq.forEach { entry ->
+                            if (!entry.isFile) return@forEach
+                            entryBaseNames.add(entry.name.substringAfterLast('/'))
                             val name = entry.name.lowercase()
-                            if (entry.isFile && (
-                                    name.endsWith(".html") ||
-                                        name.endsWith(".htm") ||
-                                        name.endsWith(".xhtml") ||
-                                        name.endsWith(".txt")
-                                    )
+                            if (name.endsWith(".html") ||
+                                name.endsWith(".htm") ||
+                                name.endsWith(".xhtml") ||
+                                name.endsWith(".txt")
                             ) {
                                 contentFileNames.add(entry.name)
                             }
@@ -297,7 +298,7 @@ class ChapterContentReader(
                     entries.sortedBy { it.first }
                         .joinToString("\n\n") { it.second }
                         .ifEmpty { null }
-                        ?.let(::rewriteAssetRefs)
+                        ?.let { rewriteAssetRefs(it, entryBaseNames::contains) }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
@@ -239,8 +239,12 @@ class BrowseSourceViewModel(
      */
     private val hideInLibraryItems = sourcePreferences.hideInLibraryItems.get()
     private fun normalizeUrl(url: String): String = url.trimEnd('/').substringBefore('#')
-    private fun normalizeUrlForLookup(url: String): String =
-        normalizeUrl(eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, url))
+    private fun normalizeUrlForLookup(url: String): String = when (source) {
+        is eu.kanade.tachiyomi.jsplugin.source.JsSource,
+        is eu.kanade.tachiyomi.source.custom.CustomNovelSource,
+        -> normalizeUrl(eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, url))
+        else -> normalizeUrl(url)
+    }
 
     val mangaPagerFlowFlow = kotlinx.coroutines.flow.combine(
         state.map { Triple(it.listing.query, it.filters, it.filters.hashCode()) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
@@ -239,12 +239,8 @@ class BrowseSourceViewModel(
      */
     private val hideInLibraryItems = sourcePreferences.hideInLibraryItems.get()
     private fun normalizeUrl(url: String): String = url.trimEnd('/').substringBefore('#')
-    private fun normalizeUrlForLookup(url: String): String = when (source) {
-        is eu.kanade.tachiyomi.jsplugin.source.JsSource,
-        is eu.kanade.tachiyomi.source.custom.CustomNovelSource,
-        -> normalizeUrl(eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, url))
-        else -> normalizeUrl(url)
-    }
+    private fun normalizeUrlForLookup(url: String): String =
+        normalizeUrl(eu.kanade.tachiyomi.util.source.normalizeSourcePath(source, url))
 
     val mangaPagerFlowFlow = kotlinx.coroutines.flow.combine(
         state.map { Triple(it.listing.query, it.filters, it.filters.hashCode()) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -475,11 +475,9 @@ class MangaViewModel(
                 }
                 // Normalize URL to ensure leading slash for JsSource/CustomNovelSource path convention
                 state.source?.let { src ->
-                    if (src is eu.kanade.tachiyomi.jsplugin.source.JsSource || src is eu.kanade.tachiyomi.source.custom.CustomNovelSource) {
-                        val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
-                        if (normalizedUrl != manga.url) {
-                            updateManga.awaitUpdateUrl(manga.id, normalizedUrl)
-                        }
+                    val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
+                    if (normalizedUrl != manga.url) {
+                        updateManga.awaitUpdateUrl(manga.id, normalizedUrl)
                     }
                 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaViewModel.kt
@@ -473,10 +473,13 @@ class MangaViewModel(
                 val categories = allCategories.filter {
                     it.contentType == contentType || it.contentType == Category.CONTENT_TYPE_ALL
                 }
+                // Normalize URL to ensure leading slash for JsSource/CustomNovelSource path convention
                 state.source?.let { src ->
-                    val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
-                    if (normalizedUrl != manga.url) {
-                        updateManga.awaitUpdateUrl(manga.id, normalizedUrl)
+                    if (src is eu.kanade.tachiyomi.jsplugin.source.JsSource || src is eu.kanade.tachiyomi.source.custom.CustomNovelSource) {
+                        val normalizedUrl = eu.kanade.tachiyomi.util.source.normalizeSourcePath(src, manga.url)
+                        if (normalizedUrl != manga.url) {
+                            updateManga.awaitUpdateUrl(manga.id, normalizedUrl)
+                        }
                     }
                 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -12,9 +12,8 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.TextSplitter
-import mihon.core.archive.HtmlAssetRewriter
 import mihon.core.archive.archiveReader
-import mihon.core.archive.relativeAssetScheme
+import mihon.core.archive.rewriteResolvedAssetRefs
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import uy.kohesive.injekt.injectLazy
@@ -57,7 +56,7 @@ internal class DownloadPageLoader(
             getPagesFromArchive(chapterPath)
         } else {
             logcat { "DownloadPageLoader.getPages: Loading from directory" }
-            getPagesFromDirectory()
+            getPagesFromDirectory(chapterPath)
         }
     }
 
@@ -67,13 +66,16 @@ internal class DownloadPageLoader(
     }
 
     private suspend fun getPagesFromArchive(file: UniFile): List<ReaderPage> {
+        val entryNames = file.archiveReader(context).use { reader ->
+            reader.useEntries { entries -> entries.filter { it.isFile }.map { it.name.substringAfterLast('/') }.toSet() }
+        }
         val loader = ArchivePageLoader(file.archiveReader(context)).also { archivePageLoader = it }
         return loader.getPages().onEach { page ->
-            page.text = page.text?.let(::rewriteAssetRefs)
+            page.text = page.text?.let { rewriteAssetRefs(it, entryNames::contains) }
         }
     }
 
-    private fun getPagesFromDirectory(): List<ReaderPage> {
+    private fun getPagesFromDirectory(chapterDir: UniFile?): List<ReaderPage> {
         logcat { "DownloadPageLoader.getPagesFromDirectory: Starting" }
         val pages = downloadManager.buildPageList(source, manga, chapter.chapter.toDomainChapter()!!)
         logcat { "DownloadPageLoader.getPagesFromDirectory: Got ${pages.size} pages from buildPageList" }
@@ -86,7 +88,7 @@ internal class DownloadPageLoader(
                 logcat { "DownloadPageLoader: Reading HTML content from $uriString" }
                 context.contentResolver.openInputStream(page.uri!!)?.use {
                     it.bufferedReader().readText()
-                }?.let(::rewriteAssetRefs)
+                }?.let { rewriteAssetRefs(it) { name -> chapterDir?.findFile(name) != null } }
             } else {
                 null
             }
@@ -141,5 +143,6 @@ internal class DownloadPageLoader(
         return normalized.endsWith(".html") || normalized.endsWith(".htm") || normalized.endsWith(".xhtml")
     }
 
-    private fun rewriteAssetRefs(text: String): String = HtmlAssetRewriter.rewriteHtml(text, ::relativeAssetScheme)
+    private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
+        rewriteResolvedAssetRefs(text, fileExists)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -12,7 +12,9 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.TextSplitter
+import mihon.core.archive.HtmlAssetRewriter
 import mihon.core.archive.archiveReader
+import mihon.core.archive.relativeAssetScheme
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import uy.kohesive.injekt.injectLazy
@@ -66,7 +68,9 @@ internal class DownloadPageLoader(
 
     private suspend fun getPagesFromArchive(file: UniFile): List<ReaderPage> {
         val loader = ArchivePageLoader(file.archiveReader(context)).also { archivePageLoader = it }
-        return loader.getPages()
+        return loader.getPages().onEach { page ->
+            page.text = page.text?.let(::rewriteAssetRefs)
+        }
     }
 
     private fun getPagesFromDirectory(): List<ReaderPage> {
@@ -82,7 +86,7 @@ internal class DownloadPageLoader(
                 logcat { "DownloadPageLoader: Reading HTML content from $uriString" }
                 context.contentResolver.openInputStream(page.uri!!)?.use {
                     it.bufferedReader().readText()
-                }
+                }?.let(::rewriteAssetRefs)
             } else {
                 null
             }
@@ -136,4 +140,6 @@ internal class DownloadPageLoader(
         val normalized = lowercase()
         return normalized.endsWith(".html") || normalized.endsWith(".htm") || normalized.endsWith(".xhtml")
     }
+
+    private fun rewriteAssetRefs(text: String): String = HtmlAssetRewriter.rewriteHtml(text, ::relativeAssetScheme)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -13,7 +13,7 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.TextSplitter
 import mihon.core.archive.archiveReader
-import mihon.core.archive.rewriteResolvedAssetRefsOnce
+import mihon.core.archive.rewriteResolvedAssetRefs
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import uy.kohesive.injekt.injectLazy
@@ -144,5 +144,5 @@ internal class DownloadPageLoader(
     }
 
     private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
-        rewriteResolvedAssetRefsOnce(text, fileExists)
+        rewriteResolvedAssetRefs(text, fileExists)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -13,7 +13,7 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.TextSplitter
 import mihon.core.archive.archiveReader
-import mihon.core.archive.rewriteResolvedAssetRefs
+import mihon.core.archive.rewriteResolvedAssetRefsOnce
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import uy.kohesive.injekt.injectLazy
@@ -144,5 +144,5 @@ internal class DownloadPageLoader(
     }
 
     private fun rewriteAssetRefs(text: String, fileExists: (String) -> Boolean): String =
-        rewriteResolvedAssetRefs(text, fileExists)
+        rewriteResolvedAssetRefsOnce(text, fileExists)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import mihon.core.archive.HtmlAssetRewriter
+import mihon.core.archive.markAssetsResolved
+import mihon.core.archive.novelImageUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import tachiyomi.core.common.util.system.logcat
@@ -40,7 +42,7 @@ class ChapterImageEmbedder(
         tmpDir: com.hippo.unifile.UniFile? = null,
     ): String = withContext(Dispatchers.IO) {
         if (!novelDownloadPreferences.downloadChapterImages().get()) {
-            return@withContext html
+            return@withContext markAssetsResolved(html)
         }
 
         val imageUrls = HtmlAssetRewriter.extractImageUrls(html).filterNot(::isAlreadyLocal)
@@ -72,7 +74,7 @@ class ChapterImageEmbedder(
                         } while (tmpDir.findFile(filename) != null)
 
                         tmpDir.createFile(filename)?.openOutputStream()?.use { it.write(imageBytes) }
-                        filename
+                        novelImageUrl(filename)
                     } else {
                         // Fallback to base64 if not actively zipping
                         val base64 = Base64.encodeToString(imageBytes, Base64.NO_WRAP)
@@ -88,7 +90,7 @@ class ChapterImageEmbedder(
         }
 
         // Attribute-aware rewrite; a plain string replace would corrupt shared-prefix srcset candidates.
-        HtmlAssetRewriter.rewriteImageUrls(html, replacements::get)
+        markAssetsResolved(HtmlAssetRewriter.rewriteImageUrls(html, replacements::get))
     }
 
     private fun isAlreadyLocal(url: String): Boolean =

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import mihon.core.archive.HtmlAssetRewriter
-import mihon.core.archive.markAssetsResolved
 import mihon.core.archive.novelImageUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -42,7 +41,7 @@ class ChapterImageEmbedder(
         tmpDir: com.hippo.unifile.UniFile? = null,
     ): String = withContext(Dispatchers.IO) {
         if (!novelDownloadPreferences.downloadChapterImages().get()) {
-            return@withContext markAssetsResolved(html)
+            return@withContext html
         }
 
         val imageUrls = HtmlAssetRewriter.extractImageUrls(html).filterNot(::isAlreadyLocal)
@@ -90,7 +89,7 @@ class ChapterImageEmbedder(
         }
 
         // Attribute-aware rewrite; a plain string replace would corrupt shared-prefix srcset candidates.
-        markAssetsResolved(HtmlAssetRewriter.rewriteImageUrls(html, replacements::get))
+        HtmlAssetRewriter.rewriteImageUrls(html, replacements::get)
     }
 
     private fun isAlreadyLocal(url: String): Boolean =

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
+import mihon.core.archive.HtmlAssetRewriter
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import tachiyomi.core.common.util.system.logcat
@@ -16,7 +17,6 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.ByteArrayOutputStream
 import java.net.URL
-import java.util.regex.Pattern
 
 /**
  * Utility class for extracting image URLs from HTML and embedding them as base64.
@@ -26,24 +26,6 @@ class ChapterImageEmbedder(
     private val novelDownloadPreferences: NovelDownloadPreferences = Injekt.get(),
 ) {
     private val client: OkHttpClient get() = networkHelper.client
-
-    // Regex patterns for finding image URLs in HTML
-    // Pattern requires whitespace between img and src, handles various attribute orderings
-    private val imgSrcPattern = Pattern.compile(
-        """<img\s+[^>]*?src\s*=\s*["']([^"']+)["'][^>]*>""",
-        Pattern.CASE_INSENSITIVE,
-    )
-
-    private val imgSrcsetPattern = Pattern.compile(
-        """<img\s+[^>]*?srcset\s*=\s*["']([^"']+)["'][^>]*>""",
-        Pattern.CASE_INSENSITIVE,
-    )
-
-    // Pattern for background-image CSS
-    private val bgImagePattern = Pattern.compile(
-        """background-image\s*:\s*url\s*\(\s*["']?([^"')]+)["']?\s*\)""",
-        Pattern.CASE_INSENSITIVE,
-    )
 
     /**
      * Process HTML content and embed images as base64 if enabled.
@@ -61,19 +43,13 @@ class ChapterImageEmbedder(
             return@withContext html
         }
 
-        var processedHtml = html
-        val imageUrls = extractImageUrls(html)
+        val imageUrls = HtmlAssetRewriter.extractImageUrls(html).filterNot(::isAlreadyLocal)
 
         logcat { "ChapterImageEmbedder: Found ${imageUrls.size} images to process" }
 
         var imageCounter = 0
+        val replacements = mutableMapOf<String, String>()
         for (imageUrl in imageUrls) {
-            // Already local or data URI, do not process
-            if (imageUrl.startsWith("tsundoku-novel-image://") || imageUrl.startsWith("file://") ||
-                imageUrl.startsWith("data:")
-            ) {
-                continue
-            }
             try {
                 val absoluteUrl = resolveUrl(imageUrl, baseUrl)
                 val imageResponse = downloadAndEncodeImage(absoluteUrl)
@@ -96,15 +72,14 @@ class ChapterImageEmbedder(
                         } while (tmpDir.findFile(filename) != null)
 
                         tmpDir.createFile(filename)?.openOutputStream()?.use { it.write(imageBytes) }
-                        "tsundoku-novel-image://$filename"
+                        filename
                     } else {
                         // Fallback to base64 if not actively zipping
                         val base64 = Base64.encodeToString(imageBytes, Base64.NO_WRAP)
                         "data:$mimeType;base64,$base64"
                     }
 
-                    // Replace the URL with local path or base64
-                    processedHtml = processedHtml.replace(imageUrl, finalUrl)
+                    replacements[imageUrl] = finalUrl
                     logcat { "ChapterImageEmbedder: Embedded image $imageUrl" }
                 }
             } catch (e: Exception) {
@@ -112,54 +87,17 @@ class ChapterImageEmbedder(
             }
         }
 
-        processedHtml
+        // Attribute-aware rewrite; a plain string replace would corrupt shared-prefix srcset candidates.
+        HtmlAssetRewriter.rewriteImageUrls(html) { replacements[it] }
     }
 
-    /**
-     * Extract all image URLs from HTML content.
-     */
-    private fun extractImageUrls(html: String): Set<String> {
-        val urls = mutableSetOf<String>()
-
-        // Find img src attributes
-        val imgMatcher = imgSrcPattern.matcher(html)
-        while (imgMatcher.find()) {
-            imgMatcher.group(1)?.let { url ->
-                if (!url.startsWith("data:")) {
-                    urls.add(url)
-                }
-            }
-        }
-
-        // Find img srcset attributes (take first URL from srcset)
-        val srcsetMatcher = imgSrcsetPattern.matcher(html)
-        while (srcsetMatcher.find()) {
-            srcsetMatcher.group(1)?.let { srcset ->
-                // srcset format: "url1 1x, url2 2x, ..." - take the first URL
-                val firstUrl = srcset.split(",").firstOrNull()?.trim()?.split(" ")?.firstOrNull()
-                if (firstUrl != null && !firstUrl.startsWith("data:")) {
-                    urls.add(firstUrl)
-                }
-            }
-        }
-
-        // Find background-image URLs
-        val bgMatcher = bgImagePattern.matcher(html)
-        while (bgMatcher.find()) {
-            bgMatcher.group(1)?.let { url ->
-                if (!url.startsWith("data:")) {
-                    urls.add(url)
-                }
-            }
-        }
-
-        return urls
-    }
+    private fun isAlreadyLocal(url: String): Boolean =
+        url.startsWith("tsundoku-novel-image://") || url.startsWith("file://") || url.startsWith("data:")
 
     /**
      * Resolve a potentially relative URL against a base URL.
      */
-    private fun resolveUrl(url: String, baseUrl: String?): String {
+    internal fun resolveUrl(url: String, baseUrl: String?): String {
         return when {
             url.startsWith("http://") || url.startsWith("https://") -> url
             url.startsWith("//") -> "https:$url"

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedder.kt
@@ -88,7 +88,7 @@ class ChapterImageEmbedder(
         }
 
         // Attribute-aware rewrite; a plain string replace would corrupt shared-prefix srcset candidates.
-        HtmlAssetRewriter.rewriteImageUrls(html) { replacements[it] }
+        HtmlAssetRewriter.rewriteImageUrls(html, replacements::get)
     }
 
     private fun isAlreadyLocal(url: String): Boolean =

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterImageEmbedderTest.kt
@@ -1,0 +1,57 @@
+package eu.kanade.tachiyomi.util.chapter
+
+import eu.kanade.tachiyomi.network.NetworkHelper
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.download.service.NovelDownloadPreferences
+
+class ChapterImageEmbedderTest {
+
+    private val embedder = ChapterImageEmbedder(
+        networkHelper = mockk<NetworkHelper>(relaxed = true),
+        novelDownloadPreferences = mockk<NovelDownloadPreferences>(relaxed = true),
+    )
+
+    @Test
+    fun `absolute urls are returned unchanged`() {
+        assertEquals("https://cdn.com/a.jpg", embedder.resolveUrl("https://cdn.com/a.jpg", "https://x.com/ch1"))
+        assertEquals("http://cdn.com/a.jpg", embedder.resolveUrl("http://cdn.com/a.jpg", null))
+    }
+
+    @Test
+    fun `protocol-relative urls inherit https`() {
+        assertEquals("https://cdn.com/a.jpg", embedder.resolveUrl("//cdn.com/a.jpg", "https://x.com/ch1"))
+    }
+
+    @Test
+    fun `root-relative urls resolve against the base host`() {
+        assertEquals(
+            "https://x.com/images/a.jpg",
+            embedder.resolveUrl("/images/a.jpg", "https://x.com/novel/ch1"),
+        )
+    }
+
+    @Test
+    fun `relative urls resolve against the base path`() {
+        assertEquals(
+            "https://x.com/novel/images/a.jpg",
+            embedder.resolveUrl("images/a.jpg", "https://x.com/novel/ch1"),
+        )
+    }
+
+    @Test
+    fun `relative url with no base url is returned as-is`() {
+        assertEquals("images/a.jpg", embedder.resolveUrl("images/a.jpg", null))
+    }
+
+    @Test
+    fun `root-relative url with no base url is returned as-is`() {
+        assertEquals("/images/a.jpg", embedder.resolveUrl("/images/a.jpg", null))
+    }
+
+    @Test
+    fun `malformed base url falls back to the original relative url`() {
+        assertEquals("images/a.jpg", embedder.resolveUrl("images/a.jpg", "not a url"))
+    }
+}

--- a/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubWriterTest.kt
@@ -210,6 +210,25 @@ class EpubWriterTest {
     }
 
     @Test
+    fun `an image id containing a space still matches the percent-encoded src`() {
+        val imgBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 0, 0)
+        val img = EpubWriter.EmbeddedImage(
+            id = "cover art.jpg",
+            bytes = imgBytes,
+            mimeType = "image/jpeg",
+            extension = "jpg",
+        )
+        val chapter = EpubWriter.Chapter(
+            title = "Ch 1",
+            content = """<img src="tsundoku-novel-image://cover%20art.jpg"/>""",
+            images = listOf(img),
+        )
+        val chapterXhtml = buildEpub(chapters = listOf(chapter)).text("OEBPS/chapter0000.xhtml")
+        assertFalse(chapterXhtml.contains("tsundoku-novel-image://"), "tsundoku-novel-image:// must be rewritten")
+        assertTrue(chapterXhtml.contains("images/chapter0000_cover art.jpg"), "Image must not be dropped as an orphan")
+    }
+
+    @Test
     fun `orphan tsundoku-novel-image img tags are removed`() {
         // Image referenced in HTML but NOT provided in images list
         val chapter = EpubWriter.Chapter(

--- a/app/src/test/java/mihon/core/archive/HtmlAssetRewriterTest.kt
+++ b/app/src/test/java/mihon/core/archive/HtmlAssetRewriterTest.kt
@@ -1,0 +1,167 @@
+package mihon.core.archive
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HtmlAssetRewriterTest {
+
+    private fun toLocal(url: String) = "local://${url.substringBefore('?')}"
+
+    @Test
+    fun `rewrites plain src attribute`() {
+        val out = HtmlAssetRewriter.rewriteHtml("""<img src="a.jpg">""", ::toLocal)
+        assertEquals("""<img src="local://a.jpg">""", out)
+    }
+
+    @Test
+    fun `leaves url untouched when mapping has no entry`() {
+        val out = HtmlAssetRewriter.rewriteHtml("""<img src="a.jpg">""") { null }
+        assertEquals("""<img src="a.jpg">""", out)
+    }
+
+    @Test
+    fun `rewrites every srcset candidate independently`() {
+        val out = HtmlAssetRewriter.rewriteHtml(
+            """<img srcset="a.jpg 1x, b.jpg 2x, c.jpg 3x">""",
+            ::toLocal,
+        )
+        assertEquals("""<img srcset="local://a.jpg 1x, local://b.jpg 2x, local://c.jpg 3x">""", out)
+    }
+
+    @Test
+    fun `srcset candidates sharing a url prefix that only differ by query are not corrupted`() {
+        val map = mapOf(
+            "image_20.jpg" to "tsundoku-novel-image://image_20.jpg",
+            "image_20.jpg?w=106&h=150" to "tsundoku-novel-image://image_20_thumb.jpg",
+        )
+        val out = HtmlAssetRewriter.rewriteHtml(
+            """<img srcset="image_20.jpg 1443w, image_20.jpg?w=106&h=150 106w">""",
+        ) { map[it] }
+        assertEquals(
+            """<img srcset="tsundoku-novel-image://image_20.jpg 1443w, """ +
+                """tsundoku-novel-image://image_20_thumb.jpg 106w">""",
+            out,
+        )
+    }
+
+    @Test
+    fun `srcset candidate with no mapping falls back to its original url unchanged`() {
+        val out = HtmlAssetRewriter.rewriteHtml(
+            """<img srcset="known.jpg 1x, unknown.jpg 2x">""",
+        ) { url -> "local://$url".takeIf { url == "known.jpg" } }
+        assertEquals("""<img srcset="local://known.jpg 1x, unknown.jpg 2x">""", out)
+    }
+
+    @Test
+    fun `blank srcset candidates from stray commas are preserved as-is`() {
+        val out = HtmlAssetRewriter.rewriteHtml("""<img srcset="a.jpg 1x, , b.jpg 2x">""", ::toLocal)
+        assertEquals("""<img srcset="local://a.jpg 1x,  , local://b.jpg 2x">""", out)
+    }
+
+    @Test
+    fun `rewrites background-image url inside a style attribute`() {
+        val out = HtmlAssetRewriter.rewriteHtml(
+            """<div style="background-image:url('bg.png')"></div>""",
+            ::toLocal,
+        )
+        assertEquals("""<div style="background-image:url('local://bg.png')"></div>""", out)
+    }
+
+    @Test
+    fun `rewrites url references inside a style block`() {
+        val out = HtmlAssetRewriter.rewriteHtml(
+            """<style>.a { background: url(bg.png); }</style>""",
+            ::toLocal,
+        )
+        assertEquals("""<style>.a { background: url(local://bg.png); }</style>""", out)
+    }
+
+    @Test
+    fun `does not touch url-like text inside a script tag`() {
+        val html = """<script>var x = "url(a.jpg)";</script>"""
+        assertEquals(html, HtmlAssetRewriter.rewriteHtml(html, ::toLocal))
+    }
+
+    @Test
+    fun `extractUrls collects every srcset candidate not just the first`() {
+        val urls = HtmlAssetRewriter.extractUrls(
+            """<img src="a.jpg" srcset="b.jpg 1x, c.jpg?w=100 2x, d.jpg 3x">""",
+        )
+        assertEquals(setOf("a.jpg", "b.jpg", "c.jpg?w=100", "d.jpg"), urls)
+    }
+
+    @Test
+    fun `extractUrls dedupes repeated urls across tags`() {
+        val urls = HtmlAssetRewriter.extractUrls(
+            """<img src="a.jpg"><img srcset="a.jpg 1x, b.jpg 2x">""",
+        )
+        assertEquals(setOf("a.jpg", "b.jpg"), urls)
+    }
+
+    @Test
+    fun `extractUrls includes css background-image urls`() {
+        val urls = HtmlAssetRewriter.extractUrls(
+            """<div style="background-image:url('bg.png')"></div><style>.a{background:url(tile.png)}</style>""",
+        )
+        assertTrue(urls.containsAll(setOf("bg.png", "tile.png")))
+    }
+
+    @Test
+    fun `extractUrls ignores data uris and anchor hrefs`() {
+        val urls = HtmlAssetRewriter.extractUrls(
+            """<img src="data:image/png;base64,AAAA"><a href="chapter2.html">next</a>""",
+        )
+        assertTrue(urls.isEmpty())
+    }
+
+    @Test
+    fun `extractImageUrls only collects img src and srcset, not link href or script src`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<link href="style.css"><script src="app.js"></script>""" +
+                """<img src="a.jpg" srcset="b.jpg 1x, c.jpg 2x">""" +
+                """<video src="clip.mp4"><source src="clip.webm"></video>""",
+        )
+        assertEquals(setOf("a.jpg", "b.jpg", "c.jpg"), urls)
+    }
+
+    @Test
+    fun `extractImageUrls collects every srcset candidate`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<img src="a.jpg" srcset="b.jpg 1x, c.jpg?w=100 2x, d.jpg 3x">""",
+        )
+        assertEquals(setOf("a.jpg", "b.jpg", "c.jpg?w=100", "d.jpg"), urls)
+    }
+
+    @Test
+    fun `extractImageUrls collects background-image but not other css url declarations`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<div style="background-image:url('bg.png')"></div>""" +
+                """<style>@font-face { src: url(font.woff2); } .a { cursor: url(cur.png), auto; }</style>""",
+        )
+        assertEquals(setOf("bg.png"), urls)
+    }
+
+    @Test
+    fun `rewriteImageUrls rewrites img src and srcset but leaves link and script untouched`() {
+        val out = HtmlAssetRewriter.rewriteImageUrls(
+            """<link href="style.css"><script src="app.js"></script><img src="a.jpg" srcset="a.jpg 1x, b.jpg 2x">""",
+        ) { url -> "local/$url".takeIf { url == "a.jpg" || url == "b.jpg" } }
+        assertEquals(
+            """<link href="style.css"><script src="app.js"></script>""" +
+                """<img src="local/a.jpg" srcset="local/a.jpg 1x, local/b.jpg 2x">""",
+            out,
+        )
+    }
+
+    @Test
+    fun `rewriteImageUrls rewrites background-image and preserves everything else in the style block`() {
+        val out = HtmlAssetRewriter.rewriteImageUrls(
+            """<style>.a { background-image: url(bg.png); } @font-face { src: url(font.woff2); }</style>""",
+        ) { url -> "local/$url".takeIf { url == "bg.png" } }
+        assertEquals(
+            """<style>.a { background-image:url(local/bg.png); } @font-face { src: url(font.woff2); }</style>""",
+            out,
+        )
+    }
+}

--- a/app/src/test/java/mihon/core/archive/HtmlAssetRewriterTest.kt
+++ b/app/src/test/java/mihon/core/archive/HtmlAssetRewriterTest.kt
@@ -84,38 +84,6 @@ class HtmlAssetRewriterTest {
     }
 
     @Test
-    fun `extractUrls collects every srcset candidate not just the first`() {
-        val urls = HtmlAssetRewriter.extractUrls(
-            """<img src="a.jpg" srcset="b.jpg 1x, c.jpg?w=100 2x, d.jpg 3x">""",
-        )
-        assertEquals(setOf("a.jpg", "b.jpg", "c.jpg?w=100", "d.jpg"), urls)
-    }
-
-    @Test
-    fun `extractUrls dedupes repeated urls across tags`() {
-        val urls = HtmlAssetRewriter.extractUrls(
-            """<img src="a.jpg"><img srcset="a.jpg 1x, b.jpg 2x">""",
-        )
-        assertEquals(setOf("a.jpg", "b.jpg"), urls)
-    }
-
-    @Test
-    fun `extractUrls includes css background-image urls`() {
-        val urls = HtmlAssetRewriter.extractUrls(
-            """<div style="background-image:url('bg.png')"></div><style>.a{background:url(tile.png)}</style>""",
-        )
-        assertTrue(urls.containsAll(setOf("bg.png", "tile.png")))
-    }
-
-    @Test
-    fun `extractUrls ignores data uris and anchor hrefs`() {
-        val urls = HtmlAssetRewriter.extractUrls(
-            """<img src="data:image/png;base64,AAAA"><a href="chapter2.html">next</a>""",
-        )
-        assertTrue(urls.isEmpty())
-    }
-
-    @Test
     fun `extractImageUrls only collects img src and srcset, not link href or script src`() {
         val urls = HtmlAssetRewriter.extractImageUrls(
             """<link href="style.css"><script src="app.js"></script>""" +
@@ -163,5 +131,45 @@ class HtmlAssetRewriterTest {
             """<style>.a { background-image:url(local/bg.png); } @font-face { src: url(font.woff2); }</style>""",
             out,
         )
+    }
+
+    @Test
+    fun `extractImageUrls prefers a lazy-load data-src over its placeholder src`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<img data-src="real.jpg" src="placeholder.gif">""",
+        )
+        assertEquals(setOf("real.jpg"), urls)
+    }
+
+    @Test
+    fun `rewriteImageUrls points src at the resolved data-src, not the placeholder`() {
+        val out = HtmlAssetRewriter.rewriteImageUrls(
+            """<img data-src="real.jpg" src="placeholder.gif">""",
+        ) { url -> "local/$url".takeIf { url == "real.jpg" } }
+        assertEquals("""<img data-src="real.jpg" src="local/real.jpg">""", out)
+    }
+
+    @Test
+    fun `extractImageUrls collects picture source srcset candidates`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<picture><source srcset="a.webp"><source srcset="b.avif"><img src="fallback.jpg"></picture>""",
+        )
+        assertEquals(setOf("a.webp", "b.avif", "fallback.jpg"), urls)
+    }
+
+    @Test
+    fun `rewriteImageUrls rewrites picture source srcset alongside the fallback img`() {
+        val out = HtmlAssetRewriter.rewriteImageUrls(
+            """<picture><source srcset="a.webp"><img src="fallback.jpg"></picture>""",
+        ) { url -> "local/$url" }
+        assertEquals("""<picture><source srcset="local/a.webp"><img src="local/fallback.jpg"></picture>""", out)
+    }
+
+    @Test
+    fun `extractImageUrls does not treat a standalone video or audio source as an image`() {
+        val urls = HtmlAssetRewriter.extractImageUrls(
+            """<video src="clip.mp4"><source src="clip.webm"></video>""",
+        )
+        assertTrue(urls.isEmpty())
     }
 }

--- a/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
+++ b/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
@@ -1,0 +1,63 @@
+package mihon.core.archive
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.URLEncoder
+
+class RelativeAssetSchemeTest {
+
+    private fun scheme(path: String) = NOVEL_IMAGE_SCHEME + URLEncoder.encode(path, "UTF-8")
+
+    @Test
+    fun `isResolvableAssetRef classification`() {
+        assertTrue(isResolvableAssetRef("image_0.jpg"))
+        assertTrue(isResolvableAssetRef("./image_0.jpg"))
+        assertTrue(isResolvableAssetRef("/image_0.jpg"))
+        assertFalse(isResolvableAssetRef("http://x/y.jpg"))
+        assertFalse(isResolvableAssetRef("https://x/y.jpg"))
+        assertFalse(isResolvableAssetRef("//cdn/x.jpg"))
+        assertFalse(isResolvableAssetRef("data:image/png;base64,AAAA"))
+        assertFalse(isResolvableAssetRef("tsundoku-novel-image://image_0.jpg"))
+        assertFalse(isResolvableAssetRef("#frag"))
+        assertFalse(isResolvableAssetRef(""))
+    }
+
+    @Test
+    fun `maps a plain relative filename to the novel image scheme`() {
+        assertEquals(scheme("image_0.jpg"), relativeAssetScheme("image_0.jpg"))
+    }
+
+    @Test
+    fun `strips a leading dot-slash or slash since there is no real root here`() {
+        assertEquals(scheme("image_0.jpg"), relativeAssetScheme("./image_0.jpg"))
+        assertEquals(scheme("image_0.jpg"), relativeAssetScheme("/image_0.jpg"))
+    }
+
+    @Test
+    fun `strips the query string before resolving`() {
+        assertEquals(scheme("image_0.jpg"), relativeAssetScheme("image_0.jpg?w=106&h=150"))
+    }
+
+    @Test
+    fun `returns null for anything already absolute so callers leave it untouched`() {
+        assertNull(relativeAssetScheme("https://cdn.com/a.jpg"))
+        assertNull(relativeAssetScheme("//cdn.com/a.jpg"))
+        assertNull(relativeAssetScheme("data:image/png;base64,AAAA"))
+    }
+
+    @Test
+    fun `is idempotent for content already carrying the scheme, so old and new downloads mix safely`() {
+        val already = scheme("image_0.jpg")
+        assertNull(relativeAssetScheme(already))
+    }
+
+    @Test
+    fun `pre-encoded refs are decoded before re-encoding`() {
+        val out = relativeAssetScheme("image%20one.jpg")!!
+        val encoded = out.removePrefix(NOVEL_IMAGE_SCHEME)
+        assertEquals("image one.jpg", java.net.URLDecoder.decode(encoded, "UTF-8"))
+    }
+}

--- a/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
+++ b/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
@@ -60,4 +60,25 @@ class RelativeAssetSchemeTest {
         val encoded = out.removePrefix(NOVEL_IMAGE_SCHEME)
         assertEquals("image one.jpg", java.net.URLDecoder.decode(encoded, "UTF-8"))
     }
+
+    @Test
+    fun `rewriteResolvedAssetRefs only rewrites a ref whose file actually exists`() {
+        val html = """<img src="a.jpg"><img src="b.jpg">"""
+        val out = rewriteResolvedAssetRefs(html) { it == "a.jpg" }
+        assertEquals("""<img src="${scheme("a.jpg")}"><img src="b.jpg">""", out)
+    }
+
+    @Test
+    fun `rewriteResolvedAssetRefsOnce skips the scan when the marker is present`() {
+        val marked = markAssetsResolved("""<img src="never-checked.jpg">""")
+        val out = rewriteResolvedAssetRefsOnce(marked) { error("fileExists must not be called for marked content") }
+        assertEquals("""<img src="never-checked.jpg">""", out)
+    }
+
+    @Test
+    fun `rewriteResolvedAssetRefsOnce falls back to a full scan for unmarked content`() {
+        val html = """<img src="a.jpg">"""
+        val out = rewriteResolvedAssetRefsOnce(html) { it == "a.jpg" }
+        assertEquals("""<img src="${scheme("a.jpg")}">""", out)
+    }
 }

--- a/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
+++ b/app/src/test/java/mihon/core/archive/RelativeAssetSchemeTest.kt
@@ -69,16 +69,20 @@ class RelativeAssetSchemeTest {
     }
 
     @Test
-    fun `rewriteResolvedAssetRefsOnce skips the scan when the marker is present`() {
-        val marked = markAssetsResolved("""<img src="never-checked.jpg">""")
-        val out = rewriteResolvedAssetRefsOnce(marked) { error("fileExists must not be called for marked content") }
-        assertEquals("""<img src="never-checked.jpg">""", out)
-    }
+    fun `rewriting the same joined text twice is a no-op, so multi-page joins are safe`() {
+        val page1 = """<img src="a.jpg">"""
+        val page2 = """<img src="b.jpg">"""
+        val joined = listOf(page1, page2).joinToString("\n\n")
 
-    @Test
-    fun `rewriteResolvedAssetRefsOnce falls back to a full scan for unmarked content`() {
-        val html = """<img src="a.jpg">"""
-        val out = rewriteResolvedAssetRefsOnce(html) { it == "a.jpg" }
-        assertEquals("""<img src="${scheme("a.jpg")}">""", out)
+        val onceRewritten = rewriteResolvedAssetRefs(joined) { it == "a.jpg" || it == "b.jpg" }
+        val twiceRewritten = rewriteResolvedAssetRefs(onceRewritten) {
+            error("fileExists must not be called for content that is already fully rewritten")
+        }
+
+        assertEquals(
+            """<img src="${scheme("a.jpg")}">""" + "\n\n" + """<img src="${scheme("b.jpg")}">""",
+            onceRewritten,
+        )
+        assertEquals(onceRewritten, twiceRewritten)
     }
 }

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubWriter.kt
@@ -191,8 +191,9 @@ class EpubWriter(
         val hasPictures = content.contains("<picture")
         if (images.isEmpty() && !hasTsundokuPaths && !hasPictures) return content
 
+        // Encode img.id the same way the read-time rewrite encoded the src attribute, or it won't match.
         val imageMap = images.associate { img ->
-            "tsundoku-novel-image://${img.id}" to "images/${chapterImageFileName(chapterPrefix, img)}"
+            novelImageUrl(img.id) to "images/${chapterImageFileName(chapterPrefix, img)}"
         }
 
         val doc = Jsoup.parseBodyFragment(content)

--- a/core/archive/src/main/kotlin/mihon/core/archive/HtmlAssetRewriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/HtmlAssetRewriter.kt
@@ -32,10 +32,32 @@ object HtmlAssetRewriter {
         "(?<![\\w:-])(src|srcset)(\\s*=\\s*)(?:([\"'])(.*?)\\3|([^\\s\"'>]+))",
         RegexOption.IGNORE_CASE,
     )
+    private val DATA_SRC_ATTR_REGEX = Regex(
+        "(?<![\\w:-])data-src(\\s*=\\s*)(?:([\"'])(.*?)\\2|([^\\s\"'>]+))",
+        RegexOption.IGNORE_CASE,
+    )
     private val BG_IMAGE_CSS_REGEX = Regex(
         "background-image\\s*:\\s*url\\s*\\(\\s*([\"']?)([^\"')]+)\\1\\s*\\)",
         RegexOption.IGNORE_CASE,
     )
+
+    private val PICTURE_BLOCK_REGEX = Regex(
+        "(<picture\\b[^>]*>)(.*?)(</picture>)",
+        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+    )
+    private val PICTURE_SOURCE_TAG_REGEX = Regex(
+        "<source\\b(?:\"[^\"]*\"|'[^']*'|[^>])*>",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private fun MatchResult.attrValue(quoteGroup: Int): String {
+        val quotedGroup = quoteGroup + 1
+        val bareGroup = quoteGroup + 2
+        return if (groupValues[quoteGroup].isNotEmpty()) groupValues[quotedGroup] else groupValues[bareGroup]
+    }
+
+    private fun lazyLoadSrc(tag: String): String? =
+        DATA_SRC_ATTR_REGEX.find(tag)?.attrValue(quoteGroup = 2)?.takeIf { it.isNotBlank() }
 
     fun rewriteHtml(content: String, toScheme: (String) -> String?): String {
         val withTags = RESOURCE_TAG_REGEX.replace(content) { tagMatch ->
@@ -43,7 +65,7 @@ object HtmlAssetRewriter {
                 val name = attr.groupValues[1]
                 val eq = attr.groupValues[2]
                 val quote = attr.groupValues[3]
-                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                val value = attr.attrValue(quoteGroup = 3)
                 val newValue = if (name.equals("srcset", ignoreCase = true)) {
                     rewriteSrcset(value, toScheme)
                 } else {
@@ -81,52 +103,16 @@ object HtmlAssetRewriter {
         }
     }
 
-    fun extractUrls(content: String): Set<String> {
-        val urls = mutableSetOf<String>()
-        fun addIfFetchable(url: String) {
-            if (url.isNotBlank() && !url.startsWith("data:", ignoreCase = true)) urls.add(url)
-        }
-
-        RESOURCE_TAG_REGEX.findAll(content).forEach { tagMatch ->
-            URL_ATTR_REGEX.findAll(tagMatch.value).forEach { attr ->
-                val name = attr.groupValues[1]
-                val quote = attr.groupValues[3]
-                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
-                if (name.equals("srcset", ignoreCase = true)) {
-                    value.split(',').forEach { candidate ->
-                        val trimmed = candidate.trim()
-                        if (trimmed.isNotEmpty()) {
-                            val spaceIdx = trimmed.indexOf(' ')
-                            addIfFetchable(if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed)
-                        }
-                    }
-                } else {
-                    addIfFetchable(value)
-                }
-            }
-        }
-
-        STYLE_BLOCK_REGEX.findAll(content).forEach { m ->
-            CSS_URL_REGEX.findAll(m.groupValues[2]).forEach { addIfFetchable(it.groupValues[2]) }
-        }
-        STYLE_ATTR_REGEX.findAll(content).forEach { m ->
-            CSS_URL_REGEX.findAll(m.groupValues[3]).forEach { addIfFetchable(it.groupValues[2]) }
-        }
-
-        return urls
-    }
-
     fun extractImageUrls(content: String): Set<String> {
         val urls = mutableSetOf<String>()
         fun addIfFetchable(url: String) {
             if (url.isNotBlank() && !url.startsWith("data:", ignoreCase = true)) urls.add(url)
         }
-
-        IMAGE_TAG_REGEX.findAll(content).forEach { tagMatch ->
-            IMAGE_ATTR_REGEX.findAll(tagMatch.value).forEach { attr ->
+        fun collectFromTag(tag: String) {
+            val lazySrc = lazyLoadSrc(tag)
+            IMAGE_ATTR_REGEX.findAll(tag).forEach { attr ->
                 val name = attr.groupValues[1]
-                val quote = attr.groupValues[3]
-                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                val value = attr.attrValue(quoteGroup = 3)
                 if (name.equals("srcset", ignoreCase = true)) {
                     value.split(',').forEach { candidate ->
                         val trimmed = candidate.trim()
@@ -135,33 +121,45 @@ object HtmlAssetRewriter {
                             addIfFetchable(if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed)
                         }
                     }
-                } else {
+                } else if (lazySrc == null) {
                     addIfFetchable(value)
                 }
             }
+            if (lazySrc != null) addIfFetchable(lazySrc)
         }
 
+        IMAGE_TAG_REGEX.findAll(content).forEach { collectFromTag(it.value) }
+        PICTURE_BLOCK_REGEX.findAll(content).forEach { block ->
+            PICTURE_SOURCE_TAG_REGEX.findAll(block.groupValues[2]).forEach { collectFromTag(it.value) }
+        }
         BG_IMAGE_CSS_REGEX.findAll(content).forEach { addIfFetchable(it.groupValues[2]) }
 
         return urls
     }
 
     fun rewriteImageUrls(content: String, toScheme: (String) -> String?): String {
-        val withImgTags = IMAGE_TAG_REGEX.replace(content) { tagMatch ->
-            IMAGE_ATTR_REGEX.replace(tagMatch.value) { attr ->
+        fun rewriteTag(tag: String): String {
+            val lazySrc = lazyLoadSrc(tag)
+            return IMAGE_ATTR_REGEX.replace(tag) { attr ->
                 val name = attr.groupValues[1]
                 val eq = attr.groupValues[2]
                 val quote = attr.groupValues[3]
-                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
-                val newValue = if (name.equals("srcset", ignoreCase = true)) {
-                    rewriteSrcset(value, toScheme)
-                } else {
-                    toScheme(value) ?: value
+                val value = attr.attrValue(quoteGroup = 3)
+                val newValue = when {
+                    name.equals("srcset", ignoreCase = true) -> rewriteSrcset(value, toScheme)
+                    lazySrc != null -> toScheme(lazySrc) ?: value
+                    else -> toScheme(value) ?: value
                 }
                 "$name$eq$quote$newValue$quote"
             }
         }
-        return BG_IMAGE_CSS_REGEX.replace(withImgTags) { m ->
+
+        val withImgTags = IMAGE_TAG_REGEX.replace(content) { rewriteTag(it.value) }
+        val withSourceTags = PICTURE_BLOCK_REGEX.replace(withImgTags) { block ->
+            val rewrittenInner = PICTURE_SOURCE_TAG_REGEX.replace(block.groupValues[2]) { rewriteTag(it.value) }
+            "${block.groupValues[1]}$rewrittenInner${block.groupValues[3]}"
+        }
+        return BG_IMAGE_CSS_REGEX.replace(withSourceTags) { m ->
             val quote = m.groupValues[1]
             val url = m.groupValues[2]
             "background-image:url($quote${toScheme(url) ?: url}$quote)"

--- a/core/archive/src/main/kotlin/mihon/core/archive/HtmlAssetRewriter.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/HtmlAssetRewriter.kt
@@ -1,0 +1,170 @@
+package mihon.core.archive
+
+/** Shared HTML resource-URL discovery and rewriting for the embedder and local-novel resolver. */
+object HtmlAssetRewriter {
+
+    private val RESOURCE_TAG_REGEX = Regex(
+        "<(?:img|source|video|audio|track|embed|object|image|link|script)\\b(?:\"[^\"]*\"|'[^']*'|[^>])*>",
+        RegexOption.IGNORE_CASE,
+    )
+    private val URL_ATTR_REGEX = Regex(
+        "(?<![\\w:-])(src|href|poster|data|srcset|xlink:href)(\\s*=\\s*)(?:([\"'])(.*?)\\3|([^\\s\"'>]+))",
+        RegexOption.IGNORE_CASE,
+    )
+    private val CSS_URL_REGEX = Regex(
+        "url\\(\\s*([\"']?)([^\"')]+)\\1\\s*\\)",
+        RegexOption.IGNORE_CASE,
+    )
+    private val STYLE_BLOCK_REGEX = Regex(
+        "(<style\\b[^>]*>)(.*?)(</style>)",
+        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+    )
+    private val STYLE_ATTR_REGEX = Regex(
+        "(style\\s*=\\s*)([\"'])(.*?)\\2",
+        RegexOption.IGNORE_CASE,
+    )
+
+    private val IMAGE_TAG_REGEX = Regex(
+        "<img\\b(?:\"[^\"]*\"|'[^']*'|[^>])*>",
+        RegexOption.IGNORE_CASE,
+    )
+    private val IMAGE_ATTR_REGEX = Regex(
+        "(?<![\\w:-])(src|srcset)(\\s*=\\s*)(?:([\"'])(.*?)\\3|([^\\s\"'>]+))",
+        RegexOption.IGNORE_CASE,
+    )
+    private val BG_IMAGE_CSS_REGEX = Regex(
+        "background-image\\s*:\\s*url\\s*\\(\\s*([\"']?)([^\"')]+)\\1\\s*\\)",
+        RegexOption.IGNORE_CASE,
+    )
+
+    fun rewriteHtml(content: String, toScheme: (String) -> String?): String {
+        val withTags = RESOURCE_TAG_REGEX.replace(content) { tagMatch ->
+            URL_ATTR_REGEX.replace(tagMatch.value) { attr ->
+                val name = attr.groupValues[1]
+                val eq = attr.groupValues[2]
+                val quote = attr.groupValues[3]
+                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                val newValue = if (name.equals("srcset", ignoreCase = true)) {
+                    rewriteSrcset(value, toScheme)
+                } else {
+                    toScheme(value) ?: value
+                }
+                "$name$eq$quote$newValue$quote"
+            }
+        }
+        val withStyleBlocks = STYLE_BLOCK_REGEX.replace(withTags) { m ->
+            "${m.groupValues[1]}${rewriteCssUrls(m.groupValues[2], toScheme)}${m.groupValues[3]}"
+        }
+        return STYLE_ATTR_REGEX.replace(withStyleBlocks) { m ->
+            val eqAndQuote = m.groupValues[1]
+            val quote = m.groupValues[2]
+            "$eqAndQuote$quote${rewriteCssUrls(m.groupValues[3], toScheme)}$quote"
+        }
+    }
+
+    fun rewriteCssUrls(css: String, toScheme: (String) -> String?): String {
+        return CSS_URL_REGEX.replace(css) { m ->
+            val quote = m.groupValues[1]
+            val url = m.groupValues[2]
+            "url($quote${toScheme(url) ?: url}$quote)"
+        }
+    }
+
+    fun rewriteSrcset(srcset: String, toScheme: (String) -> String?): String {
+        return srcset.split(',').joinToString(", ") { candidate ->
+            val trimmed = candidate.trim()
+            if (trimmed.isEmpty()) return@joinToString candidate
+            val spaceIdx = trimmed.indexOf(' ')
+            val url = if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed
+            val descriptor = if (spaceIdx >= 0) trimmed.substring(spaceIdx) else ""
+            "${toScheme(url) ?: url}$descriptor"
+        }
+    }
+
+    fun extractUrls(content: String): Set<String> {
+        val urls = mutableSetOf<String>()
+        fun addIfFetchable(url: String) {
+            if (url.isNotBlank() && !url.startsWith("data:", ignoreCase = true)) urls.add(url)
+        }
+
+        RESOURCE_TAG_REGEX.findAll(content).forEach { tagMatch ->
+            URL_ATTR_REGEX.findAll(tagMatch.value).forEach { attr ->
+                val name = attr.groupValues[1]
+                val quote = attr.groupValues[3]
+                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                if (name.equals("srcset", ignoreCase = true)) {
+                    value.split(',').forEach { candidate ->
+                        val trimmed = candidate.trim()
+                        if (trimmed.isNotEmpty()) {
+                            val spaceIdx = trimmed.indexOf(' ')
+                            addIfFetchable(if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed)
+                        }
+                    }
+                } else {
+                    addIfFetchable(value)
+                }
+            }
+        }
+
+        STYLE_BLOCK_REGEX.findAll(content).forEach { m ->
+            CSS_URL_REGEX.findAll(m.groupValues[2]).forEach { addIfFetchable(it.groupValues[2]) }
+        }
+        STYLE_ATTR_REGEX.findAll(content).forEach { m ->
+            CSS_URL_REGEX.findAll(m.groupValues[3]).forEach { addIfFetchable(it.groupValues[2]) }
+        }
+
+        return urls
+    }
+
+    fun extractImageUrls(content: String): Set<String> {
+        val urls = mutableSetOf<String>()
+        fun addIfFetchable(url: String) {
+            if (url.isNotBlank() && !url.startsWith("data:", ignoreCase = true)) urls.add(url)
+        }
+
+        IMAGE_TAG_REGEX.findAll(content).forEach { tagMatch ->
+            IMAGE_ATTR_REGEX.findAll(tagMatch.value).forEach { attr ->
+                val name = attr.groupValues[1]
+                val quote = attr.groupValues[3]
+                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                if (name.equals("srcset", ignoreCase = true)) {
+                    value.split(',').forEach { candidate ->
+                        val trimmed = candidate.trim()
+                        if (trimmed.isNotEmpty()) {
+                            val spaceIdx = trimmed.indexOf(' ')
+                            addIfFetchable(if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed)
+                        }
+                    }
+                } else {
+                    addIfFetchable(value)
+                }
+            }
+        }
+
+        BG_IMAGE_CSS_REGEX.findAll(content).forEach { addIfFetchable(it.groupValues[2]) }
+
+        return urls
+    }
+
+    fun rewriteImageUrls(content: String, toScheme: (String) -> String?): String {
+        val withImgTags = IMAGE_TAG_REGEX.replace(content) { tagMatch ->
+            IMAGE_ATTR_REGEX.replace(tagMatch.value) { attr ->
+                val name = attr.groupValues[1]
+                val eq = attr.groupValues[2]
+                val quote = attr.groupValues[3]
+                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
+                val newValue = if (name.equals("srcset", ignoreCase = true)) {
+                    rewriteSrcset(value, toScheme)
+                } else {
+                    toScheme(value) ?: value
+                }
+                "$name$eq$quote$newValue$quote"
+            }
+        }
+        return BG_IMAGE_CSS_REGEX.replace(withImgTags) { m ->
+            val quote = m.groupValues[1]
+            val url = m.groupValues[2]
+            "background-image:url($quote${toScheme(url) ?: url}$quote)"
+        }
+    }
+}

--- a/core/archive/src/main/kotlin/mihon/core/archive/NovelImageScheme.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/NovelImageScheme.kt
@@ -1,9 +1,9 @@
 package mihon.core.archive
 
-/**
- * URL scheme for local-novel images resolved through the app's page loaders rather than the
- * network. Declared here in core.archive because it is the lowest module shared by every
- * producer/consumer (EpubReader/EpubWriter here, source-local's asset rewriter, and the app's
- * WebView/text-view image loaders), so they can't drift on the literal.
- */
+import java.net.URLEncoder
+
 const val NOVEL_IMAGE_SCHEME = "tsundoku-novel-image://"
+
+// "%20" instead of URLEncoder's "+", since android.net.Uri.decode and java.net.URLDecoder disagree on "+".
+fun novelImageUrl(path: String): String =
+    NOVEL_IMAGE_SCHEME + URLEncoder.encode(path, "UTF-8").replace("+", "%20")

--- a/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
@@ -29,3 +29,13 @@ fun relativeAssetScheme(ref: String): String? = relativeAssetPath(ref)?.let(::no
 /** Rewrites resolvable asset refs to [NOVEL_IMAGE_SCHEME] URIs, only when [fileExists] confirms the file. */
 fun rewriteResolvedAssetRefs(text: String, fileExists: (String) -> Boolean): String =
     HtmlAssetRewriter.rewriteHtml(text) { ref -> relativeAssetPath(ref)?.takeIf(fileExists)?.let(::novelImageUrl) }
+
+private const val ASSETS_RESOLVED_MARKER = "<!--tsundoku:assets-resolved-->"
+
+fun markAssetsResolved(text: String): String = ASSETS_RESOLVED_MARKER + text
+
+/** Skips the regex scan entirely for content already stamped by [markAssetsResolved]. */
+fun rewriteResolvedAssetRefsOnce(text: String, fileExists: (String) -> Boolean): String {
+    if (text.startsWith(ASSETS_RESOLVED_MARKER)) return text.removePrefix(ASSETS_RESOLVED_MARKER)
+    return rewriteResolvedAssetRefs(text, fileExists)
+}

--- a/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
@@ -1,0 +1,27 @@
+package mihon.core.archive
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+private val ABSOLUTE_SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:|^//")
+
+/** True when [ref] is a same-origin-relative reference resolvable to a local file. */
+fun isResolvableAssetRef(ref: String): Boolean {
+    val v = ref.trim()
+    if (v.isEmpty()) return false
+    if (v.startsWith("#") || v.startsWith("//")) return false
+    return !ABSOLUTE_SCHEME_REGEX.containsMatchIn(v)
+}
+
+/** Maps a flat/relative asset reference to a [NOVEL_IMAGE_SCHEME] URI, or null if already absolute. */
+fun relativeAssetScheme(ref: String): String? {
+    val v = ref.trim()
+    if (!isResolvableAssetRef(v)) return null
+    val decoded = decodeAssetPath(v.substringBefore('?').substringBefore('#'))
+        .removePrefix("./").removePrefix("/")
+    if (decoded.isBlank()) return null
+    return NOVEL_IMAGE_SCHEME + URLEncoder.encode(decoded, "UTF-8")
+}
+
+private fun decodeAssetPath(path: String): String =
+    runCatching { URLDecoder.decode(path.replace("+", "%2B"), "UTF-8") }.getOrDefault(path)

--- a/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
@@ -26,16 +26,12 @@ private fun decodeAssetPath(path: String): String =
 /** Maps a flat/relative asset reference to a [NOVEL_IMAGE_SCHEME] URI, or null if already absolute. */
 fun relativeAssetScheme(ref: String): String? = relativeAssetPath(ref)?.let(::novelImageUrl)
 
-/** Rewrites resolvable asset refs to [NOVEL_IMAGE_SCHEME] URIs, only when [fileExists] confirms the file. */
+/**
+ * Rewrites resolvable asset refs to [NOVEL_IMAGE_SCHEME] URIs, only when [fileExists] confirms the file.
+ *
+ * Already-rewritten refs use an absolute scheme, so [isResolvableAssetRef] rejects them and this is a
+ * no-op on a second pass. That idempotency is what lets callers join several already-processed HTML
+ * pages into one string and rewrite once, safely, with no per-document "already resolved" marker needed.
+ */
 fun rewriteResolvedAssetRefs(text: String, fileExists: (String) -> Boolean): String =
     HtmlAssetRewriter.rewriteHtml(text) { ref -> relativeAssetPath(ref)?.takeIf(fileExists)?.let(::novelImageUrl) }
-
-private const val ASSETS_RESOLVED_MARKER = "<!--tsundoku:assets-resolved-->"
-
-fun markAssetsResolved(text: String): String = ASSETS_RESOLVED_MARKER + text
-
-/** Skips the regex scan entirely for content already stamped by [markAssetsResolved]. */
-fun rewriteResolvedAssetRefsOnce(text: String, fileExists: (String) -> Boolean): String {
-    if (text.startsWith(ASSETS_RESOLVED_MARKER)) return text.removePrefix(ASSETS_RESOLVED_MARKER)
-    return rewriteResolvedAssetRefs(text, fileExists)
-}

--- a/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/RelativeAssetScheme.kt
@@ -1,7 +1,6 @@
 package mihon.core.archive
 
 import java.net.URLDecoder
-import java.net.URLEncoder
 
 private val ABSOLUTE_SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:|^//")
 
@@ -13,15 +12,20 @@ fun isResolvableAssetRef(ref: String): Boolean {
     return !ABSOLUTE_SCHEME_REGEX.containsMatchIn(v)
 }
 
-/** Maps a flat/relative asset reference to a [NOVEL_IMAGE_SCHEME] URI, or null if already absolute. */
-fun relativeAssetScheme(ref: String): String? {
+fun relativeAssetPath(ref: String): String? {
     val v = ref.trim()
     if (!isResolvableAssetRef(v)) return null
     val decoded = decodeAssetPath(v.substringBefore('?').substringBefore('#'))
         .removePrefix("./").removePrefix("/")
-    if (decoded.isBlank()) return null
-    return NOVEL_IMAGE_SCHEME + URLEncoder.encode(decoded, "UTF-8")
+    return decoded.ifBlank { null }
 }
 
 private fun decodeAssetPath(path: String): String =
     runCatching { URLDecoder.decode(path.replace("+", "%2B"), "UTF-8") }.getOrDefault(path)
+
+/** Maps a flat/relative asset reference to a [NOVEL_IMAGE_SCHEME] URI, or null if already absolute. */
+fun relativeAssetScheme(ref: String): String? = relativeAssetPath(ref)?.let(::novelImageUrl)
+
+/** Rewrites resolvable asset refs to [NOVEL_IMAGE_SCHEME] URIs, only when [fileExists] confirms the file. */
+fun rewriteResolvedAssetRefs(text: String, fileExists: (String) -> Boolean): String =
+    HtmlAssetRewriter.rewriteHtml(text) { ref -> relativeAssetPath(ref)?.takeIf(fileExists)?.let(::novelImageUrl) }

--- a/source-local/src/main/kotlin/tachiyomi/source/local/NovelAssetRewriter.kt
+++ b/source-local/src/main/kotlin/tachiyomi/source/local/NovelAssetRewriter.kt
@@ -1,74 +1,22 @@
 package tachiyomi.source.local
 
+import mihon.core.archive.HtmlAssetRewriter
 import mihon.core.archive.NOVEL_IMAGE_SCHEME
+import mihon.core.archive.isResolvableAssetRef
+import mihon.core.archive.relativeAssetScheme
 
 internal object NovelAssetRewriter {
 
     const val SCHEME = NOVEL_IMAGE_SCHEME
 
-    private val RESOURCE_TAG_REGEX = Regex(
-        "<(?:img|source|video|audio|track|embed|object|image|link|script)\\b(?:\"[^\"]*\"|'[^']*'|[^>])*>",
-        RegexOption.IGNORE_CASE,
-    )
-    private val URL_ATTR_REGEX = Regex(
-        "(?<![\\w:-])(src|href|poster|data|srcset|xlink:href)(\\s*=\\s*)(?:([\"'])(.*?)\\3|([^\\s\"'>]+))",
-        RegexOption.IGNORE_CASE,
-    )
-    private val CSS_URL_REGEX = Regex(
-        "url\\(\\s*([\"']?)([^\"')]+)\\1\\s*\\)",
-        RegexOption.IGNORE_CASE,
-    )
-    private val STYLE_BLOCK_REGEX = Regex(
-        "(<style\\b[^>]*>)(.*?)(</style>)",
-        setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
-    )
-    private val STYLE_ATTR_REGEX = Regex(
-        "(style\\s*=\\s*)([\"'])(.*?)\\2",
-        RegexOption.IGNORE_CASE,
-    )
     private val MD_IMAGE_REGEX = Regex("""(!\[[^\]]*]\()([^)\s]+)""")
-    private val ABSOLUTE_SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:|^//")
 
     fun rewrite(content: String, ext: String, toScheme: (String) -> String?): String {
         return when (ext.lowercase()) {
-            "html", "htm", "xhtml" -> rewriteHtml(content, toScheme)
-            "md", "markdown" -> rewriteHtml(rewriteMarkdownImages(content, toScheme), toScheme)
+            "html", "htm", "xhtml" -> HtmlAssetRewriter.rewriteHtml(content, toScheme)
+            "md", "markdown" ->
+                HtmlAssetRewriter.rewriteHtml(rewriteMarkdownImages(content, toScheme), toScheme)
             else -> content
-        }
-    }
-
-    private fun rewriteHtml(content: String, toScheme: (String) -> String?): String {
-        val withTags = RESOURCE_TAG_REGEX.replace(content) { tagMatch ->
-            URL_ATTR_REGEX.replace(tagMatch.value) { attr ->
-                val name = attr.groupValues[1]
-                val eq = attr.groupValues[2]
-                val quote = attr.groupValues[3]
-                val value = if (quote.isNotEmpty()) attr.groupValues[4] else attr.groupValues[5]
-                val newValue = if (name.equals("srcset", ignoreCase = true)) {
-                    rewriteSrcset(value, toScheme)
-                } else {
-                    toScheme(value) ?: value
-                }
-                "$name$eq$quote$newValue$quote"
-            }
-        }
-        // Scope url() rewriting to actual CSS (<style> blocks and inline style attributes) so a
-        // relative-looking url(...) token inside a <script> body or text node isn't corrupted.
-        val withStyleBlocks = STYLE_BLOCK_REGEX.replace(withTags) { m ->
-            "${m.groupValues[1]}${rewriteCssUrls(m.groupValues[2], toScheme)}${m.groupValues[3]}"
-        }
-        return STYLE_ATTR_REGEX.replace(withStyleBlocks) { m ->
-            val eqAndQuote = m.groupValues[1]
-            val quote = m.groupValues[2]
-            "$eqAndQuote$quote${rewriteCssUrls(m.groupValues[3], toScheme)}$quote"
-        }
-    }
-
-    private fun rewriteCssUrls(css: String, toScheme: (String) -> String?): String {
-        return CSS_URL_REGEX.replace(css) { m ->
-            val quote = m.groupValues[1]
-            val url = m.groupValues[2]
-            "url($quote${toScheme(url) ?: url}$quote)"
         }
     }
 
@@ -78,33 +26,11 @@ internal object NovelAssetRewriter {
         }
     }
 
-    private fun rewriteSrcset(srcset: String, toScheme: (String) -> String?): String {
-        return srcset.split(',').joinToString(", ") { candidate ->
-            val trimmed = candidate.trim()
-            if (trimmed.isEmpty()) return@joinToString candidate
-            val spaceIdx = trimmed.indexOf(' ')
-            val url = if (spaceIdx >= 0) trimmed.substring(0, spaceIdx) else trimmed
-            val descriptor = if (spaceIdx >= 0) trimmed.substring(spaceIdx) else ""
-            "${toScheme(url) ?: url}$descriptor"
-        }
-    }
-
     // Root-absolute refs in a saved site point at the site root, which for a local novel is the
     // chapter's own base directory, so they resolve like relative refs once the leading slash is dropped.
-    fun isResolvableRef(ref: String): Boolean {
-        val v = ref.trim()
-        if (v.isEmpty()) return false
-        if (v.startsWith("#") || v.startsWith("//")) return false
-        return !ABSOLUTE_SCHEME_REGEX.containsMatchIn(v)
-    }
+    fun isResolvableRef(ref: String): Boolean = isResolvableAssetRef(ref)
 
-    fun relativeScheme(ref: String): String? {
-        val v = ref.trim()
-        if (!isResolvableRef(v)) return null
-        val path = decodePath(v.substringBefore('?').substringBefore('#')).removePrefix("./").removePrefix("/")
-        if (path.isBlank()) return null
-        return "$SCHEME${java.net.URLEncoder.encode(path, "UTF-8")}"
-    }
+    fun relativeScheme(ref: String): String? = relativeAssetScheme(ref)
 
     fun archiveScheme(baseDir: String, ref: String): String? {
         val v = ref.trim()

--- a/source-local/src/main/kotlin/tachiyomi/source/local/NovelAssetRewriter.kt
+++ b/source-local/src/main/kotlin/tachiyomi/source/local/NovelAssetRewriter.kt
@@ -3,6 +3,7 @@ package tachiyomi.source.local
 import mihon.core.archive.HtmlAssetRewriter
 import mihon.core.archive.NOVEL_IMAGE_SCHEME
 import mihon.core.archive.isResolvableAssetRef
+import mihon.core.archive.novelImageUrl
 import mihon.core.archive.relativeAssetScheme
 
 internal object NovelAssetRewriter {
@@ -39,7 +40,7 @@ internal object NovelAssetRewriter {
         val effectiveBase = if (decoded.startsWith("/")) "" else baseDir
         val path = resolveArchivePath(effectiveBase, decoded) ?: return null
         if (path.isBlank()) return null
-        return "$SCHEME${java.net.URLEncoder.encode(path, "UTF-8")}"
+        return novelImageUrl(path)
     }
 
     // Saved web pages write pre-encoded refs; decode before re-encoding so "%20" doesn't become "%2520".


### PR DESCRIPTION
downloaded chapters now save relative paths instead of baking the tsundoku uri