### PR TITLE
Fix legacy app.cash.quickjs.QuickJs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Library sort by last read now updates after reading [@mrissaoussama](https://github.com/mrissaoussama) [#400](https://github.com/tsundoku-otaku/tsundoku/pull/400)
+- Update QuickJS [@mrissaoussama](https://github.com/mrissaoussama) [#414](https://github.com/tsundoku-otaku/tsundoku/pull/414)
 - Double-tapping browse now does novel search if manga UI hidden [@mrissaoussama](https://github.com/mrissaoussama) [#401](https://github.com/tsundoku-otaku/tsundoku/pull/401)
 - Clarified UI text on text-selectable option [@mrissaoussama](https://github.com/mrissaoussama) [#403](https://github.com/tsundoku-otaku/tsundoku/pull/403)
 - Fix novel theme preference showing null [@mrissaoussama](https://github.com/mrissaoussama) [#404](https://github.com/tsundoku-otaku/tsundoku/pull/404)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -17,6 +17,7 @@
 -keep,allowoptimization class rx.** { public protected *; }
 -keep,allowoptimization class com.dokar.quickjs.** { public protected *; }
 -keep class com.dokar.quickjs.MemoryUsage { *; }
+-keep,allowoptimization class app.cash.quickjs.** { public protected *; }
 -keepclassmembers class kotlin.UByteArray { <init>(...); }
 -keep,allowoptimization class uy.kohesive.injekt.** { public protected *; }
 -keep,allowoptimization class com.squareup.zstd.** { public protected *; }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     implementation(libs.natural.comparator)
 
     // JavaScript engine
-    // implementation(libs.quickJs)
     implementation("io.github.dokar3:quickjs-kt:1.0.0-alpha13")
 
     testImplementation(libs.bundles.test)

--- a/core/common/src/main/kotlin/app/cash/quickjs/QuickJs.kt
+++ b/core/common/src/main/kotlin/app/cash/quickjs/QuickJs.kt
@@ -1,0 +1,30 @@
+package app.cash.quickjs
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import java.io.Closeable
+import com.dokar.quickjs.QuickJs as DokarQuickJs
+
+class QuickJs private constructor(private val delegate: DokarQuickJs) : Closeable {
+
+    fun evaluate(script: String): Any? = runBlocking(Dispatchers.Default) {
+        delegate.evaluate<Any?>(script)
+    }
+
+    fun evaluate(script: String, fileName: String): Any? = runBlocking(Dispatchers.Default) {
+        delegate.evaluate<Any?>(script, fileName)
+    }
+
+    fun compile(sourceCode: String, fileName: String): ByteArray = delegate.compile(sourceCode, fileName)
+
+    fun execute(bytecode: ByteArray): Any? = runBlocking(Dispatchers.Default) {
+        delegate.evaluate<Any?>(bytecode)
+    }
+
+    override fun close() = delegate.close()
+
+    companion object {
+        @JvmStatic
+        fun create(): QuickJs = QuickJs(DokarQuickJs.create(Dispatchers.Default))
+    }
+}


### PR DESCRIPTION
provide backward compat with app.cash.quickjs.QuickJs

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
