### PR TITLE
Fix chapter/manga memo dropped on download and batch manga fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix TTS highlight outline getting clipped in WebView reader [@mrissaoussama](https://github.com/mrissaoussama) [#406](https://github.com/tsundoku-otaku/tsundoku/pull/406)
 - Globally throttle notification updates for massimport across batches [@mrissaoussama](https://github.com/mrissaoussama) [#407](https://github.com/tsundoku-otaku/tsundoku/pull/407)
 - Fix JS result unescaping misreading obfuscated backslashes as escapes [@mrissaoussama](https://github.com/mrissaoussama) [#405](https://github.com/tsundoku-otaku/tsundoku/pull/405)
+- Fix chapter/manga memo column getting droped on download/batch fetch [@mrissaoussama](https://github.com/mrissaoussama) [#412](https://github.com/tsundoku-otaku/tsundoku/pull/412)
 
 ## [v0.3.2] - 2026-08-21
 ### Improved

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -30,6 +30,7 @@ data class Download(
     val chapterScanlator: String?,
     val chapterDateUpload: Long,
     val chapterNumber: Double,
+    val chapterMemo: JsonObject = JsonObject.EMPTY,
 ) {
     var pages: List<Page>? = null
 
@@ -127,6 +128,7 @@ data class Download(
                 chapterScanlator = chapter.scanlator,
                 chapterDateUpload = chapter.dateUpload,
                 chapterNumber = chapter.chapterNumber,
+                chapterMemo = chapter.memo,
             ).apply { this.bypassRateLimit = bypassRateLimit }
         }
 
@@ -161,7 +163,7 @@ data class Download(
             lastModifiedAt = 0,
             version = 1,
             locked = false,
-            memo = JsonObject.EMPTY,
+            memo = chapterMemo,
         )
     }
 }

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -144,9 +144,11 @@ class MangaRepositoryImpl(
                     _,
                     _,
                     _,
-                    _,
+                    memo,
                 ->
-                MangaMapper.mapManga(id, source, url, artist, author, description, genre, title, alternative_titles, status, thumbnail_url, favorite, last_update, next_update, initialized, viewer, chapter_flags, cover_last_modified, date_added, update_strategy, calculate_interval, last_modified_at, favorite_modified_at, version, is_syncing, notes, is_novel)
+                MangaMapper.mapManga(id, source, url, artist, author, description, genre, title, alternative_titles, status, thumbnail_url, favorite, last_update, next_update, initialized, viewer, chapter_flags, cover_last_modified, date_added, update_strategy, calculate_interval, last_modified_at, favorite_modified_at, version, is_syncing, notes, is_novel).copy(
+                    memo = memo,
+                )
             }.awaitAsList()
         }
     }


### PR DESCRIPTION
fixed downloads setting memo to JsonObject.EMPTY

Also fixed MangaRepositoryImpl.getMangasByIds discarding the memo column.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
