### PR TITLE
Fix/lnreader backup import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Prevent crash with setting search on duplicate key [@mrissaoussama](https://github.com/mrissaoussama) [#383](https://github.com/tsundoku-otaku/tsundoku/pull/383)
+- Fix importing new LNreader backups, all novels in DB come favorited [@mrissaoussama](https://github.com/mrissaoussama) [#388](https://github.com/tsundoku-otaku/tsundoku/pull/388)
 
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.data.backup
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.graphics.BitmapFactory
 import androidx.core.app.NotificationCompat
 import com.hippo.unifile.UniFile
@@ -8,6 +10,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
@@ -177,9 +180,23 @@ class BackupNotifier(private val context: Context) {
                     context.stringResource(MR.strings.action_show_errors),
                     errorLogIntent,
                 )
+            } else {
+                setContentIntent(openMainActivityPendingActivity())
             }
 
             show(Notifications.ID_RESTORE_COMPLETE)
         }
+    }
+
+    private fun openMainActivityPendingActivity(): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        return PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
@@ -194,7 +194,9 @@ class LNReaderBackupImporter(
 
         try {
             // Step 1: Extract data only
-            val (novels, categories, pluginZipFile) = extractBackupData(uri)
+            val (novels, categories, legacyZipFile, pluginsZipFile, novelFilesZipFile) = extractBackupData(uri)
+            val effectivePluginsZipFile = pluginsZipFile ?: legacyZipFile
+            val effectiveAssetsZipFile = novelFilesZipFile ?: legacyZipFile
 
             try {
                 logcat(LogPriority.INFO) {
@@ -217,8 +219,8 @@ class LNReaderBackupImporter(
                 }
 
                 // Step 3: Install plugins
-                if (options.restorePlugins && pluginZipFile != null) {
-                    installedPluginCount = installPluginsFromDownloadZip(pluginZipFile)
+                if (options.restorePlugins && effectivePluginsZipFile != null) {
+                    installedPluginCount = installPluginsFromDownloadZip(effectivePluginsZipFile)
                     // Wait for plugins to be processed by subscribing to the hot flow or just a short delay
                     // Since it's blocking in the plugin manager ideally, we can remove the delay
                 }
@@ -346,10 +348,10 @@ class LNReaderBackupImporter(
                         }
                     }
                 }
-                // Step 5: Restore downloaded chapter HTML and cached covers from LNReader download.zip
-                if ((options.restoreDownloadedChapters || options.restoreCovers) && pluginZipFile != null) {
+                // Step 5: Restore downloaded chapter HTML and cached covers
+                if ((options.restoreDownloadedChapters || options.restoreCovers) && effectiveAssetsZipFile != null) {
                     val restored = restoreDownloadedAssetsFromDownloadZip(
-                        pluginZipFile,
+                        effectiveAssetsZipFile,
                         novels,
                         pluginIdToSourceId,
                         options.restoreDownloadedChapters,
@@ -360,7 +362,9 @@ class LNReaderBackupImporter(
                     restoredCoverCount = restored.second
                 }
             } finally {
-                pluginZipFile?.delete()
+                legacyZipFile?.delete()
+                pluginsZipFile?.delete()
+                novelFilesZipFile?.delete()
             }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "LNReaderImport: Failed to import backup" }
@@ -392,18 +396,26 @@ class LNReaderBackupImporter(
     }
 
     /**
-     * Represents extracted backup data: novels, categories, and optional plugin zip bytes.
+     * Represents extracted backup data: novels, categories, and optional plugin/asset zip bytes.
+     *
+     * Older LNReader exports bundle plugin code and downloaded chapters/covers into a single
+     * "download.zip" ([legacyZipFile]); newer exports split them into "plugins.zip"
+     * ([pluginsZipFile]) and "novel-files.zip" ([novelFilesZipFile]).
      */
     data class ExtractedBackup(
         val novels: List<LNNovel>,
         val categories: List<LNCategory>,
-        val pluginZipFile: File?,
+        val legacyZipFile: File?,
+        val pluginsZipFile: File?,
+        val novelFilesZipFile: File?,
     )
 
     private fun extractBackupData(uri: Uri): ExtractedBackup {
         val novels = mutableListOf<LNNovel>()
         var categories = emptyList<LNCategory>()
         var downloadZipFile: File? = null
+        var pluginsZipFile: File? = null
+        var novelFilesZipFile: File? = null
         var lastNotifyTime = 0L
 
         try {
@@ -446,6 +458,20 @@ class LNReaderBackupImporter(
                                 }
                                 downloadZipFile = tempFile
                             }
+                            name == "plugins.zip" -> {
+                                val tempFile = context.createFileInCacheDir("lnreader_plugins.zip")
+                                tempFile.outputStream().use { fos ->
+                                    zip.copyTo(fos)
+                                }
+                                pluginsZipFile = tempFile
+                            }
+                            name == "novel-files.zip" -> {
+                                val tempFile = context.createFileInCacheDir("lnreader_novel_files.zip")
+                                tempFile.outputStream().use { fos ->
+                                    zip.copyTo(fos)
+                                }
+                                novelFilesZipFile = tempFile
+                            }
                         }
                         zip.closeEntry()
                         entry = zip.nextEntry
@@ -455,10 +481,12 @@ class LNReaderBackupImporter(
             }
         } catch (e: Exception) {
             downloadZipFile?.delete()
+            pluginsZipFile?.delete()
+            novelFilesZipFile?.delete()
             throw e
         }
 
-        return ExtractedBackup(novels, categories, downloadZipFile)
+        return ExtractedBackup(novels, categories, downloadZipFile, pluginsZipFile, novelFilesZipFile)
     }
 
     private suspend fun installPluginsFromDownloadZip(zipFile: File): Int {
@@ -470,10 +498,16 @@ class LNReaderBackupImporter(
                     val name = entry.name
                     // Process plugin JS files
                     val nameLower = name.lowercase()
-                    if (nameLower.startsWith("plugins/") && nameLower.endsWith("/index.js") && !entry.isDirectory) {
-                        val parts = name.removePrefix(name.substringBefore("/") + "/").split("/")
-                        if (parts.size == 2) {
-                            val pluginId = parts[0]
+                    if (nameLower.endsWith("/index.js") && !entry.isDirectory) {
+                        val parts = name.split("/")
+                        // Older LNReader exports wrap plugins in a "plugins/" folder inside
+                        // download.zip; newer plugins.zip exports are flat: "<id>/index.js".
+                        val pluginId = when {
+                            parts.size == 2 -> parts[0]
+                            parts.size == 3 && parts[0].equals("plugins", ignoreCase = true) -> parts[1]
+                            else -> null
+                        }
+                        if (pluginId != null) {
                             try {
                                 val code = zip.bufferedReader(StandardCharsets.UTF_8).readText()
                                 if (code.isNotBlank()) {
@@ -502,6 +536,19 @@ class LNReaderBackupImporter(
             errors.add(Date() to "Failed to process download.zip: ${e.message}")
         }
         return installedCount
+    }
+
+    /**
+     * Older LNReader download.zip exports wrap asset entries in a "Novels/" folder; newer
+     * novel-files.zip exports are flat: "<pluginId>/<novelId>/...". Strip the wrapper so both
+     * layouts resolve to the same "<pluginId>/<novelId>/..." shape.
+     */
+    private fun normalizeAssetEntryName(name: String): String {
+        return if (name.substringBefore('/').equals("Novels", ignoreCase = true)) {
+            name.substringAfter('/')
+        } else {
+            name
+        }
     }
 
     private suspend fun restoreDownloadedAssetsFromDownloadZip(
@@ -547,10 +594,10 @@ class LNReaderBackupImporter(
                         continue
                     }
 
-                    val parts = name.split('/')
-                    if (parts.size >= 4 && parts[0].equals("Novels", ignoreCase = true)) {
-                        val pluginId = parts[1]
-                        val novelId = parts[2].toIntOrNull()
+                    val parts = normalizeAssetEntryName(name).split('/')
+                    if (parts.size >= 3) {
+                        val pluginId = parts[0]
+                        val novelId = parts[1].toIntOrNull()
 
                         if (novelId != null) {
                             entriesToProcess.add(Triple(novelId, pluginId, entry))
@@ -584,16 +631,15 @@ class LNReaderBackupImporter(
                                     var dbManga: tachiyomi.domain.manga.model.Manga? = null
 
                                     for ((_, _, entry) in novelEntries) {
-                                        val name = entry.name
-                                        val parts = name.split('/')
+                                        val parts = normalizeAssetEntryName(entry.name).split('/')
 
                                         val isChapter =
-                                            parts.size == 5 && parts[4].startsWith("index.", ignoreCase = true)
+                                            parts.size == 4 && parts[3].startsWith("index.", ignoreCase = true)
                                         val isCover =
-                                            parts.size == 4 && parts[3].startsWith("cover.", ignoreCase = true)
+                                            parts.size == 3 && parts[2].startsWith("cover.", ignoreCase = true)
 
                                         if (isChapter && restoreDownloadedChapters) {
-                                            val chapterId = parts[3].toIntOrNull()
+                                            val chapterId = parts[2].toIntOrNull()
                                             if (chapterId != null) {
                                                 val chapter = downloadedChapterByKey[
                                                     Triple(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
@@ -23,9 +23,19 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.intOrNull
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.model.Category
@@ -57,6 +67,26 @@ import java.util.zip.ZipInputStream
  * └── Setting.json
  * ```
  */
+
+/**
+ * LNReader used to export SQLite boolean columns as 0/1 integers; newer versions export them
+ * as real JSON booleans. Accept either so backups from both eras import cleanly.
+ */
+private object FlexibleBoolAsIntSerializer : KSerializer<Int> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("FlexibleBoolAsInt", PrimitiveKind.INT)
+
+    override fun serialize(encoder: Encoder, value: Int) {
+        encoder.encodeInt(value)
+    }
+
+    override fun deserialize(decoder: Decoder): Int {
+        val element = (decoder as JsonDecoder).decodeJsonElement() as? JsonPrimitive
+            ?: return 0
+        element.booleanOrNull?.let { return if (it) 1 else 0 }
+        return element.intOrNull ?: 0
+    }
+}
+
 class LNReaderBackupImporter(
     private val context: Context,
     private val notifier: BackupNotifier? = null,
@@ -89,7 +119,9 @@ class LNReaderBackupImporter(
         val artist: String? = null,
         val status: String? = null,
         val genres: String? = null,
+        @Serializable(with = FlexibleBoolAsIntSerializer::class)
         val inLibrary: Int = 0,
+        @Serializable(with = FlexibleBoolAsIntSerializer::class)
         val isLocal: Int = 0,
         val totalPages: Int = 0,
         val chapters: List<LNChapter> = emptyList(),
@@ -103,8 +135,11 @@ class LNReaderBackupImporter(
         val name: String = "",
         val releaseTime: String? = null,
         val readTime: String? = null,
+        @Serializable(with = FlexibleBoolAsIntSerializer::class)
         val bookmark: Int = 0,
+        @Serializable(with = FlexibleBoolAsIntSerializer::class)
         val unread: Int = 1,
+        @Serializable(with = FlexibleBoolAsIntSerializer::class)
         val isDownloaded: Int = 0,
         val updatedTime: String? = null,
         val chapterNumber: Float? = null,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
@@ -68,10 +68,7 @@ import java.util.zip.ZipInputStream
  * ```
  */
 
-/**
- * LNReader used to export SQLite boolean columns as 0/1 integers; newer versions export them
- * as real JSON booleans. Accept either so backups from both eras import cleanly.
- */
+/** Older LNReader exports use 0/1 for booleans; newer ones use real JSON booleans. Accept both. */
 private object FlexibleBoolAsIntSerializer : KSerializer<Int> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("FlexibleBoolAsInt", PrimitiveKind.INT)
 
@@ -396,11 +393,8 @@ class LNReaderBackupImporter(
     }
 
     /**
-     * Represents extracted backup data: novels, categories, and optional plugin/asset zip bytes.
-     *
-     * Older LNReader exports bundle plugin code and downloaded chapters/covers into a single
-     * "download.zip" ([legacyZipFile]); newer exports split them into "plugins.zip"
-     * ([pluginsZipFile]) and "novel-files.zip" ([novelFilesZipFile]).
+     * Older LNReader exports bundle plugins and downloaded assets into one [legacyZipFile];
+     * newer ones split them into [pluginsZipFile] and [novelFilesZipFile].
      */
     data class ExtractedBackup(
         val novels: List<LNNovel>,
@@ -500,8 +494,7 @@ class LNReaderBackupImporter(
                     val nameLower = name.lowercase()
                     if (nameLower.endsWith("/index.js") && !entry.isDirectory) {
                         val parts = name.split("/")
-                        // Older LNReader exports wrap plugins in a "plugins/" folder inside
-                        // download.zip; newer plugins.zip exports are flat: "<id>/index.js".
+                        // legacy: "plugins/<id>/index.js"; new plugins.zip: flat "<id>/index.js"
                         val pluginId = when {
                             parts.size == 2 -> parts[0]
                             parts.size == 3 && parts[0].equals("plugins", ignoreCase = true) -> parts[1]
@@ -538,11 +531,7 @@ class LNReaderBackupImporter(
         return installedCount
     }
 
-    /**
-     * Older LNReader download.zip exports wrap asset entries in a "Novels/" folder; newer
-     * novel-files.zip exports are flat: "<pluginId>/<novelId>/...". Strip the wrapper so both
-     * layouts resolve to the same "<pluginId>/<novelId>/..." shape.
-     */
+    /** Strips the legacy "Novels/" wrapper so old and new asset paths share one shape. */
     private fun normalizeAssetEntryName(name: String): String {
         return if (name.substringBefore('/').equals("Novels", ignoreCase = true)) {
             name.substringAfter('/')
@@ -822,8 +811,7 @@ class LNReaderBackupImporter(
                     dateFetch = 0L,
                     dateUpload = parseDate(ch.releaseTime) ?: 0L,
                     chapterNumber = ch.chapterNumber ?: (index + 1).toFloat(),
-                    // LNReader stores chapters oldest-first, but sourceOrder follows this
-                    // codebase's newest-first convention (sourceOrder 0 == newest chapter).
+                    // LNReader lists chapters oldest-first; sourceOrder 0 must be the newest
                     sourceOrder = (lastIndex - index).toLong(),
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporter.kt
@@ -810,6 +810,7 @@ class LNReaderBackupImporter(
         includeCategories: Boolean = true,
     ): BackupManga {
         val backupChapters = if (includeChapters) {
+            val lastIndex = novel.chapters.size - 1
             novel.chapters.mapIndexed { index, ch ->
                 BackupChapter(
                     url = ch.path,
@@ -821,7 +822,9 @@ class LNReaderBackupImporter(
                     dateFetch = 0L,
                     dateUpload = parseDate(ch.releaseTime) ?: 0L,
                     chapterNumber = ch.chapterNumber ?: (index + 1).toFloat(),
-                    sourceOrder = index.toLong(),
+                    // LNReader stores chapters oldest-first, but sourceOrder follows this
+                    // codebase's newest-first convention (sourceOrder 0 == newest chapter).
+                    sourceOrder = (lastIndex - index).toLong(),
                 )
             }
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -95,8 +95,7 @@ class MangaRestorer(
         backupCategories: List<BackupCategory>,
     ) {
         database.transaction {
-            // A restore implies the novel should be in the library, even if the existing DB
-            // row (e.g. from a prior browse/search) isn't favorited yet.
+            // an existing row may be a non-favorite leftover (e.g. from browse/search)
             if (!existingManga.favorite && backupManga.favorite) {
                 updateManga(existingManga.copy(favorite = true))
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -95,6 +95,11 @@ class MangaRestorer(
         backupCategories: List<BackupCategory>,
     ) {
         database.transaction {
+            // A restore implies the novel should be in the library, even if the existing DB
+            // row (e.g. from a prior browse/search) isn't favorited yet.
+            if (!existingManga.favorite && backupManga.favorite) {
+                updateManga(existingManga.copy(favorite = true))
+            }
             restoreChapters(existingManga, backupManga.chapters)
             restoreHistory(existingManga, backupManga.history)
             if (backupManga.categories.isNotEmpty()) {

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporterTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/LNReaderBackupImporterTest.kt
@@ -1,0 +1,52 @@
+package eu.kanade.tachiyomi.data.backup.restore
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LNReaderBackupImporterTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `decodes chapter booleans from newer LNReader JSON boolean export`() {
+        val chapter = json.decodeFromString<LNReaderBackupImporter.LNChapter>(
+            """{"id":1,"novelId":1,"path":"p","name":"n","bookmark":false,"unread":false,"isDownloaded":true}""",
+        )
+
+        assertEquals(0, chapter.bookmark)
+        assertEquals(0, chapter.unread)
+        assertEquals(1, chapter.isDownloaded)
+    }
+
+    @Test
+    fun `decodes chapter booleans from older LNReader 0-1 integer export`() {
+        val chapter = json.decodeFromString<LNReaderBackupImporter.LNChapter>(
+            """{"id":1,"novelId":1,"path":"p","name":"n","bookmark":1,"unread":0,"isDownloaded":1}""",
+        )
+
+        assertEquals(1, chapter.bookmark)
+        assertEquals(0, chapter.unread)
+        assertEquals(1, chapter.isDownloaded)
+    }
+
+    @Test
+    fun `decodes novel booleans from newer LNReader JSON boolean export`() {
+        val novel = json.decodeFromString<LNReaderBackupImporter.LNNovel>(
+            """{"id":1,"path":"p","pluginId":"x","name":"n","inLibrary":true,"isLocal":false}""",
+        )
+
+        assertEquals(1, novel.inLibrary)
+        assertEquals(0, novel.isLocal)
+    }
+
+    @Test
+    fun `decodes novel booleans from older LNReader 0-1 integer export`() {
+        val novel = json.decodeFromString<LNReaderBackupImporter.LNNovel>(
+            """{"id":1,"path":"p","pluginId":"x","name":"n","inLibrary":0,"isLocal":1}""",
+        )
+
+        assertEquals(0, novel.inLibrary)
+        assertEquals(1, novel.isLocal)
+    }
+}


### PR DESCRIPTION
- fixed importing new lnreader backups (true/false over 0/1)
- supports new zip file names for plugins and novel data
- made it so novels in db but not favorited are now favorited if they exist in the backup
