### PR TITLE
Fix LLM translation prompt customization and extend to all engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Improved
 - Add option to clear only error-free completed massimport batches [@mrissaoussama](https://github.com/mrissaoussama) [#402](https://github.com/tsundoku-otaku/tsundoku/pull/402)
+- Add multiline LLM prompt editor, and reset option to all LLM options [@mrissaoussama](https://github.com/mrissaoussama) [#411](https://github.com/tsundoku-otaku/tsundoku/pull/411)
 
 
 ### Fixed

--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -146,6 +146,21 @@ sealed class Preference {
         }
 
         /**
+         * A [PreferenceItem] for editing a multi-line LLM prompt template, prefilled with
+         * [defaultValue] when unset, and resettable back to it.
+         */
+        data class PromptPreference(
+            val preference: PreferenceData<String>,
+            override val title: String,
+            val defaultValue: String,
+            override val subtitle: String? = null,
+            override val enabled: Boolean = true,
+            override val onValueChanged: suspend (value: String) -> Boolean = { true },
+        ) : PreferenceItem<String, Boolean>() {
+            override val icon: ImageVector? = null
+        }
+
+        /**
          * A [PreferenceItem] for individual tracker.
          */
         data class TrackerPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -22,6 +22,7 @@ import eu.kanade.presentation.more.settings.widget.ListPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.MultiSelectListPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.PrefsHorizontalPadding
 import eu.kanade.presentation.more.settings.widget.PrefsVerticalPadding
+import eu.kanade.presentation.more.settings.widget.PromptPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.SwitchPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.TitleFontSize
@@ -166,6 +167,21 @@ internal fun PreferenceItem(
                         if (accepted) item.preference.set(it)
                         accepted
                     },
+                )
+            }
+            is Preference.PreferenceItem.PromptPreference -> {
+                val value by item.preference.collectAsState()
+                PromptPreferenceWidget(
+                    title = item.title,
+                    subtitle = item.subtitle,
+                    value = value,
+                    defaultValue = item.defaultValue,
+                    onConfirm = {
+                        val accepted = item.onValueChanged(it)
+                        if (accepted) item.preference.set(it)
+                        accepted
+                    },
+                    onReset = { item.preference.delete() },
                 )
             }
             is Preference.PreferenceItem.TrackerPreference -> {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SearchableSettings.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SearchableSettings.kt
@@ -121,6 +121,7 @@ interface SearchableSettings : Screen {
                 is Preference.PreferenceItem.ListPreference<*> -> item.preference.delete()
                 is Preference.PreferenceItem.MultiSelectListPreference<*> -> item.preference.delete()
                 is Preference.PreferenceItem.EditTextPreference -> item.preference.delete()
+                is Preference.PreferenceItem.PromptPreference -> item.preference.delete()
                 is Preference.PreferenceItem.SliderPreference -> item.preference?.delete()
                 is Preference.PreferenceItem.TextPreference -> {}
                 is Preference.PreferenceItem.TrackerPreference -> {}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.data.translation.TranslationEngineManager
 import kotlinx.coroutines.launch
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.novel.TDMR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -340,15 +341,17 @@ object SettingsTranslationScreen : SearchableSettings {
                         title = stringResource(TDMR.strings.pref_translation_openai_key),
                         subtitle = if (openAiKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
                     ),
-                    Preference.PreferenceItem.EditTextPreference(
+                    Preference.PreferenceItem.PromptPreference(
                         preference = prefs.openAiSystemPrompt(),
                         title = stringResource(MR.strings.pref_translation_system_prompt),
                         subtitle = stringResource(MR.strings.pref_translation_system_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT,
                     ),
-                    Preference.PreferenceItem.EditTextPreference(
+                    Preference.PreferenceItem.PromptPreference(
                         preference = prefs.openAiUserPrompt(),
                         title = stringResource(MR.strings.pref_translation_user_prompt),
                         subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_USER_PROMPT,
                     ),
                     testButton(engineManager.engines.first { it.name.contains("OpenAI") }),
                 ),
@@ -384,6 +387,18 @@ object SettingsTranslationScreen : SearchableSettings {
                         title = stringResource(TDMR.strings.pref_translation_ollama_model),
                         subtitle = nvidiaNimModel.ifBlank { stringResource(TDMR.strings.not_set) },
                     ),
+                    Preference.PreferenceItem.PromptPreference(
+                        preference = prefs.nvidiaNimSystemPrompt(),
+                        title = stringResource(MR.strings.pref_translation_system_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_system_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT,
+                    ),
+                    Preference.PreferenceItem.PromptPreference(
+                        preference = prefs.nvidiaNimUserPrompt(),
+                        title = stringResource(MR.strings.pref_translation_user_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_USER_PROMPT,
+                    ),
                     testButton(engineManager.getEngineById(TranslationEngineManager.ENGINE_NVIDIA_NIM)!!),
                 ),
             ),
@@ -395,6 +410,18 @@ object SettingsTranslationScreen : SearchableSettings {
                         preference = prefs.deepSeekApiKey(),
                         title = stringResource(TDMR.strings.pref_translation_deepseek_key),
                         subtitle = if (deepSeekKey.isNotBlank()) "••••••••" else stringResource(TDMR.strings.not_set),
+                    ),
+                    Preference.PreferenceItem.PromptPreference(
+                        preference = prefs.deepSeekSystemPrompt(),
+                        title = stringResource(MR.strings.pref_translation_system_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_system_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT,
+                    ),
+                    Preference.PreferenceItem.PromptPreference(
+                        preference = prefs.deepSeekUserPrompt(),
+                        title = stringResource(MR.strings.pref_translation_user_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_USER_PROMPT,
                     ),
                     testButton(engineManager.engines.first { it.name.contains("DeepSeek") }),
                 ),
@@ -456,6 +483,12 @@ object SettingsTranslationScreen : SearchableSettings {
                         title = stringResource(TDMR.strings.pref_translation_ollama_model),
                         subtitle = geminiModel.ifBlank { "gemini-2.0-flash" },
                     ),
+                    Preference.PreferenceItem.PromptPreference(
+                        preference = prefs.geminiPrompt(),
+                        title = stringResource(MR.strings.pref_translation_custom_prompt),
+                        subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT,
+                    ),
                     testButton(engineManager.engines.first { it.name.contains("Gemini") }),
                 ),
             ),
@@ -496,10 +529,11 @@ object SettingsTranslationScreen : SearchableSettings {
                         title = stringResource(TDMR.strings.pref_translation_ollama_model),
                         subtitle = ollamaModel,
                     ),
-                    Preference.PreferenceItem.EditTextPreference(
+                    Preference.PreferenceItem.PromptPreference(
                         preference = prefs.ollamaPrompt(),
                         title = stringResource(MR.strings.pref_translation_custom_prompt),
                         subtitle = stringResource(MR.strings.pref_translation_user_prompt_desc),
+                        defaultValue = TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT,
                     ),
                     testButton(engineManager.engines.first { it.name.contains("Ollama") }),
                 ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/PromptPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/PromptPreferenceWidget.kt
@@ -1,0 +1,127 @@
+package eu.kanade.presentation.more.settings.widget
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+/**
+ * Preference widget for editing a multi-line LLM prompt template.
+ * Prefilled with [defaultValue] when [value] is blank, and resettable back to it.
+ */
+@Composable
+fun PromptPreferenceWidget(
+    title: String,
+    subtitle: String?,
+    value: String,
+    defaultValue: String,
+    onConfirm: suspend (String) -> Boolean,
+    onReset: () -> Unit,
+) {
+    var isDialogShown by remember { mutableStateOf(false) }
+
+    TextPreferenceWidget(
+        title = title,
+        subtitle = subtitle,
+        icon = null,
+        onPreferenceClick = { isDialogShown = true },
+    )
+
+    if (isDialogShown) {
+        val scope = rememberCoroutineScope()
+        val initialValue = value.ifBlank { defaultValue }
+        val onDismissRequest = { isDialogShown = false }
+        var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+            mutableStateOf(TextFieldValue(initialValue))
+        }
+        var isResetConfirmShown by rememberSaveable { mutableStateOf(false) }
+
+        AlertDialog(
+            onDismissRequest = onDismissRequest,
+            title = { Text(text = title) },
+            text = {
+                OutlinedTextField(
+                    value = textFieldValue,
+                    onValueChange = { textFieldValue = it },
+                    trailingIcon = {
+                        if (textFieldValue.text.isBlank()) {
+                            Icon(imageVector = Icons.Filled.Error, contentDescription = null)
+                        }
+                    },
+                    isError = textFieldValue.text.isBlank(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 160.dp),
+                )
+            },
+            properties = DialogProperties(usePlatformDefaultWidth = true),
+            confirmButton = {
+                TextButton(
+                    enabled = textFieldValue.text != initialValue && textFieldValue.text.isNotBlank(),
+                    onClick = {
+                        scope.launch {
+                            if (onConfirm(textFieldValue.text)) {
+                                onDismissRequest()
+                            }
+                        }
+                    },
+                ) {
+                    Text(text = stringResource(MR.strings.action_ok))
+                }
+            },
+            dismissButton = {
+                if (value.isNotBlank()) {
+                    TextButton(onClick = { isResetConfirmShown = true }) {
+                        Text(text = stringResource(MR.strings.action_reset))
+                    }
+                }
+                TextButton(onClick = onDismissRequest) {
+                    Text(text = stringResource(MR.strings.action_cancel))
+                }
+            },
+        )
+
+        if (isResetConfirmShown) {
+            AlertDialog(
+                onDismissRequest = { isResetConfirmShown = false },
+                title = { Text(text = stringResource(MR.strings.action_reset)) },
+                text = { Text(text = stringResource(MR.strings.pref_translation_reset_prompt_confirm)) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            onReset()
+                            isResetConfirmShown = false
+                            onDismissRequest()
+                        },
+                    ) {
+                        Text(text = stringResource(MR.strings.action_reset))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { isResetConfirmShown = false }) {
+                        Text(text = stringResource(MR.strings.action_cancel))
+                    }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/DeepSeekTranslateEngine.kt
@@ -15,6 +15,7 @@ import tachiyomi.domain.translation.model.LanguageCodes
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -116,26 +117,24 @@ class DeepSeekTranslateEngine(
     ): String {
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+        val sourceLangDisplay = TranslationPromptDefaults.sourceLangDisplay(sourceLanguage, sourceLangName)
 
-        val fromClause = if (sourceLanguage == "auto") {
-            "Detect the source language and translate the following text to $targetLangName."
-        } else {
-            "Translate the following text from $sourceLangName to $targetLangName."
-        }
-
-        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
-Rules:
-- Only output the translation, nothing else
-- Preserve paragraph structure (keep empty lines between paragraphs)
-- Maintain the author's writing style and tone
-- Keep character names consistent
-- Do not add explanations or notes
-- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
+        val systemPrompt = TranslationPromptDefaults.apply(
+            preferences.deepSeekSystemPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+        )
+        val userPrompt = TranslationPromptDefaults.apply(
+            preferences.deepSeekUserPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_USER_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+            text,
+        )
 
         val request = ChatRequest(
             messages = listOf(
                 Message(role = "system", content = systemPrompt),
-                Message(role = "user", content = text),
+                Message(role = "user", content = userPrompt),
             ),
         )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/GeminiTranslateEngine.kt
@@ -16,6 +16,7 @@ import tachiyomi.domain.translation.model.LanguageCodes
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -102,34 +103,11 @@ class GeminiTranslateEngine(
     ): String {
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+        val sourceLangDisplay = TranslationPromptDefaults.sourceLangDisplay(sourceLanguage, sourceLangName)
 
-        val fromClause = if (sourceLanguage == "auto") {
-            "Detect the source language and translate the following text to $targetLangName."
-        } else {
-            "Translate the following text from $sourceLangName to $targetLangName."
-        }
-
-        val prompt = """
-    You are a professional translator specializing in novel/fiction translation.
-
-    $fromClause
-
-    Rules:
-    - Only output the translation, nothing else
-    - Preserve paragraph structure
-    - Do NOT summarize.
-    - Do NOT merge or split paragraphs.
-    - Do NOT normalize whitespace.
-    - Maintain style and tone
-    - Keep character names consistent
-    - Every line break in the input MUST be preserved exactly in the output.
-    - Do NOT wrap lines.
-    - Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them.
-    Text:
-    $text
-
-    Translation:
-        """.trimIndent()
+        val template = preferences.geminiPrompt().get()
+            .ifBlank { TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT }
+        val prompt = TranslationPromptDefaults.apply(template, sourceLangDisplay, targetLangName, text)
 
         val request = GenerateRequest(
             contents = listOf(Content(parts = listOf(Part(prompt)))),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/NvidiaNimTranslateEngine.kt
@@ -15,6 +15,7 @@ import tachiyomi.domain.translation.model.LanguageCodes
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -126,27 +127,25 @@ class NvidiaNimTranslateEngine(
     ): String {
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+        val sourceLangDisplay = TranslationPromptDefaults.sourceLangDisplay(sourceLanguage, sourceLangName)
 
-        val fromClause = if (sourceLanguage == "auto") {
-            "Detect the source language and translate the following text to $targetLangName."
-        } else {
-            "Translate the following text from $sourceLangName to $targetLangName."
-        }
-
-        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
-Rules:
-- Only output the translation, nothing else
-- Preserve paragraph structure
-- Maintain the author's writing style and tone
-- Keep character names consistent
-- Do not add explanations or notes
-- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
+        val systemPrompt = TranslationPromptDefaults.apply(
+            preferences.nvidiaNimSystemPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+        )
+        val userPrompt = TranslationPromptDefaults.apply(
+            preferences.nvidiaNimUserPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_USER_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+            text,
+        )
 
         val request = ChatRequest(
             model = model,
             messages = listOf(
                 Message(role = "system", content = systemPrompt),
-                Message(role = "user", content = text),
+                Message(role = "user", content = userPrompt),
             ),
         )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OllamaTranslateEngine.kt
@@ -12,6 +12,7 @@ import tachiyomi.domain.translation.model.LanguageCodes
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.TimeUnit
@@ -115,36 +116,11 @@ class OllamaTranslateEngine(
     ): String {
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+        val sourceLangDisplay = TranslationPromptDefaults.sourceLangDisplay(sourceLanguage, sourceLangName)
 
-        val fromClause = if (sourceLanguage == "auto") {
-            "Detect the source language and translate the following text to $targetLangName."
-        } else {
-            "Translate the following text from $sourceLangName to $targetLangName."
-        }
-
-        // Use custom prompt if configured
-        val customPrompt = preferences.ollamaPrompt().get()
-        val prompt = if (customPrompt.isNotBlank()) {
-            customPrompt
-                .replace("{SOURCE_LANG}", sourceLangName)
-                .replace("{TARGET_LANG}", targetLangName)
-                .replace("{TEXT}", text)
-        } else {
-            """You are a professional translator specializing in novel/fiction translation.
-$fromClause
-Rules:
-- Only output the translation, nothing else
-- Preserve paragraph structure (keep empty lines between paragraphs)
-- Maintain the author's writing style and tone
-- Keep character names consistent
-- Do not add explanations or notes
-- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them
-
-Text to translate:
-$text
-
-Translation:"""
-        }
+        val template = preferences.ollamaPrompt().get()
+            .ifBlank { TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT }
+        val prompt = TranslationPromptDefaults.apply(template, sourceLangDisplay, targetLangName, text)
 
         val request = GenerateRequest(
             model = model,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/engine/OpenAITranslateEngine.kt
@@ -15,6 +15,7 @@ import tachiyomi.domain.translation.model.LanguageCodes
 import tachiyomi.domain.translation.model.TranslationEngine
 import tachiyomi.domain.translation.model.TranslationResult
 import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.domain.translation.service.TranslationPromptDefaults
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -116,26 +117,24 @@ class OpenAITranslateEngine(
     ): String {
         val sourceLangName = LanguageCodes.getDisplayName(sourceLanguage)
         val targetLangName = LanguageCodes.getDisplayName(targetLanguage)
+        val sourceLangDisplay = TranslationPromptDefaults.sourceLangDisplay(sourceLanguage, sourceLangName)
 
-        val fromClause = if (sourceLanguage == "auto") {
-            "Detect the source language and translate the following text to $targetLangName."
-        } else {
-            "Translate the following text from $sourceLangName to $targetLangName."
-        }
-
-        val systemPrompt = """You are a professional translator specializing in novel/fiction translation. $fromClause
-Rules:
-- Only output the translation, nothing else
-- Preserve paragraph structure (keep empty lines between paragraphs)
-- Maintain the author's writing style and tone
-- Keep character names consistent
-- Do not add explanations or notes
-- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
+        val systemPrompt = TranslationPromptDefaults.apply(
+            preferences.openAiSystemPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+        )
+        val userPrompt = TranslationPromptDefaults.apply(
+            preferences.openAiUserPrompt().get().ifBlank { TranslationPromptDefaults.DEFAULT_USER_PROMPT },
+            sourceLangDisplay,
+            targetLangName,
+            text,
+        )
 
         val request = ChatRequest(
             messages = listOf(
                 Message(role = "system", content = systemPrompt),
-                Message(role = "user", content = text),
+                Message(role = "user", content = userPrompt),
             ),
         )
 

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -132,10 +132,46 @@ class TranslationPreferences(
     )
 
     /**
+     * Custom system prompt for NVIDIA NIM models. Blank means use [TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT].
+     * Supports {SOURCE_LANG} and {TARGET_LANG} placeholders.
+     */
+    fun nvidiaNimSystemPrompt() = preferenceStore.getString(
+        "translation_nvidia_nim_system_prompt",
+        "",
+    )
+
+    /**
+     * Custom user prompt template for NVIDIA NIM models. Blank means use [TranslationPromptDefaults.DEFAULT_USER_PROMPT].
+     * Supports {SOURCE_LANG}, {TARGET_LANG}, and {TEXT} placeholders.
+     */
+    fun nvidiaNimUserPrompt() = preferenceStore.getString(
+        "translation_nvidia_nim_user_prompt",
+        "",
+    )
+
+    /**
      * DeepSeek API key.
      */
     fun deepSeekApiKey() = preferenceStore.getString(
         "translation_deepseek_api_key",
+        "",
+    )
+
+    /**
+     * Custom system prompt for DeepSeek models. Blank means use [TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT].
+     * Supports {SOURCE_LANG} and {TARGET_LANG} placeholders.
+     */
+    fun deepSeekSystemPrompt() = preferenceStore.getString(
+        "translation_deepseek_system_prompt",
+        "",
+    )
+
+    /**
+     * Custom user prompt template for DeepSeek models. Blank means use [TranslationPromptDefaults.DEFAULT_USER_PROMPT].
+     * Supports {SOURCE_LANG}, {TARGET_LANG}, and {TEXT} placeholders.
+     */
+    fun deepSeekUserPrompt() = preferenceStore.getString(
+        "translation_deepseek_user_prompt",
         "",
     )
 
@@ -196,7 +232,7 @@ class TranslationPreferences(
     )
 
     /**
-     * Custom prompt template for Ollama.
+     * Custom prompt template for Ollama. Blank means use [TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT].
      * Supports {SOURCE_LANG}, {TARGET_LANG}, and {TEXT} placeholders.
      */
     fun ollamaPrompt() = preferenceStore.getString(
@@ -205,7 +241,8 @@ class TranslationPreferences(
     )
 
     /**
-     * Custom system prompt for OpenAI/GPT models.
+     * Custom system prompt for OpenAI/GPT models. Blank means use [TranslationPromptDefaults.DEFAULT_SYSTEM_PROMPT].
+     * Supports {SOURCE_LANG} and {TARGET_LANG} placeholders.
      */
     fun openAiSystemPrompt() = preferenceStore.getString(
         "translation_openai_system_prompt",
@@ -213,7 +250,7 @@ class TranslationPreferences(
     )
 
     /**
-     * Custom user prompt template for OpenAI/GPT models.
+     * Custom user prompt template for OpenAI/GPT models. Blank means use [TranslationPromptDefaults.DEFAULT_USER_PROMPT].
      * Supports {SOURCE_LANG}, {TARGET_LANG}, and {TEXT} placeholders.
      */
     fun openAiUserPrompt() = preferenceStore.getString(
@@ -377,5 +414,14 @@ class TranslationPreferences(
     fun geminiModel() = preferenceStore.getString(
         "translation_gemini_model",
         "gemini-2.0-flash",
+    )
+
+    /**
+     * Custom prompt template for Gemini. Blank means use [TranslationPromptDefaults.DEFAULT_COMBINED_PROMPT].
+     * Supports {SOURCE_LANG}, {TARGET_LANG}, and {TEXT} placeholders.
+     */
+    fun geminiPrompt() = preferenceStore.getString(
+        "translation_gemini_prompt",
+        "",
     )
 }

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPromptDefaults.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPromptDefaults.kt
@@ -1,0 +1,42 @@
+package tachiyomi.domain.translation.service
+
+/**
+ * Shared default prompt text for LLM-based translation engines.
+ * Placeholders: {SOURCE_LANG}, {TARGET_LANG}, {TEXT}.
+ */
+object TranslationPromptDefaults {
+
+    const val DEFAULT_SYSTEM_PROMPT = """You are a professional translator specializing in novel/fiction translation. Translate the following text from {SOURCE_LANG} to {TARGET_LANG}.
+Rules:
+- Only output the translation, nothing else
+- Preserve paragraph structure (keep empty lines between paragraphs)
+- Do not summarize, merge, or split paragraphs
+- Preserve every line break exactly as in the input; do not wrap lines or normalize whitespace
+- Maintain the author's writing style and tone
+- Keep character names consistent
+- Do not add explanations or notes
+- Copy tokens like [IMG_PLACEHOLDER_0] verbatim — do not translate or alter them"""
+
+    const val DEFAULT_USER_PROMPT = "{TEXT}"
+
+    /** Combined single-string default for completion-style APIs that send one prompt (e.g. Ollama). */
+    val DEFAULT_COMBINED_PROMPT = """$DEFAULT_SYSTEM_PROMPT
+
+Text to translate:
+$DEFAULT_USER_PROMPT
+
+Translation:"""
+
+    /** Display text for {SOURCE_LANG} when the source language is auto-detected. */
+    fun sourceLangDisplay(sourceLanguage: String, sourceLangName: String): String {
+        return if (sourceLanguage == "auto") "the automatically-detected source language" else sourceLangName
+    }
+
+    fun apply(template: String, sourceLangDisplay: String, targetLangName: String, text: String? = null): String {
+        var result = template
+            .replace("{SOURCE_LANG}", sourceLangDisplay)
+            .replace("{TARGET_LANG}", targetLangName)
+        if (text != null) result = result.replace("{TEXT}", text)
+        return result
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1197,6 +1197,7 @@
     <string name="pref_translation_system_prompt_desc">Custom system prompt for GPT models. Leave empty for default.</string>
     <string name="pref_translation_user_prompt">User Prompt Template</string>
     <string name="pref_translation_user_prompt_desc">Use {SOURCE_LANG}, {TARGET_LANG}, {TEXT} as placeholders.</string>
+    <string name="pref_translation_reset_prompt_confirm">Reset this prompt to its default text? Your custom text will be lost.</string>
     <string name="pref_translation_api_key">API Key</string>
     <string name="pref_translation_api_url">API URL</string>
     <string name="pref_translation_custom_prompt">Custom Prompt</string>


### PR DESCRIPTION
add a multiline prompt editor with prefilled text and a reset option to all LLM options.


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
