### PR TITLE
Fix novel theme preference showing null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Library sort by last read now updates after reading [@mrissaoussama](https://github.com/mrissaoussama) [#400](https://github.com/tsundoku-otaku/tsundoku/pull/400)
 - Double-tapping browse now does novel search if manga UI hidden [@mrissaoussama](https://github.com/mrissaoussama) [#401](https://github.com/tsundoku-otaku/tsundoku/pull/401)
 - Clarified UI text on text-selectable option [@mrissaoussama](https://github.com/mrissaoussama) [#403](https://github.com/tsundoku-otaku/tsundoku/pull/403)
+-Fix novel theme preference showing null [@mrissaoussama](https://github.com/mrissaoussama) [#404](https://github.com/tsundoku-otaku/tsundoku/pull/404)
 
 ## [v0.3.2] - 2026-08-21
 ### Improved

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -139,11 +139,13 @@ object SettingsNovelReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.ListPreference(
                     preference = readerPreferences.novelTheme,
                     entries = mapOf(
+                        "app" to "App",
                         "light" to "Light",
                         "dark" to "Dark",
                         "sepia" to "Sepia",
                         "black" to "Black",
                         "grey" to "Grey",
+                        "custom" to "Custom",
                     ).toMap(),
                     title = stringResource(TDMR.strings.pref_novel_theme),
                 ),


### PR DESCRIPTION
The theme ListPreference entries map was missing "app" (the default value) and "custom", so the current selection had no matching label and rendered as null.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
