### PR TITLE
Add blank title/URL filter and category dialog to duplicate detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - avoid list copies during backup restore [@mrissaoussama](https://github.com/mrissaoussama) [#389](https://github.com/tsundoku-otaku/tsundoku/pull/389)
 - Improve UI filter panel with scroll, apply library filters [@mrissaoussama](https://github.com/mrissaoussama) [#382](https://github.com/tsundoku-otaku/tsundoku/pull/382)
 - Asset-rewrite logic uses relative paths for chapter embedder/local novels [@mrissaoussama](https://github.com/mrissaoussama) [#385](https://github.com/tsundoku-otaku/tsundoku/pull/385)
+- Add blank title/URL filter and category dialog to duplicate detection - #393 [@mrissaoussama](https://github.com/mrissaoussama) [#393](https://github.com/tsundoku-otaku/tsundoku/pull/393)
 
 ### Fixed
 - Prevent crash with setting search on duplicate key [@mrissaoussama](https://github.com/mrissaoussama) [#383](https://github.com/tsundoku-otaku/tsundoku/pull/383)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -78,12 +78,16 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.library.DeleteLibraryMangaDialog
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
+import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.util.source.getMangaUrlOrNull
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.preference.CheckboxState
+import tachiyomi.domain.manga.interactor.BlankTitleFilter
 import tachiyomi.domain.manga.interactor.DuplicateMatchMode
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.source.service.SourceManager
@@ -521,6 +525,55 @@ class DuplicateDetectionScreen : Screen {
                                     },
                                 )
                             }
+
+                            val blankFiltersEnabled = !state.listingMode &&
+                                state.matchMode != DuplicateMatchMode.CONTAINS
+                            FlowRow(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    stringResource(MR.strings.duplicate_blank_label),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    modifier = Modifier.align(Alignment.CenterVertically),
+                                )
+                                FilterChip(
+                                    selected = state.blankTitleFilter == BlankTitleFilter.EXCLUDE,
+                                    enabled = blankFiltersEnabled,
+                                    onClick = { screenModel.setBlankTitleFilter(BlankTitleFilter.EXCLUDE) },
+                                    label = { Text(stringResource(MR.strings.duplicate_blank_exclude)) },
+                                    leadingIcon = if (state.blankTitleFilter == BlankTitleFilter.EXCLUDE) {
+                                        { Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp)) }
+                                    } else {
+                                        null
+                                    },
+                                )
+                                FilterChip(
+                                    selected = state.blankTitleFilter == BlankTitleFilter.INCLUDE,
+                                    enabled = blankFiltersEnabled,
+                                    onClick = { screenModel.setBlankTitleFilter(BlankTitleFilter.INCLUDE) },
+                                    label = { Text(stringResource(MR.strings.duplicate_blank_include)) },
+                                    leadingIcon = if (state.blankTitleFilter == BlankTitleFilter.INCLUDE) {
+                                        { Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp)) }
+                                    } else {
+                                        null
+                                    },
+                                )
+                                FilterChip(
+                                    selected = state.blankTitleFilter == BlankTitleFilter.ONLY,
+                                    enabled = blankFiltersEnabled,
+                                    onClick = { screenModel.setBlankTitleFilter(BlankTitleFilter.ONLY) },
+                                    label = { Text(stringResource(MR.strings.duplicate_blank_only)) },
+                                    leadingIcon = if (state.blankTitleFilter == BlankTitleFilter.ONLY) {
+                                        { Icon(Icons.Filled.Check, contentDescription = null, Modifier.size(18.dp)) }
+                                    } else {
+                                        null
+                                    },
+                                )
+                            }
+
                             // Sort mode selector
                             FlowRow(
                                 modifier = Modifier
@@ -915,9 +968,17 @@ class DuplicateDetectionScreen : Screen {
                             state.filteredDuplicateGroups.toList(),
                             key = { it.first },
                         ) { (title, mangaList) ->
+                            val fullGroupCount = state.fullGroupIds[title]?.size ?: mangaList.size
+                            val canSelectHiddenTail = state.searchQuery.isBlank() &&
+                                state.contentType == DuplicateDetectionViewModel.ContentType.ALL &&
+                                state.selectedCategoryFilters.isEmpty() &&
+                                state.excludedCategoryFilters.isEmpty() &&
+                                !state.applyLibraryFilters
                             DuplicateGroupCard(
                                 groupTitle = title,
                                 mangaList = mangaList,
+                                fullGroupCount = fullGroupCount,
+                                canSelectHiddenTail = canSelectHiddenTail,
                                 selection = state.selection,
                                 mangaCategories = state.mangaCategories,
                                 showFullUrls = state.showFullUrls,
@@ -968,13 +1029,19 @@ class DuplicateDetectionScreen : Screen {
 
         // Move to category dialog
         if (state.showMoveToCategoryDialog) {
-            MoveToCategoryDialog(
-                categories = state.categories,
-                onDismiss = { screenModel.closeMoveToCategoryDialog() },
-                onConfirm = { categoryIds ->
+            ChangeCategoryDialog(
+                initialSelection = remember(state.selection, state.mangaCategoryIdSets, state.categories) {
+                    categorySelectionFor(state)
+                },
+                onDismissRequest = { screenModel.closeMoveToCategoryDialog() },
+                onEditCategories = {
+                    screenModel.closeMoveToCategoryDialog()
+                    navigator.push(CategoryScreen())
+                },
+                onConfirm = { addCategories, removeCategories ->
                     val count = state.selection.size
                     scope.launch {
-                        screenModel.moveSelectedToCategories(categoryIds)
+                        screenModel.moveSelectedToCategories(addCategories, removeCategories)
                         snackbarHostState.showSnackbar(
                             context.ctxStringResource(MR.strings.duplicate_moved_count, count),
                         )
@@ -985,10 +1052,31 @@ class DuplicateDetectionScreen : Screen {
     }
 }
 
+private fun categorySelectionFor(
+    state: DuplicateDetectionViewModel.State,
+): List<CheckboxState<CategoryModel>> {
+    val selectedIds = state.selection
+    if (selectedIds.isEmpty()) return state.categories.map { CheckboxState.State.None(it) }
+
+    val perManga = selectedIds.map { state.mangaCategoryIdSets[it] ?: setOf(0L) }
+    val common = perManga.reduce { a, b -> a intersect b }
+    val union = perManga.flatten().toSet()
+
+    return state.categories.map {
+        when {
+            it.id in common -> CheckboxState.State.Checked(it)
+            it.id in union -> CheckboxState.TriState.None(it)
+            else -> CheckboxState.State.None(it)
+        }
+    }
+}
+
 @Composable
 private fun DuplicateGroupCard(
     groupTitle: String,
     mangaList: List<MangaWithChapterCount>,
+    fullGroupCount: Int,
+    canSelectHiddenTail: Boolean,
     selection: Set<Long>,
     mangaCategories: Map<Long, List<CategoryModel>>,
     showFullUrls: Boolean,
@@ -1027,6 +1115,25 @@ private fun DuplicateGroupCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    if (fullGroupCount > mangaList.size) {
+                        Text(
+                            text = if (canSelectHiddenTail) {
+                                stringResource(
+                                    MR.strings.duplicate_group_truncated_selectable,
+                                    mangaList.size,
+                                    fullGroupCount,
+                                )
+                            } else {
+                                stringResource(
+                                    MR.strings.duplicate_group_truncated_filtered,
+                                    mangaList.size,
+                                    fullGroupCount,
+                                )
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
                 }
                 IconButton(onClick = onSelectGroup) {
                     Icon(
@@ -1216,63 +1323,3 @@ private fun DuplicateItem(
     }
 }
 
-@Composable
-private fun MoveToCategoryDialog(
-    categories: List<CategoryModel>,
-    onDismiss: () -> Unit,
-    onConfirm: (List<Long>) -> Unit,
-) {
-    var selectedCategories by remember { mutableStateOf(setOf<Long>()) }
-
-    androidx.compose.material3.AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(MR.strings.duplicate_move_to_category)) },
-        text = {
-            LazyColumn {
-                items(categories) { category ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                selectedCategories = if (category.id in selectedCategories) {
-                                    selectedCategories - category.id
-                                } else {
-                                    selectedCategories + category.id
-                                }
-                            }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = category.id in selectedCategories,
-                            onCheckedChange = {
-                                selectedCategories = if (it) {
-                                    selectedCategories + category.id
-                                } else {
-                                    selectedCategories - category.id
-                                }
-                            },
-                        )
-                        Text(category.name.ifBlank { stringResource(MR.strings.label_default) })
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onConfirm(selectedCategories.toList())
-                    onDismiss()
-                },
-                enabled = selectedCategories.isNotEmpty(),
-            ) {
-                Text(stringResource(MR.strings.action_move))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(MR.strings.action_cancel))
-            }
-        },
-    )
-}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -968,7 +968,13 @@ class DuplicateDetectionScreen : Screen {
                             state.filteredDuplicateGroups.toList(),
                             key = { it.first },
                         ) { (title, mangaList) ->
-                            val fullGroupCount = state.fullGroupIds[title]?.size ?: mangaList.size
+                            val materializedGroupCount = state.duplicateGroups[title]?.size ?: mangaList.size
+                            val scanFullCount = state.fullGroupIds[title]?.size ?: materializedGroupCount
+                            val fullGroupCount = if (scanFullCount > materializedGroupCount) {
+                                scanFullCount
+                            } else {
+                                mangaList.size
+                            }
                             val canSelectHiddenTail = state.canIncludeHiddenTail
                             DuplicateGroupCard(
                                 groupTitle = title,
@@ -1035,12 +1041,14 @@ class DuplicateDetectionScreen : Screen {
                     navigator.push(CategoryScreen())
                 },
                 onConfirm = { addCategories, removeCategories ->
-                    val count = state.selection.size
-                    scope.launch {
-                        screenModel.moveSelectedToCategories(addCategories, removeCategories)
-                        snackbarHostState.showSnackbar(
-                            context.ctxStringResource(MR.strings.duplicate_moved_count, count),
-                        )
+                    if (addCategories.isNotEmpty() || removeCategories.isNotEmpty()) {
+                        val count = state.selection.size
+                        scope.launch {
+                            screenModel.moveSelectedToCategories(addCategories, removeCategories)
+                            snackbarHostState.showSnackbar(
+                                context.ctxStringResource(MR.strings.duplicate_moved_count, count),
+                            )
+                        }
                     }
                 },
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionScreen.kt
@@ -969,11 +969,7 @@ class DuplicateDetectionScreen : Screen {
                             key = { it.first },
                         ) { (title, mangaList) ->
                             val fullGroupCount = state.fullGroupIds[title]?.size ?: mangaList.size
-                            val canSelectHiddenTail = state.searchQuery.isBlank() &&
-                                state.contentType == DuplicateDetectionViewModel.ContentType.ALL &&
-                                state.selectedCategoryFilters.isEmpty() &&
-                                state.excludedCategoryFilters.isEmpty() &&
-                                !state.applyLibraryFilters
+                            val canSelectHiddenTail = state.canIncludeHiddenTail
                             DuplicateGroupCard(
                                 groupTitle = title,
                                 mangaList = mangaList,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
@@ -146,6 +146,19 @@ class DuplicateDetectionViewModel(
         val precheckProgress: Pair<Int, Int>? = null,
     ) {
 
+        /**
+         * Safe to include a truncated group's hidden tail (in selection/select-all) only when no
+         * filter needs per-manga data (genre/category/download/etc.) to decide whether it matches,
+         * since full rows were never fetched for it. Single source of truth shared by the
+         * selection logic and the "Showing X of Y" UI hint so they can't silently desync.
+         */
+        val canIncludeHiddenTail: Boolean
+            get() = searchQuery.isBlank() &&
+                contentType == ContentType.ALL &&
+                selectedCategoryFilters.isEmpty() &&
+                excludedCategoryFilters.isEmpty() &&
+                !applyLibraryFilters
+
         fun computeFilteredGroups(): Map<String, List<MangaWithChapterCount>> {
             val visibleGroups = duplicateGroups.filterKeys { it !in dismissedGroups }
             val searchFiltered = if (searchQuery.isBlank()) {
@@ -551,7 +564,8 @@ class DuplicateDetectionViewModel(
                         if (truncated.isEmpty()) {
                             emptyMap()
                         } else {
-                            val metricsById = mangaRepository.getFavoriteSelectionMetrics(emptyList())
+                            val hiddenIds = truncated.values.flatten().filterNot { it in materializedIds }.distinct()
+                            val metricsById = mangaRepository.getSelectionMetricsForIds(hiddenIds)
                                 .associateBy { it.id }
                             truncated.mapValues { (_, ids) ->
                                 ids.filter { it !in materializedIds }.mapNotNull { id ->
@@ -656,13 +670,7 @@ class DuplicateDetectionViewModel(
             }
         } else {
             val readCounts = state.mangaReadCounts
-            // Safe only when no filter needs per-manga data (genre/category/download/etc.) to
-            // decide whether the hidden tail matches, since full rows were never fetched for it.
-            val canIncludeHiddenTail = state.searchQuery.isBlank() &&
-                state.contentType == ContentType.ALL &&
-                state.selectedCategoryFilters.isEmpty() &&
-                state.excludedCategoryFilters.isEmpty() &&
-                !state.applyLibraryFilters
+            val canIncludeHiddenTail = state.canIncludeHiddenTail
             state.filteredDuplicateGroups.map { (key, group) ->
                 val materialized = group.map { entry ->
                     SelItem(
@@ -920,8 +928,14 @@ class DuplicateDetectionViewModel(
     }
 
     fun selectGroup(groupTitle: String) {
-        val group = state.value.filteredDuplicateGroups[groupTitle] ?: return
-        val groupIds = group.map { it.manga.id }.toSet()
+        val snapshot = state.value
+        val group = snapshot.filteredDuplicateGroups[groupTitle] ?: return
+        val hiddenTailIds = if (snapshot.canIncludeHiddenTail) {
+            snapshot.truncatedGroupExtraItems[groupTitle]?.map { it.id } ?: emptyList()
+        } else {
+            emptyList()
+        }
+        val groupIds = (group.map { it.manga.id } + hiddenTailIds).toSet()
         mutableState.update { state ->
             val allSelected = groupIds.isNotEmpty() && state.selection.containsAll(groupIds)
             val newSelection = if (allSelected) state.selection - groupIds else state.selection + groupIds

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
@@ -101,6 +101,7 @@ class DuplicateDetectionViewModel(
         val source: Long,
         val chapterCount: Int,
         val readCount: Int,
+        val downloadCount: Int = 0,
     )
 
     data class State(
@@ -556,26 +557,44 @@ class DuplicateDetectionViewModel(
 
                 val readCounts = allMangaItems.associate { it.manga.id to it.readCount.toInt() }
 
-                // Only fetch metrics for a truncated group's hidden tail, and only when one exists.
                 val materializedIds = allMangaItems.mapTo(HashSet()) { it.manga.id }
-                val truncatedGroupExtraItems = fullGroupIds
-                    .filterValues { ids -> ids.any { it !in materializedIds } }
-                    .let { truncated ->
-                        if (truncated.isEmpty()) {
-                            emptyMap()
-                        } else {
-                            val hiddenIds = truncated.values.flatten().filterNot { it in materializedIds }.distinct()
-                            val metricsById = mangaRepository.getSelectionMetricsForIds(hiddenIds)
-                                .associateBy { it.id }
-                            truncated.mapValues { (_, ids) ->
-                                ids.filter { it !in materializedIds }.mapNotNull { id ->
-                                    metricsById[id]?.let {
-                                        SelItem(it.id, it.source, it.chapterCount, it.readCount)
-                                    }
-                                }
+                val hiddenIdsByGroup = fullGroupIds.mapValues { (_, ids) ->
+                    ids.filterNot { it in materializedIds }.distinct()
+                }.filterValues { it.isNotEmpty() }
+                val cappedHiddenIdsByGroup = hiddenIdsByGroup.mapValues { (_, ids) ->
+                    if (ids.size > HIDDEN_TAIL_METRICS_MAX) {
+                        logcat(LogPriority.WARN) {
+                            "loadDuplicates: hidden tail of ${ids.size} ids exceeds " +
+                                "$HIDDEN_TAIL_METRICS_MAX, truncating metrics hydration"
+                        }
+                        ids.take(HIDDEN_TAIL_METRICS_MAX)
+                    } else {
+                        ids
+                    }
+                }
+                val truncatedGroupExtraItems = if (cappedHiddenIdsByGroup.isEmpty()) {
+                    emptyMap()
+                } else {
+                    val allHiddenIds = cappedHiddenIdsByGroup.values.flatten().distinct()
+                    val metrics = mangaRepository.getSelectionMetricsForIds(allHiddenIds)
+                    val hiddenDownloadCounts = downloadManager.getDownloadCounts(
+                        metrics.map { Manga.create().copy(id = it.id, source = it.source, title = it.title) },
+                    )
+                    val metricsById = metrics.associateBy { it.id }
+                    cappedHiddenIdsByGroup.mapValues { (_, ids) ->
+                        ids.mapNotNull { id ->
+                            metricsById[id]?.let {
+                                SelItem(
+                                    it.id,
+                                    it.source,
+                                    it.chapterCount,
+                                    it.readCount,
+                                    hiddenDownloadCounts[it.id] ?: 0,
+                                )
                             }
                         }
                     }
+                }
 
                 mutableState.update {
                     it.copy(
@@ -660,16 +679,18 @@ class DuplicateDetectionViewModel(
     private fun selectionItemGroups(state: State): List<List<SelItem>> {
         return if (state.listingMode) {
             val novelIds = state.novelSourceIds
+            val downloadCounts = state.mangaDownloadCounts
             state.selectionGroups.mapNotNull { group ->
                 val filtered = when (state.contentType) {
                     ContentType.ALL -> group
                     ContentType.MANGA -> group.filter { it.source !in novelIds }
                     ContentType.NOVEL -> group.filter { it.source in novelIds }
-                }
+                }.map { item -> item.copy(downloadCount = downloadCounts[item.id] ?: item.downloadCount) }
                 filtered.ifEmpty { null }
             }
         } else {
             val readCounts = state.mangaReadCounts
+            val downloadCounts = state.mangaDownloadCounts
             val canIncludeHiddenTail = state.canIncludeHiddenTail
             state.filteredDuplicateGroups.map { (key, group) ->
                 val materialized = group.map { entry ->
@@ -678,6 +699,7 @@ class DuplicateDetectionViewModel(
                         source = entry.manga.source,
                         chapterCount = entry.chapterCount.toInt(),
                         readCount = readCounts[entry.manga.id] ?: entry.readCount.toInt(),
+                        downloadCount = downloadCounts[entry.manga.id] ?: 0,
                     )
                 }
                 if (canIncludeHiddenTail) {
@@ -886,27 +908,21 @@ class DuplicateDetectionViewModel(
     }
 
     fun selectLowestDownloadCount() {
-        val downloadCounts = state.value.mangaDownloadCounts
-        val ids = state.value.filteredDuplicateGroups.values
-            .mapNotNull { group ->
-                // Filter to only those with downloads > 0
-                val withDownloads = group.filter { (downloadCounts[it.manga.id] ?: 0) > 0 }
-                withDownloads.minByOrNull { downloadCounts[it.manga.id] ?: 0 }?.manga?.id
+        mutableState.update { state ->
+            val ids = selectionItemGroups(state).mapNotNullTo(HashSet()) { group ->
+                group.filter { it.downloadCount > 0 }.minByOrNull { it.downloadCount }?.id
             }
-            .toSet()
-        mutableState.update { it.copy(selection = ids) }
+            state.copy(selection = ids)
+        }
     }
 
     fun selectHighestDownloadCount() {
-        val downloadCounts = state.value.mangaDownloadCounts
-        val ids = state.value.filteredDuplicateGroups.values
-            .mapNotNull { group ->
-                // Filter to only those with downloads > 0
-                val withDownloads = group.filter { (downloadCounts[it.manga.id] ?: 0) > 0 }
-                withDownloads.maxByOrNull { downloadCounts[it.manga.id] ?: 0 }?.manga?.id
+        mutableState.update { state ->
+            val ids = selectionItemGroups(state).mapNotNullTo(HashSet()) { group ->
+                group.filter { it.downloadCount > 0 }.maxByOrNull { it.downloadCount }?.id
             }
-            .toSet()
-        mutableState.update { it.copy(selection = ids) }
+            state.copy(selection = ids)
+        }
     }
 
     fun selectLowestReadCount() {
@@ -1133,6 +1149,7 @@ class DuplicateDetectionViewModel(
         private const val UNCATEGORIZED_ID = 0L
         private const val TAG_PRECISE_RECHECK_MAX = 200_000
         private const val TAG_PRECHECK_CHUNK = 2000
+        private const val HIDDEN_TAIL_METRICS_MAX = 20_000
 
         fun matchesTagFilter(genre: List<String>?, snapshot: LibraryFilterSnapshot): Boolean {
             if (snapshot.includedTags.isEmpty() &&

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/duplicate/DuplicateDetectionViewModel.kt
@@ -21,9 +21,12 @@ import mihon.core.viewmodel.StateViewModel
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.manga.interactor.BlankTitleFilter
 import tachiyomi.domain.manga.interactor.DuplicateMatchMode
+import tachiyomi.domain.manga.interactor.DuplicateScanResult
 import tachiyomi.domain.manga.interactor.FindDuplicateNovels
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaSelectionMetric
@@ -48,6 +51,7 @@ class DuplicateDetectionViewModel(
     private val coverCache: CoverCache = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
     private val translatedChapterRepository: TranslatedChapterRepository = Injekt.get(),
+    private val setMangaCategories: SetMangaCategories = Injekt.get(),
 ) : StateViewModel<DuplicateDetectionViewModel.State>(State()) {
 
     private val pinnedSourceIds: Set<Long> by lazy {
@@ -132,7 +136,12 @@ class DuplicateDetectionViewModel(
         val listingMode: Boolean = false,
         val listingTruncated: Boolean = false,
         val listingTotalMatches: Int = 0,
+        val blankTitleFilter: BlankTitleFilter = BlankTitleFilter.EXCLUDE,
         val selectionGroups: List<List<SelItem>> = emptyList(),
+        /** Non-listing mode only: every id in each duplicate group, uncapped (see [DuplicateScanResult]). */
+        val fullGroupIds: Map<String, List<Long>> = emptyMap(),
+        /** Members of a truncated group beyond the materialized cap, keyed by group; empty when nothing was capped. */
+        val truncatedGroupExtraItems: Map<String, List<SelItem>> = emptyMap(),
         /** (scanned, total) while the precise tag recheck is running over a large candidate set. */
         val precheckProgress: Pair<Int, Int>? = null,
     ) {
@@ -410,6 +419,8 @@ class DuplicateDetectionViewModel(
                     mangaDownloadCounts = emptyMap(),
                     mangaReadCounts = emptyMap(),
                     selectionGroups = emptyList(),
+                    fullGroupIds = emptyMap(),
+                    truncatedGroupExtraItems = emptyMap(),
                     precheckProgress = null,
                 )
             }
@@ -417,6 +428,7 @@ class DuplicateDetectionViewModel(
                 var truncated = false
                 var listingTotalMatches = 0
                 var selectionGroups = emptyList<List<SelItem>>()
+                var fullGroupIds: Map<String, List<Long>> = emptyMap()
                 val groups = if (state.value.listingMode) {
                     val restriction = resolveListingCategoryRestriction(state.value)
                     val rawMetrics = mangaRepository.getFavoriteSelectionMetrics(restriction.dbCategoryIds)
@@ -499,7 +511,12 @@ class DuplicateDetectionViewModel(
                         .map { (_, items) -> items.map { SelItem(it.id, it.source, it.chapterCount, it.readCount) } }
                     findDuplicateNovels.findGroupedByIds(downloadFilteredMetrics.take(LISTING_MAX).map { it.id })
                 } else {
-                    findDuplicateNovels.findDuplicatesGrouped(state.value.matchMode)
+                    val scanResult: DuplicateScanResult = findDuplicateNovels.findDuplicatesGrouped(
+                        state.value.matchMode,
+                        state.value.blankTitleFilter,
+                    )
+                    fullGroupIds = scanResult.fullGroupIds
+                    scanResult.displayGroups
                 }
 
                 val allMangaItems = groups.values.flatten()
@@ -526,6 +543,26 @@ class DuplicateDetectionViewModel(
 
                 val readCounts = allMangaItems.associate { it.manga.id to it.readCount.toInt() }
 
+                // Only fetch metrics for a truncated group's hidden tail, and only when one exists.
+                val materializedIds = allMangaItems.mapTo(HashSet()) { it.manga.id }
+                val truncatedGroupExtraItems = fullGroupIds
+                    .filterValues { ids -> ids.any { it !in materializedIds } }
+                    .let { truncated ->
+                        if (truncated.isEmpty()) {
+                            emptyMap()
+                        } else {
+                            val metricsById = mangaRepository.getFavoriteSelectionMetrics(emptyList())
+                                .associateBy { it.id }
+                            truncated.mapValues { (_, ids) ->
+                                ids.filter { it !in materializedIds }.mapNotNull { id ->
+                                    metricsById[id]?.let {
+                                        SelItem(it.id, it.source, it.chapterCount, it.readCount)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                 mutableState.update {
                     it.copy(
                         duplicateGroups = groups,
@@ -541,6 +578,8 @@ class DuplicateDetectionViewModel(
                         listingTruncated = truncated,
                         listingTotalMatches = listingTotalMatches,
                         selectionGroups = selectionGroups,
+                        fullGroupIds = fullGroupIds,
+                        truncatedGroupExtraItems = truncatedGroupExtraItems,
                         precheckProgress = null,
                     )
                 }
@@ -555,6 +594,8 @@ class DuplicateDetectionViewModel(
                         listingTruncated = false,
                         listingTotalMatches = 0,
                         selectionGroups = emptyList(),
+                        fullGroupIds = emptyMap(),
+                        truncatedGroupExtraItems = emptyMap(),
                     )
                 }
             }
@@ -615,14 +656,26 @@ class DuplicateDetectionViewModel(
             }
         } else {
             val readCounts = state.mangaReadCounts
-            state.filteredDuplicateGroups.values.map { group ->
-                group.map { entry ->
+            // Safe only when no filter needs per-manga data (genre/category/download/etc.) to
+            // decide whether the hidden tail matches, since full rows were never fetched for it.
+            val canIncludeHiddenTail = state.searchQuery.isBlank() &&
+                state.contentType == ContentType.ALL &&
+                state.selectedCategoryFilters.isEmpty() &&
+                state.excludedCategoryFilters.isEmpty() &&
+                !state.applyLibraryFilters
+            state.filteredDuplicateGroups.map { (key, group) ->
+                val materialized = group.map { entry ->
                     SelItem(
                         id = entry.manga.id,
                         source = entry.manga.source,
                         chapterCount = entry.chapterCount.toInt(),
                         readCount = readCounts[entry.manga.id] ?: entry.readCount.toInt(),
                     )
+                }
+                if (canIncludeHiddenTail) {
+                    materialized + (state.truncatedGroupExtraItems[key] ?: emptyList())
+                } else {
+                    materialized
                 }
             }
         }
@@ -643,6 +696,12 @@ class DuplicateDetectionViewModel(
     fun setListingMode(enabled: Boolean) {
         if (enabled == state.value.listingMode) return
         mutableState.update { it.copy(listingMode = enabled, selection = emptySet()) }
+        loadDuplicates()
+    }
+
+    fun setBlankTitleFilter(filter: BlankTitleFilter) {
+        if (filter == state.value.blankTitleFilter) return
+        mutableState.update { it.copy(blankTitleFilter = filter, selection = emptySet()) }
         loadDuplicates()
     }
 
@@ -1042,10 +1101,14 @@ class DuplicateDetectionViewModel(
         }
     }
 
-    suspend fun moveSelectedToCategories(categoryIds: List<Long>) {
+    suspend fun moveSelectedToCategories(addCategories: List<Long>, removeCategories: List<Long>) {
         val selectedIds = state.value.selection.toList()
         withContext(Dispatchers.IO) {
-            mangaRepository.setMangasCategories(selectedIds, categoryIds)
+            if (addCategories.isNotEmpty()) setMangaCategories.add(selectedIds, addCategories, skipRefresh = true)
+            if (removeCategories.isNotEmpty()) {
+                setMangaCategories.remove(selectedIds, removeCategories, skipRefresh = true)
+            }
+            setMangaCategories.refreshLibrary()
             mutableState.update { it.copy(selection = emptySet()) }
             loadDuplicates()
         }

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1415,6 +1415,32 @@ class MangaRepositoryImpl(
         }
     }
 
+    override suspend fun getSelectionMetricsForIds(ids: List<Long>): List<MangaSelectionMetric> {
+        if (ids.isEmpty()) return emptyList()
+        val mapper = { id: Long, source: Long, title: String, totalCount: Long, readCount: Long ->
+            MangaSelectionMetric(
+                id = id,
+                groupKey = title.trim().lowercase().ifBlank { id.toString() },
+                source = source,
+                title = title,
+                chapterCount = totalCount.toInt(),
+                readCount = readCount.toInt(),
+            )
+        }
+        return ids.chunked(500).flatMap { chunk ->
+            database.mangasQueries.getSelectionMetricsForIds(chunk, mapper).awaitAsList()
+        }
+    }
+
+    override suspend fun getTotalCountsForIds(ids: List<Long>): List<Pair<Long, Long>> {
+        if (ids.isEmpty()) return emptyList()
+        return ids.chunked(500).flatMap { chunk ->
+            database.mangasQueries.getTotalCountsForIds(chunk) { id, totalCount ->
+                id to totalCount
+            }.awaitAsList()
+        }
+    }
+
     override suspend fun findDuplicatesByUrl(includeBlank: Boolean): List<DuplicateGroup> {
         return database.mangasQueries.findDuplicatesByUrl(includeBlank) { url, source, ids, count ->
             DuplicateGroup(

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -1306,8 +1306,8 @@ class MangaRepositoryImpl(
         }.awaitAsList()
     }
 
-    override suspend fun findDuplicatesExact(): List<DuplicateGroup> {
-        return database.mangasQueries.findDuplicatesExact { normalizedTitle, ids, count ->
+    override suspend fun findDuplicatesExact(includeBlank: Boolean): List<DuplicateGroup> {
+        return database.mangasQueries.findDuplicatesExact(includeBlank) { normalizedTitle, ids, count ->
             DuplicateGroup(
                 normalizedTitle = normalizedTitle ?: "",
                 ids =
@@ -1415,8 +1415,8 @@ class MangaRepositoryImpl(
         }
     }
 
-    override suspend fun findDuplicatesByUrl(): List<DuplicateGroup> {
-        return database.mangasQueries.findDuplicatesByUrl { url, source, ids, count ->
+    override suspend fun findDuplicatesByUrl(includeBlank: Boolean): List<DuplicateGroup> {
+        return database.mangasQueries.findDuplicatesByUrl(includeBlank) { url, source, ids, count ->
             DuplicateGroup(
                 normalizedTitle = url, // Using URL as the group key
                 ids = ids.split(",").mapNotNull { id -> id.toLongOrNull() },

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -311,7 +311,7 @@ SELECT
     CAST(group_concat(_id) AS TEXT) AS ids,
     count(*) AS duplicate_count
 FROM mangas
-WHERE favorite = 1
+WHERE favorite = 1 AND (:includeBlank OR trim(title) <> '')
 GROUP BY lower(trim(title))
 HAVING count(*) > 1
 ORDER BY duplicate_count DESC;
@@ -362,7 +362,7 @@ SELECT
     CAST(group_concat(_id) AS TEXT) AS ids,
     count(*) AS duplicate_count
 FROM mangas
-WHERE favorite = 1
+WHERE favorite = 1 AND (:includeBlank OR trim(url) <> '')
 GROUP BY url, source
 HAVING count(*) > 1
 ORDER BY duplicate_count DESC;

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -1092,6 +1092,21 @@ FROM mangas M
 JOIN mangas_categories MC ON MC.manga_id = M._id
 WHERE M.favorite = 1 AND MC.category_id IN :categoryIds;
 
+-- Targeted variant of getFavoriteSelectionMetrics scoped to a known id set (e.g. a truncated
+-- duplicate group's hidden tail), so hydrating a handful of ids doesn't require scanning every
+-- favorite in a huge library.
+getSelectionMetricsForIds:
+SELECT _id, source, title, total_count, read_count
+FROM mangas
+WHERE _id IN :ids;
+
+-- Cheap (_id, total_count) lookup scoped to a known id set, used to rank a duplicate group's
+-- members by chapter count before it gets truncated for display.
+getTotalCountsForIds:
+SELECT _id, total_count
+FROM mangas
+WHERE _id IN :ids;
+
 -- Ids of favorites matching the cheap/DB-expressible half of the Library screen's active filters
 -- (source exclusion, unread/started/completed/novel/chapter-count columns, and an included-tags
 -- SUPERSET prefilter using the same substring technique as libraryPageFiltered). Used to restrict a listing-mode

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
@@ -11,6 +11,22 @@ enum class DuplicateMatchMode {
     URL, // Same URL within the same extension/source
 }
 
+enum class BlankTitleFilter {
+    EXCLUDE, // Default; avoids one giant false-duplicate group of every blank title/URL
+    INCLUDE,
+    ONLY,
+}
+
+/**
+ * [displayGroups] is capped per-group to avoid materializing a pathologically large group (e.g.
+ * hundreds of thousands of blank titles) into full manga rows. [fullGroupIds] keeps every id in
+ * each surviving group, uncapped, for callers that don't need full manga rows (bulk select/delete/move).
+ */
+data class DuplicateScanResult(
+    val displayGroups: Map<String, List<MangaWithChapterCount>>,
+    val fullGroupIds: Map<String, List<Long>>,
+)
+
 /**
  * Interactor to find duplicate novels in the library.
  * Uses database queries for efficient duplicate detection without blocking UI thread.
@@ -22,8 +38,8 @@ class FindDuplicateNovels(
      * Find duplicate groups using exact matching (case-insensitive, trimmed).
      * Returns groups of manga IDs that share the same normalized title.
      */
-    suspend fun findExact(): List<DuplicateGroup> {
-        return mangaRepository.findDuplicatesExact()
+    suspend fun findExact(includeBlank: Boolean = false): List<DuplicateGroup> {
+        return mangaRepository.findDuplicatesExact(includeBlank)
     }
 
     /**
@@ -94,8 +110,8 @@ class FindDuplicateNovels(
      * Find duplicates by URL within the same extension.
      * Returns groups where multiple manga have the same URL from the same source.
      */
-    suspend fun findUrlDuplicates(): List<DuplicateGroup> {
-        return mangaRepository.findDuplicatesByUrl()
+    suspend fun findUrlDuplicates(includeBlank: Boolean = false): List<DuplicateGroup> {
+        return mangaRepository.findDuplicatesByUrl(includeBlank)
     }
 
     /**
@@ -157,67 +173,57 @@ class FindDuplicateNovels(
         return result
     }
 
-    /**
-     * Find duplicates and return full manga info with chapter counts.
-     * Groups results by normalized title.
-     */
-    suspend fun findDuplicatesGrouped(mode: DuplicateMatchMode): Map<String, List<MangaWithChapterCount>> {
-        return when (mode) {
-            DuplicateMatchMode.EXACT -> {
-                val groups = findExact()
-                val allIds = groups.flatMap { it.ids }
-                val mangaMap = getMangaWithCountsLight(allIds).associateBy { it.manga.id }
-
-                groups.mapNotNull { group ->
-                    val mangaList = group.ids.mapNotNull { mangaMap[it] }
-                    if (mangaList.size > 1) {
-                        group.normalizedTitle to mangaList.sortedByDescending { it.chapterCount }
-                    } else {
-                        null
-                    }
-                }.toMap()
-            }
-            DuplicateMatchMode.CONTAINS -> {
-                val pairs = findContains()
-                // Group pairs by the shorter title (the one that's contained)
-                val allIds = pairs.flatMap { listOf(it.idA, it.idB) }.distinct()
-                val mangaMap = getMangaWithCountsLight(allIds).associateBy { it.manga.id }
-
-                val groups = mutableMapOf<String, MutableSet<Long>>()
-                pairs.forEach { pair ->
-                    val keyA = pair.titleA.lowercase().trim()
-                    val keyB = pair.titleB.lowercase().trim()
-                    val key = if (keyA.length <= keyB.length) keyA else keyB
-
-                    groups.getOrPut(key) { mutableSetOf() }.apply {
-                        add(pair.idA)
-                        add(pair.idB)
-                    }
-                }
-
-                groups.mapNotNull { (title, ids) ->
-                    val mangaList = ids.mapNotNull { mangaMap[it] }
-                    if (mangaList.size > 1) {
-                        title to mangaList.sortedByDescending { it.chapterCount }
-                    } else {
-                        null
-                    }
-                }.toMap()
-            }
-            DuplicateMatchMode.URL -> {
-                val groups = findUrlDuplicates()
-                val allIds = groups.flatMap { it.ids }
-                val mangaMap = getMangaWithCountsLight(allIds).associateBy { it.manga.id }
-
-                groups.mapNotNull { group ->
-                    val mangaList = group.ids.mapNotNull { mangaMap[it] }
-                    if (mangaList.size > 1) {
-                        group.normalizedTitle to mangaList.sortedByDescending { it.chapterCount }
-                    } else {
-                        null
-                    }
-                }.toMap()
+    private fun groupContainsPairs(pairs: List<DuplicatePair>): Map<String, List<Long>> {
+        val groups = mutableMapOf<String, MutableSet<Long>>()
+        pairs.forEach { pair ->
+            val keyA = pair.titleA.lowercase().trim()
+            val keyB = pair.titleB.lowercase().trim()
+            // Group pairs by the shorter title (the one that's contained)
+            val key = if (keyA.length <= keyB.length) keyA else keyB
+            groups.getOrPut(key) { mutableSetOf() }.apply {
+                add(pair.idA)
+                add(pair.idB)
             }
         }
+        return groups.mapValues { it.value.toList() }
+    }
+
+    /**
+     * Find duplicates and return full manga info with chapter counts, grouped by key.
+     * See [DuplicateScanResult] for how a pathologically large group is handled.
+     */
+    suspend fun findDuplicatesGrouped(
+        mode: DuplicateMatchMode,
+        blankTitleFilter: BlankTitleFilter = BlankTitleFilter.EXCLUDE,
+    ): DuplicateScanResult {
+        val includeBlank = blankTitleFilter != BlankTitleFilter.EXCLUDE
+
+        var rawGroups = when (mode) {
+            DuplicateMatchMode.EXACT -> findExact(includeBlank).associate { it.normalizedTitle to it.ids }
+            DuplicateMatchMode.URL -> findUrlDuplicates(includeBlank).associate { it.normalizedTitle to it.ids }
+            DuplicateMatchMode.CONTAINS -> groupContainsPairs(findContains())
+        }.filterValues { it.size > 1 }
+
+        // CONTAINS never groups blanks (findContains already excludes them), so a leftover ONLY
+        // filter from a previous EXACT/URL session would otherwise silently zero out the results.
+        if (blankTitleFilter == BlankTitleFilter.ONLY && mode != DuplicateMatchMode.CONTAINS) {
+            rawGroups = rawGroups.filterKeys { it.isBlank() }
+        }
+
+        val cappedGroups = rawGroups.mapValues { (_, ids) -> ids.take(MAX_GROUP_MEMBERS) }
+        val mangaMap = getMangaWithCountsLight(cappedGroups.values.flatten()).associateBy { it.manga.id }
+
+        val displayGroups = cappedGroups.mapNotNull { (key, ids) ->
+            val mangaList = ids.mapNotNull { mangaMap[it] }
+            if (mangaList.size > 1) key to mangaList.sortedByDescending { it.chapterCount } else null
+        }.toMap()
+
+        val fullGroupIds = rawGroups.filterKeys { it in displayGroups }
+
+        return DuplicateScanResult(displayGroups, fullGroupIds)
+    }
+
+    companion object {
+        private const val MAX_GROUP_MEMBERS = 2000
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
@@ -90,7 +90,7 @@ class FindDuplicateNovels(
      * Returns novels in library that match or contain the title.
      */
     suspend fun findSimilarTo(mangaId: Long, title: String): List<MangaWithChapterCount> {
-        val exactMatches = mangaRepository.findDuplicatesExact()
+        val exactMatches = mangaRepository.findDuplicatesExact(includeBlank = true)
             .find { group -> group.ids.contains(mangaId) }
             ?.ids?.filter { it != mangaId }
             ?: emptyList()
@@ -173,6 +173,21 @@ class FindDuplicateNovels(
         return result
     }
 
+    /**
+     * Turns [DuplicateGroup]s into a key->ids map. URL-mode groups are keyed by URL alone (the
+     * SQL groups by url+source), so two different-source groups can share a normalizedTitle;
+     * disambiguate rather than letting `.associate` silently drop one group's ids.
+     */
+    private fun groupsToMap(groups: List<DuplicateGroup>): Map<String, List<Long>> {
+        val result = LinkedHashMap<String, List<Long>>()
+        groups.forEach { group ->
+            val baseKey = group.normalizedTitle
+            val key = if (result.containsKey(baseKey)) "$baseKey#${group.ids.first()}" else baseKey
+            result[key] = group.ids
+        }
+        return result
+    }
+
     private fun groupContainsPairs(pairs: List<DuplicatePair>): Map<String, List<Long>> {
         val groups = mutableMapOf<String, MutableSet<Long>>()
         pairs.forEach { pair ->
@@ -199,8 +214,8 @@ class FindDuplicateNovels(
         val includeBlank = blankTitleFilter != BlankTitleFilter.EXCLUDE
 
         var rawGroups = when (mode) {
-            DuplicateMatchMode.EXACT -> findExact(includeBlank).associate { it.normalizedTitle to it.ids }
-            DuplicateMatchMode.URL -> findUrlDuplicates(includeBlank).associate { it.normalizedTitle to it.ids }
+            DuplicateMatchMode.EXACT -> groupsToMap(findExact(includeBlank))
+            DuplicateMatchMode.URL -> groupsToMap(findUrlDuplicates(includeBlank))
             DuplicateMatchMode.CONTAINS -> groupContainsPairs(findContains())
         }.filterValues { it.size > 1 }
 
@@ -210,7 +225,17 @@ class FindDuplicateNovels(
             rawGroups = rawGroups.filterKeys { it.isBlank() }
         }
 
-        val cappedGroups = rawGroups.mapValues { (_, ids) -> ids.take(MAX_GROUP_MEMBERS) }
+        // Rank by chapter count BEFORE truncating so a group larger than MAX_GROUP_MEMBERS keeps
+        // its highest-chapter-count entries instead of an arbitrary DB-order slice; total_count is
+        // a cached column, so this is a cheap id-scoped lookup, not a full manga row fetch.
+        val cappedGroups = rawGroups.mapValues { (_, ids) ->
+            if (ids.size <= MAX_GROUP_MEMBERS) {
+                ids
+            } else {
+                val counts = mangaRepository.getTotalCountsForIds(ids).toMap()
+                ids.sortedByDescending { counts[it] ?: 0L }.take(MAX_GROUP_MEMBERS)
+            }
+        }
         val mangaMap = getMangaWithCountsLight(cappedGroups.values.flatten()).associateBy { it.manga.id }
 
         val displayGroups = cappedGroups.mapNotNull { (key, ids) ->

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FindDuplicateNovels.kt
@@ -178,6 +178,10 @@ class FindDuplicateNovels(
      * SQL groups by url+source), so two different-source groups can share a normalizedTitle;
      * disambiguate rather than letting `.associate` silently drop one group's ids.
      */
+    private fun List<DuplicateGroup>.filterOnlyBlank(onlyBlank: Boolean): List<DuplicateGroup> {
+        return if (onlyBlank) filter { it.normalizedTitle.isBlank() } else this
+    }
+
     private fun groupsToMap(groups: List<DuplicateGroup>): Map<String, List<Long>> {
         val result = LinkedHashMap<String, List<Long>>()
         groups.forEach { group ->
@@ -212,18 +216,13 @@ class FindDuplicateNovels(
         blankTitleFilter: BlankTitleFilter = BlankTitleFilter.EXCLUDE,
     ): DuplicateScanResult {
         val includeBlank = blankTitleFilter != BlankTitleFilter.EXCLUDE
+        val onlyBlank = blankTitleFilter == BlankTitleFilter.ONLY && mode != DuplicateMatchMode.CONTAINS
 
-        var rawGroups = when (mode) {
-            DuplicateMatchMode.EXACT -> groupsToMap(findExact(includeBlank))
-            DuplicateMatchMode.URL -> groupsToMap(findUrlDuplicates(includeBlank))
+        val rawGroups = when (mode) {
+            DuplicateMatchMode.EXACT -> groupsToMap(findExact(includeBlank).filterOnlyBlank(onlyBlank))
+            DuplicateMatchMode.URL -> groupsToMap(findUrlDuplicates(includeBlank).filterOnlyBlank(onlyBlank))
             DuplicateMatchMode.CONTAINS -> groupContainsPairs(findContains())
         }.filterValues { it.size > 1 }
-
-        // CONTAINS never groups blanks (findContains already excludes them), so a leftover ONLY
-        // filter from a previous EXACT/URL session would otherwise silently zero out the results.
-        if (blankTitleFilter == BlankTitleFilter.ONLY && mode != DuplicateMatchMode.CONTAINS) {
-            rawGroups = rawGroups.filterKeys { it.isBlank() }
-        }
 
         // Rank by chapter count BEFORE truncating so a group larger than MAX_GROUP_MEMBERS keeps
         // its highest-chapter-count entries instead of an arbitrary DB-order slice; total_count is

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -154,6 +154,12 @@ interface MangaRepository {
     /** Unbounded selection metrics for favorites, optionally restricted to [categoryIds]. */
     suspend fun getFavoriteSelectionMetrics(categoryIds: List<Long>): List<MangaSelectionMetric>
 
+    /** Targeted selection metrics for [ids], so hydrating a small known set never scans the full favorites table. */
+    suspend fun getSelectionMetricsForIds(ids: List<Long>): List<MangaSelectionMetric>
+
+    /** Targeted (id, total_count) lookup for [ids], used to rank a group's members before truncation. */
+    suspend fun getTotalCountsForIds(ids: List<Long>): List<Pair<Long, Long>>
+
     /**
      * Get all favorite manga ids in [categoryId] (0 = uncategorized). Id-only for bulk category actions.
      */

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -128,7 +128,7 @@ interface MangaRepository {
         limit: Long,
     ): List<MangaWithChapterCount>
 
-    suspend fun findDuplicatesExact(): List<DuplicateGroup>
+    suspend fun findDuplicatesExact(includeBlank: Boolean = false): List<DuplicateGroup>
 
     suspend fun findDuplicatesContains(): List<DuplicatePair>
 
@@ -175,7 +175,7 @@ interface MangaRepository {
      * Find duplicates by URL within the same source.
      * Returns groups where multiple manga have the same URL from the same source.
      */
-    suspend fun findDuplicatesByUrl(): List<DuplicateGroup>
+    suspend fun findDuplicatesByUrl(includeBlank: Boolean = false): List<DuplicateGroup>
 
     /**
      * Get lightweight favorite genres for tag counting.

--- a/domain/src/test/java/tachiyomi/domain/manga/interactor/FindDuplicateNovelsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/interactor/FindDuplicateNovelsTest.kt
@@ -65,6 +65,7 @@ class FindDuplicateNovelsTest {
         val hugeIds = (1L..5000L).toList()
         val hugeGroup = DuplicateGroup(normalizedTitle = "", ids = hugeIds, count = hugeIds.size)
         coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(hugeGroup)
+        coEvery { mangaRepository.getTotalCountsForIds(any()) } returns emptyList()
         coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
             val ids = firstArg<List<Long>>()
             ids.map { mangaWithCount(it, "") }
@@ -82,6 +83,7 @@ class FindDuplicateNovelsTest {
         val hugeIds = (1L..5000L).toList()
         val hugeGroup = DuplicateGroup(normalizedTitle = "", ids = hugeIds, count = hugeIds.size)
         coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(hugeGroup)
+        coEvery { mangaRepository.getTotalCountsForIds(any()) } returns emptyList()
         coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
             val ids = firstArg<List<Long>>()
             ids.map { mangaWithCount(it, "") }
@@ -92,4 +94,53 @@ class FindDuplicateNovelsTest {
         result.displayGroups[""]?.size shouldBe 2000
         result.fullGroupIds[""]?.size shouldBe 5000
     }
+
+    @Test
+    fun `truncation keeps the highest chapter-count members, not an arbitrary id-order slice`() =
+        kotlinx.coroutines.test.runTest {
+            val hugeIds = (1L..5000L).toList()
+            val hugeGroup = DuplicateGroup(normalizedTitle = "", ids = hugeIds, count = hugeIds.size)
+            coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(hugeGroup)
+            // The true best copy (id 4999) sits outside the first 2000 ids returned by the DB.
+            coEvery { mangaRepository.getTotalCountsForIds(any()) } returns
+                hugeIds.map { id -> id to if (id == 4999L) 999L else 1L }
+            coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
+                val ids = firstArg<List<Long>>()
+                ids.map { mangaWithCount(it, "") }
+            }
+
+            val result = findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT, BlankTitleFilter.INCLUDE)
+
+            result.displayGroups[""]?.map { it.manga.id } shouldBe listOf(4999L) +
+                (1L..1999L).toList()
+        }
+
+    @Test
+    fun `findSimilarTo includes blank titles even though findDuplicatesExact now defaults to excluding them`() =
+        kotlinx.coroutines.test.runTest {
+            val blankGroup = DuplicateGroup(normalizedTitle = "", ids = listOf(1L, 2L), count = 2)
+            coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(blankGroup)
+            coEvery { mangaRepository.findDuplicatesContains() } returns emptyList()
+            coEvery { mangaRepository.getMangaWithCounts(listOf(2L)) } returns listOf(mangaWithCount(2L, ""))
+
+            findDuplicateNovels.findSimilarTo(1L, "")
+
+            coVerify(exactly = 1) { mangaRepository.findDuplicatesExact(includeBlank = true) }
+        }
+
+    @Test
+    fun `URL groups sharing the same url key across sources are not collapsed into one`() =
+        kotlinx.coroutines.test.runTest {
+            val groupA = DuplicateGroup(normalizedTitle = "", ids = listOf(1L, 2L), count = 2)
+            val groupB = DuplicateGroup(normalizedTitle = "", ids = listOf(3L, 4L), count = 2)
+            coEvery { mangaRepository.findDuplicatesByUrl(includeBlank = true) } returns listOf(groupA, groupB)
+            coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
+                val ids = firstArg<List<Long>>()
+                ids.map { mangaWithCount(it, "") }
+            }
+
+            val result = findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.URL, BlankTitleFilter.INCLUDE)
+
+            result.fullGroupIds.values.flatten().toSet() shouldBe setOf(1L, 2L, 3L, 4L)
+        }
 }

--- a/domain/src/test/java/tachiyomi/domain/manga/interactor/FindDuplicateNovelsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/interactor/FindDuplicateNovelsTest.kt
@@ -1,0 +1,95 @@
+package tachiyomi.domain.manga.interactor
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaWithChapterCount
+import tachiyomi.domain.manga.repository.DuplicateGroup
+import tachiyomi.domain.manga.repository.MangaRepository
+
+@Execution(ExecutionMode.CONCURRENT)
+class FindDuplicateNovelsTest {
+
+    private val mangaRepository = mockk<MangaRepository>()
+    private val findDuplicateNovels = FindDuplicateNovels(mangaRepository)
+
+    private fun mangaWithCount(id: Long, title: String) = MangaWithChapterCount(
+        manga = Manga.create().copy(id = id, title = title),
+        chapterCount = 0,
+    )
+
+    @Test
+    fun `default blank filter excludes blank titles at the query level`() = kotlinx.coroutines.test.runTest {
+        coEvery { mangaRepository.findDuplicatesExact(includeBlank = false) } returns emptyList()
+        coEvery { mangaRepository.getMangaWithCountsLightWithGenre(emptyList()) } returns emptyList()
+
+        findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT)
+
+        coVerify(exactly = 1) { mangaRepository.findDuplicatesExact(includeBlank = false) }
+    }
+
+    @Test
+    fun `include filter passes includeBlank through to the query`() = kotlinx.coroutines.test.runTest {
+        coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns emptyList()
+        coEvery { mangaRepository.getMangaWithCountsLightWithGenre(emptyList()) } returns emptyList()
+
+        findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT, BlankTitleFilter.INCLUDE)
+
+        coVerify(exactly = 1) { mangaRepository.findDuplicatesExact(includeBlank = true) }
+    }
+
+    @Test
+    fun `only filter keeps just the blank-key group`() = kotlinx.coroutines.test.runTest {
+        val blankGroup = DuplicateGroup(normalizedTitle = "", ids = listOf(1L, 2L), count = 2)
+        val namedGroup = DuplicateGroup(normalizedTitle = "one piece", ids = listOf(3L, 4L), count = 2)
+        coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(blankGroup, namedGroup)
+        coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } returns listOf(
+            mangaWithCount(1L, ""),
+            mangaWithCount(2L, ""),
+            mangaWithCount(3L, "One Piece"),
+            mangaWithCount(4L, "One Piece"),
+        )
+
+        val result = findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT, BlankTitleFilter.ONLY)
+
+        result.displayGroups.keys shouldBe setOf("")
+    }
+
+    @Test
+    fun `a group larger than the cap is truncated before manga rows are materialized`() = kotlinx.coroutines.test.runTest {
+        val hugeIds = (1L..5000L).toList()
+        val hugeGroup = DuplicateGroup(normalizedTitle = "", ids = hugeIds, count = hugeIds.size)
+        coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(hugeGroup)
+        coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
+            val ids = firstArg<List<Long>>()
+            ids.map { mangaWithCount(it, "") }
+        }
+
+        findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT, BlankTitleFilter.INCLUDE)
+
+        coVerify(exactly = 1) {
+            mangaRepository.getMangaWithCountsLightWithGenre(withArg { it.size shouldBe 2000 })
+        }
+    }
+
+    @Test
+    fun `fullGroupIds keeps every member even though display is capped`() = kotlinx.coroutines.test.runTest {
+        val hugeIds = (1L..5000L).toList()
+        val hugeGroup = DuplicateGroup(normalizedTitle = "", ids = hugeIds, count = hugeIds.size)
+        coEvery { mangaRepository.findDuplicatesExact(includeBlank = true) } returns listOf(hugeGroup)
+        coEvery { mangaRepository.getMangaWithCountsLightWithGenre(any()) } answers {
+            val ids = firstArg<List<Long>>()
+            ids.map { mangaWithCount(it, "") }
+        }
+
+        val result = findDuplicateNovels.findDuplicatesGrouped(DuplicateMatchMode.EXACT, BlankTitleFilter.INCLUDE)
+
+        result.displayGroups[""]?.size shouldBe 2000
+        result.fullGroupIds[""]?.size shouldBe 5000
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -933,6 +933,12 @@
     <string name="action_clear_category">Clear category…</string>
     <string name="duplicate_listing_mode">List all</string>
     <string name="duplicate_listing_truncated">Showing 2000 of %1$d matching entries. Narrow with category filters, or use Select All to act on all %1$d.</string>
+    <string name="duplicate_blank_label">Blank titles/URLs:</string>
+    <string name="duplicate_blank_exclude">Exclude</string>
+    <string name="duplicate_blank_include">Include</string>
+    <string name="duplicate_blank_only">Only</string>
+    <string name="duplicate_group_truncated_selectable">Showing %1$d of %2$d..</string>
+    <string name="duplicate_group_truncated_filtered">Showing %1$d of %2$d.</string>
     <string name="duplicate_filters_sort">Filters &amp; Sort</string>
     <string name="duplicate_type_label">Type:</string>
     <string name="duplicate_type_all">All</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -937,7 +937,7 @@
     <string name="duplicate_blank_exclude">Exclude</string>
     <string name="duplicate_blank_include">Include</string>
     <string name="duplicate_blank_only">Only</string>
-    <string name="duplicate_group_truncated_selectable">Showing %1$d of %2$d..</string>
+    <string name="duplicate_group_truncated_selectable">Showing %1$d of %2$d.</string>
     <string name="duplicate_group_truncated_filtered">Showing %1$d of %2$d.</string>
     <string name="duplicate_filters_sort">Filters &amp; Sort</string>
     <string name="duplicate_type_label">Type:</string>


### PR DESCRIPTION
- Add EXCLUDE/INCLUDE/ONLY filter for blank titles/URLs in duplicate scans, cap materialized group size to avoid OOM 
- Swap the move-to-category dialog for the shared tri-state ChangeCategoryDialog so mixed category selections across the current selection are handled correctly.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
