### PR TITLE
Novel Extension Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 ### Improved
+- Novel Extension Repo > Extension Store + Related fixes [@Rojikku](https://github.com/Rojikku) [#391](https://github.com/tsundoku-otaku/tsundoku/pull/391)
 - Handle picture/source/video/audio tags in text view [@mrissaoussama](https://github.com/mrissaoussama) [#381](https://github.com/tsundoku-otaku/tsundoku/pull/381)
 - avoid list copies during backup restore [@mrissaoussama](https://github.com/mrissaoussama) [#389](https://github.com/tsundoku-otaku/tsundoku/pull/389)
 - Improve UI filter panel with scroll, apply library filters [@mrissaoussama](https://github.com/mrissaoussama) [#382](https://github.com/tsundoku-otaku/tsundoku/pull/382)

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -229,7 +229,7 @@ class DomainModule : InjektModule {
         addFactory { DeleteSourcePinGroup(get()) }
         addSingletonFactory { TrustExtension(get(), get()) } // Singleton to enable caching of trusted fingerprints
 
-        addSingletonFactory { ExtensionStoreService(get(), get(), get()) }
+        addSingletonFactory { ExtensionStoreService(get(), get()) }
         addSingletonFactory<ExtensionStoreRepository> { ExtensionStoreRepositoryImpl(get(), get()) }
         addFactory { AddExtensionStore(get()) }
         addFactory { GetExtensionStoreCountAsFlow(get()) }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresViewModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresViewModel.kt
@@ -41,7 +41,7 @@ class ExtensionStoresViewModel(
     init {
         viewModelScope.launchIO {
             combine(
-                getExtensionStores.subscribe(),
+                getExtensionStores.subscribe(isNovel = false),
                 sourcePreferences.disabledExtensionRepos.changes(),
             ) { stores, disabled -> stores to disabled }
                 .collectLatest { (stores, disabled) ->

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresViewModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresViewModel.kt
@@ -41,7 +41,7 @@ class ExtensionStoresViewModel(
     init {
         viewModelScope.launchIO {
             combine(
-                getExtensionStores.subscribe(isNovel = false),
+                getExtensionStores.subscribe(),
                 sourcePreferences.disabledExtensionRepos.changes(),
             ) { stores, disabled -> stores to disabled }
                 .collectLatest { (stores, disabled) ->

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -217,10 +217,11 @@ class ExtensionManager(
                 changed = true
             } else if (availableExt != null) {
                 val hasUpdate = extension.updateExists(availableExt)
-                if (extension.hasUpdate != hasUpdate) {
+                if (extension.hasUpdate != hasUpdate || extension.isObsolete) {
                     installedExtensionsMap[pkgName] = extension.copy(
                         hasUpdate = hasUpdate,
                         store = availableExt.store,
+                        isObsolete = false,
                     )
                 } else {
                     installedExtensionsMap[pkgName] = extension.copy(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedCard
@@ -47,6 +48,8 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.icons.CustomIcons
+import tachiyomi.presentation.core.icons.Discord
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -405,13 +408,25 @@ private fun KotlinRepoListItem(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repo.indexUrl))
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repo.contact.website))
                 context.startActivity(intent)
             }) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                    imageVector = Icons.Outlined.Public,
                     contentDescription = stringResource(MR.strings.action_open_in_browser),
                 )
+            }
+
+            if (repo.contact.discord != null) {
+                IconButton(onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repo.contact.discord))
+                    context.startActivity(intent)
+                }) {
+                    Icon(
+                        imageVector = CustomIcons.Discord,
+                        contentDescription = null,
+                    )
+                }
             }
 
             IconButton(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposScreen.kt
@@ -68,7 +68,7 @@ class NovelExtensionReposScreen(
         Scaffold(
             topBar = {
                 AppBar(
-                    title = stringResource(MR.strings.label_extension_repos),
+                    title = stringResource(MR.strings.extensionStores),
                     navigateUp = navigator::pop,
                     actions = {
                         androidx.compose.material3.IconButton(onClick = screenModel::refreshRepos) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
@@ -39,7 +39,7 @@ class NovelExtensionReposViewModel(
         viewModelScope.launchIO {
             combine(
                 jsPluginManager.repositories,
-                getExtensionStores.subscribe(isNovel = true),
+                getExtensionStores.subscribe(),
                 sourcePreferences.disabledExtensionRepos.changes(),
             ) { jsRepos, kotlinRepos, disabledKotlinRepos ->
                 NovelRepoScreenState.Success(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
@@ -100,6 +100,7 @@ class NovelExtensionReposViewModel(
 
     fun setJsRepoEnabled(url: String, enabled: Boolean) {
         jsPluginManager.setRepositoryEnabled(url, enabled)
+        viewModelScope.launchIO { jsPluginManager.refreshAvailablePlugins() }
     }
 
     fun setKotlinRepoEnabled(indexUrl: String, enabled: Boolean) {
@@ -108,6 +109,7 @@ class NovelExtensionReposViewModel(
                 if (enabled) disabledRepos - indexUrl else disabledRepos + indexUrl
             },
         )
+        viewModelScope.launchIO { extensionManager.findAvailableExtensions() }
     }
 
     fun refreshRepos() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionReposViewModel.kt
@@ -39,7 +39,7 @@ class NovelExtensionReposViewModel(
         viewModelScope.launchIO {
             combine(
                 jsPluginManager.repositories,
-                getExtensionStores.subscribe(),
+                getExtensionStores.subscribe(isNovel = true),
                 sourcePreferences.disabledExtensionRepos.changes(),
             ) { jsRepos, kotlinRepos, disabledKotlinRepos ->
                 NovelRepoScreenState.Success(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/NovelExtensionsTab.kt
@@ -43,7 +43,7 @@ fun novelExtensionsTab(
                 onClick = { navigator.push(ExtensionFilterScreen()) },
             ),
             AppBar.OverflowAction(
-                title = stringResource(MR.strings.label_extension_repos),
+                title = stringResource(MR.strings.extensionStores),
                 onClick = { navigator.push(NovelExtensionReposScreen()) },
             ),
         ),

--- a/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
+++ b/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
@@ -84,11 +84,13 @@ class ExtensionStoreRepositoryImpl(
                     .map { store ->
                         async {
                             val resolved = normalizeIfStub(store)
-                            service.getExtensions(resolved).onFailure {
-                                this@ExtensionStoreRepositoryImpl.logcat(LogPriority.ERROR, it) {
-                                    "Failed to fetch extensions for store '${resolved.name} (${resolved.indexUrl})'"
+                            service.getExtensions(resolved)
+                                .onSuccess { syncContentType(resolved, it) }
+                                .onFailure {
+                                    this@ExtensionStoreRepositoryImpl.logcat(LogPriority.ERROR, it) {
+                                        "Failed to fetch extensions for store '${resolved.name} (${resolved.indexUrl})'"
+                                    }
                                 }
-                            }
                         }
                     }
                     .awaitAll()
@@ -97,6 +99,17 @@ class ExtensionStoreRepositoryImpl(
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             emptyList()
+        }
+    }
+
+    // The isNovel tag on the store row is only a UI-list sorting hint set at add time; correct it
+    // from what the store actually serves so a manga store that starts publishing novels (or vice
+    // versa) moves to the right screen without the user having to re-add it.
+    private suspend fun syncContentType(store: ExtensionStore, extensions: List<Extension.Available>) {
+        if (extensions.isEmpty()) return
+        val derivedIsNovel = extensions.count { it.isNovel } > extensions.size / 2
+        if (derivedIsNovel != store.isNovel) {
+            upsert(store.copy(isNovel = derivedIsNovel))
         }
     }
 

--- a/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
+++ b/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
@@ -102,7 +102,7 @@ class ExtensionStoreRepositoryImpl(
 
     private suspend fun normalizeIfStub(store: ExtensionStore): ExtensionStore {
         if (store.isLegacy || !store.indexUrl.endsWith("/repo.json")) return store
-        return service.fetch(store.indexUrl).map { resolved ->
+        return service.fetch(store.indexUrl).mapCatching { resolved ->
             val fixed = resolved.copy(isNovel = store.isNovel)
             database.transaction {
                 upsert(fixed)
@@ -111,6 +111,10 @@ class ExtensionStoreRepositoryImpl(
                 }
             }
             fixed
+        }.onFailure {
+            logcat(LogPriority.ERROR, it) {
+                "Failed to normalize stub store '${store.name} (${store.indexUrl})'"
+            }
         }.getOrDefault(store)
     }
 

--- a/data/src/main/java/mihon/data/extension/service/ExtensionStoreService.kt
+++ b/data/src/main/java/mihon/data/extension/service/ExtensionStoreService.kt
@@ -23,12 +23,19 @@ import kotlin.coroutines.cancellation.CancellationException
 
 class ExtensionStoreService(
     private val network: NetworkHelper,
-    private val json: Json,
     private val protoBuf: ProtoBuf,
 ) {
     // Extension repo hosts aren't novel/manga sources - exempt them same as the sibling
     // ExtensionInstaller (which downloads the APK these fetches point to).
     private val client by lazy { network.client.rateLimitExempt() }
+
+    // protobuf's canonical JSON mapping renders int64 fields (versionCode, source ids) as
+    // quoted strings, so this needs isLenient to accept indexes published via json_format.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        isLenient = true
+    }
 
     suspend fun fetch(indexUrl: String): Result<ExtensionStore> {
         var updatedIndexUrl: String = indexUrl

--- a/domain/src/main/java/mihon/domain/extension/interactor/GetExtensionStores.kt
+++ b/domain/src/main/java/mihon/domain/extension/interactor/GetExtensionStores.kt
@@ -1,6 +1,7 @@
 package mihon.domain.extension.interactor
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import mihon.domain.extension.model.ExtensionStore
 import mihon.domain.extension.repository.ExtensionStoreRepository
 
@@ -10,4 +11,12 @@ class GetExtensionStores(
     suspend fun get(): List<ExtensionStore> = repository.getAll()
 
     fun subscribe(): Flow<List<ExtensionStore>> = repository.getAllAsFlow()
+
+    /**
+     * Stores filtered by which screen registered them, for tidier repo-management lists.
+     * Novel only shows stores explicitly tagged isNovel=true; manga shows everything else,
+     * so an untagged/legacy store (isNovel defaults false) still shows up somewhere.
+     */
+    fun subscribe(isNovel: Boolean): Flow<List<ExtensionStore>> =
+        repository.getAllAsFlow().map { stores -> stores.filter { it.isNovel == isNovel } }
 }

--- a/domain/src/main/java/mihon/domain/extension/interactor/GetExtensionStores.kt
+++ b/domain/src/main/java/mihon/domain/extension/interactor/GetExtensionStores.kt
@@ -1,7 +1,6 @@
 package mihon.domain.extension.interactor
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import mihon.domain.extension.model.ExtensionStore
 import mihon.domain.extension.repository.ExtensionStoreRepository
 
@@ -11,8 +10,4 @@ class GetExtensionStores(
     suspend fun get(): List<ExtensionStore> = repository.getAll()
 
     fun subscribe(): Flow<List<ExtensionStore>> = repository.getAllAsFlow()
-
-    /** Stores filtered by content type so the manga and novel screens list only their own. */
-    fun subscribe(isNovel: Boolean): Flow<List<ExtensionStore>> =
-        repository.getAllAsFlow().map { stores -> stores.filter { it.isNovel == isNovel } }
 }


### PR DESCRIPTION
Renamed button on novel extensions from Extension Repo to Extension Store.

Resolves several assorted bugs:
* If source re-enabled, de-orphan
* More resilent fetch
* Show website/discord buttons in novel side