### PR TITLE
Fix JS result unescaping misreading obfuscated backslashes as escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix novel theme preference showing null [@mrissaoussama](https://github.com/mrissaoussama) [#404](https://github.com/tsundoku-otaku/tsundoku/pull/404)
 - Fix TTS highlight outline getting clipped in WebView reader [@mrissaoussama](https://github.com/mrissaoussama) [#406](https://github.com/tsundoku-otaku/tsundoku/pull/406)
 - Globally throttle notification updates for massimport across batches [@mrissaoussama](https://github.com/mrissaoussama) [#407](https://github.com/tsundoku-otaku/tsundoku/pull/407)
+- Fix JS result unescaping misreading obfuscated backslashes as escapes [@mrissaoussama](https://github.com/mrissaoussama) [#405](https://github.com/tsundoku-otaku/tsundoku/pull/405)
 
 ## [v0.3.2] - 2026-08-21
 ### Improved

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -84,6 +84,52 @@ internal object NovelWebViewChapterMeta {
         return sb.toString()
     }
 
+    /**
+     * Inverse of [quoteForJson]: decodes a JSON string literal (as handed back by
+     * `evaluateJavascript`, quotes included) into the raw text.
+     *
+     * Walks the string once, consuming each backslash escape together with the character
+     * after it. Sequential global replaces (e.g. `.replace("\\n", "\n")` after `.replace("\\\\",
+     * "\\")`) can't tell a real `\n` escape apart from an escaped literal backslash followed by
+     * the letter n - both collapse to the same two characters after the backslash-unescape pass,
+     * so a page using "\" as text obfuscation would have it misread as a newline.
+     */
+    fun unescapeJsResult(result: String): String {
+        if (!(result.startsWith("\"") && result.endsWith("\""))) return result
+        val inner = result.substring(1, result.length - 1)
+        val sb = StringBuilder(inner.length)
+        var i = 0
+        while (i < inner.length) {
+            val c = inner[i]
+            if (c == '\\' && i + 1 < inner.length) {
+                when (inner[i + 1]) {
+                    '\\' -> { sb.append('\\'); i += 2 }
+                    'n' -> { sb.append('\n'); i += 2 }
+                    't' -> { sb.append('\t'); i += 2 }
+                    'r' -> { sb.append('\r'); i += 2 }
+                    '"' -> { sb.append('"'); i += 2 }
+                    '/' -> { sb.append('/'); i += 2 }
+                    'u' -> {
+                        val hex = inner.substring(i + 2, minOf(i + 6, inner.length))
+                        val code = hex.takeIf { it.length == 4 }?.toIntOrNull(16)
+                        if (code != null) {
+                            sb.append(code.toChar())
+                            i += 6
+                        } else {
+                            sb.append(c)
+                            i += 1
+                        }
+                    }
+                    else -> { sb.append(c); i += 1 }
+                }
+            } else {
+                sb.append(c)
+                i += 1
+            }
+        }
+        return sb.toString()
+    }
+
     fun toAbsoluteChapterUrl(chapterPath: String?, novelUrl: String?): String {
         val normalized = HtmlUtils.normalizeUrl(chapterPath).orEmpty().trim()
         if (normalized.isBlank()) return ""

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -109,6 +109,8 @@ internal object NovelWebViewChapterMeta {
                     'r' -> { sb.append('\r'); i += 2 }
                     '"' -> { sb.append('"'); i += 2 }
                     '/' -> { sb.append('/'); i += 2 }
+                    'b' -> { sb.append('\b'); i += 2 }
+                    'f' -> { sb.append('\u000C'); i += 2 }
                     'u' -> {
                         val hex = inner.substring(i + 2, minOf(i + 6, inner.length))
                         val code = hex.takeIf { it.length == 4 }?.toIntOrNull(16)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -63,6 +63,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_CHAPTER_ATTR
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_OBJECT_NAME
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.quoteForJson
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.unescapeJsResult
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -115,18 +116,6 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 }).join('\n');
             })();
         """
-
-        fun unescapeJsResult(result: String): String =
-            if (result.startsWith("\"") && result.endsWith("\"")) {
-                // \\ must come first so \\n stays as backslash+n rather than becoming a newline.
-                result.substring(1, result.length - 1)
-                    .replace("\\\\", "\\")
-                    .replace("\\n", "\n")
-                    .replace("\\t", "\t")
-                    .replace("\\\"", "\"")
-            } else {
-                result
-            }
     }
 
     private val container = FrameLayout(activity)

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaUnescapeTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaUnescapeTest.kt
@@ -1,0 +1,50 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
+
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.unescapeJsResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [NovelWebViewChapterMeta.unescapeJsResult], the JSON-string decoder applied to
+ * `evaluateJavascript` results (e.g. TTS text extraction).
+ */
+class NovelWebViewChapterMetaUnescapeTest {
+
+    @Test
+    fun `decodes standard escapes`() {
+        val input = "\"line one\\nline two\\ttabbed\\\"quoted\\\"\""
+        val expected = "line one\nline two\ttabbed\"quoted\""
+        assertEquals(expected, unescapeJsResult(input))
+    }
+
+    @Test
+    fun `literal backslash followed by n is not turned into a newline`() {
+        // JS string containing a literal backslash then the letter n (page obfuscation,
+        // e.g. "light\novel") is JSON-encoded as \\n (backslash, backslash, n).
+        val input = "\"light\\\\novel\""
+        assertEquals("light\\novel", unescapeJsResult(input))
+    }
+
+    @Test
+    fun `literal backslash followed by other letters stays intact`() {
+        val input = "\"c\\\\o/m\\\\world\""
+        assertEquals("c\\o/m\\world", unescapeJsResult(input))
+    }
+
+    @Test
+    fun `mixed literal backslash and real newline decode independently`() {
+        // paragraph separator (real \n) next to obfuscation backslash+n in the same string.
+        val input = "\"para one\\nlight\\\\novel\""
+        assertEquals("para one\nlight\\novel", unescapeJsResult(input))
+    }
+
+    @Test
+    fun `non quoted result is returned unchanged`() {
+        assertEquals("null", unescapeJsResult("null"))
+    }
+
+    @Test
+    fun `unicode escape decodes to character`() {
+        assertEquals("café", unescapeJsResult("\"caf\\u00e9\""))
+    }
+}


### PR DESCRIPTION
a VERY rare case of text having the characters "\n" caused tts to think the paragraph ended
