### PR TITLE
Fix extension deeplinks resolving to a blank search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 
 ### Fixed
+- Deeplinks from extensions ("open in app") now resolve to the entry page instead of a blank search  [@Rojikku](https://github.com/Rojikku) [#416](https://github.com/tsundoku-otaku/tsundoku/pull/416)
 - Library sort by last read now updates after reading [@mrissaoussama](https://github.com/mrissaoussama) [#400](https://github.com/tsundoku-otaku/tsundoku/pull/400)
 - Update QuickJS [@mrissaoussama](https://github.com/mrissaoussama) [#414](https://github.com/tsundoku-otaku/tsundoku/pull/414)
 - Double-tapping browse now does novel search if manga UI hidden [@mrissaoussama](https://github.com/mrissaoussama) [#401](https://github.com/tsundoku-otaku/tsundoku/pull/401)

--- a/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/MassImport.kt
@@ -3,6 +3,7 @@ package eu.kanade.domain.manga.interactor
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.massimport.DeeplinkResolver
 import eu.kanade.tachiyomi.data.massimport.PackageManagerDeeplinkResolver
+import eu.kanade.tachiyomi.data.massimport.resolveDeeplinkManga
 import eu.kanade.tachiyomi.jsplugin.source.JsSource
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.isNovelSource
@@ -37,6 +38,10 @@ class MassImport(
     companion object {
         private val GLUE_REGEX = Regex("(?<=[^\\s])(?=https?://)")
         private val SCHEME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9+\\-.]*://")
+
+        // Upper bound on the deeplink pattern-match + optional canonical-URL lookup done while
+        // resolving a single shared URL (deeplink handling, not the batched import).
+        private const val URL_RESOLVE_TIMEOUT_MS = 30_000L
 
         // Shared tokenizer for every entry point so the "valid" count matches what the import
         // walks. Splits on comma/semicolon/space/tab and de-glues separator-less URLs.
@@ -80,6 +85,33 @@ class MassImport(
         }
 
         return networkToLocalManga(sManga.toDomainManga(source.id, source.isNovelSource()))
+    }
+
+    /**
+     * Resolve a shared/browser URL to a local [Manga] via the same steps the URL mass-import
+     * flow uses: match the URL to an installed source by host, resolve its canonical path
+     * (extension deeplink pattern when the URL diverges from the stored path, otherwise the
+     * URL's own path), then fetch details. Shared with the deeplink handler so both agree on
+     * how a pasted URL maps to a library entry.
+     *
+     * @return the resolved [Manga] paired with the [source] it came from, or null when no
+     *   installed source matches the URL's host. Throws when a source matched but its
+     *   extension failed to fetch/parse the entry.
+     */
+    suspend fun resolveUrlToManga(url: String): Pair<Manga, CatalogueSource>? {
+        val source = findMatchingSource(url) ?: return null
+        return resolveUrlToManga(url, source) to source
+    }
+
+    /**
+     * Same as [resolveUrlToManga] but for a caller that already knows the source (e.g. an
+     * extension's "open in app" intent names its own package), skipping the host match.
+     */
+    suspend fun resolveUrlToManga(url: String, source: CatalogueSource): Manga {
+        val resolved = resolveDeeplinkManga(source, url, deeplinkResolverFactory(), URL_RESOLVE_TIMEOUT_MS)
+        val path = resolved?.let { runCatching { it.url }.getOrNull() }?.takeIf { it.isNotBlank() }
+            ?: extractPathFromUrl(url, getSourceBaseUrl(source), source)
+        return resolveMangaUrl(url, path, source)
     }
 
     private fun getAllSources(): List<CatalogueSource> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
@@ -13,6 +13,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.NovelGlobalSearchScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import tachiyomi.i18n.MR
@@ -22,6 +23,7 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 
 class DeepLinkScreen(
     val query: String = "",
+    private val extensionPackage: String? = null,
 ) : Screen() {
 
     @Composable
@@ -33,6 +35,7 @@ class DeepLinkScreen(
             factory = DeepLinkViewModel.Factory,
             extras = CreationExtras {
                 set(DeepLinkViewModel.QUERY_KEY, query)
+                extensionPackage?.let { set(DeepLinkViewModel.PACKAGE_KEY, it) }
             },
         )
         val state by viewModel.state.collectAsState()
@@ -50,7 +53,11 @@ class DeepLinkScreen(
                     LoadingScreen(Modifier.padding(contentPadding))
                 }
                 is DeepLinkViewModel.State.NoResults -> {
-                    navigator.replace(GlobalSearchScreen(query))
+                    if ((state as DeepLinkViewModel.State.NoResults).isNovel) {
+                        navigator.replace(NovelGlobalSearchScreen(query))
+                    } else {
+                        navigator.replace(GlobalSearchScreen(query))
+                    }
                 }
                 is DeepLinkViewModel.State.Result -> {
                     val resultState = state as DeepLinkViewModel.State.Result

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkViewModel.kt
@@ -5,16 +5,21 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import eu.kanade.domain.manga.interactor.MassImport
+import eu.kanade.tachiyomi.extension.ExtensionManager
+import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isNovelSource
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.online.ResolvableSource
 import eu.kanade.tachiyomi.source.online.UriType
 import kotlinx.coroutines.flow.update
+import logcat.LogPriority
 import mihon.core.viewmodel.StateViewModel
 import mihon.domain.manga.model.toDomainManga
 import mihon.domain.source.interactor.UpdateMangaFromRemote
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapterByUrlAndMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
@@ -24,20 +29,25 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 class DeepLinkViewModel(
-    query: String,
+    private val query: String,
+    private val extensionPackage: String? = null,
     private val sourceManager: SourceManager = Injekt.get(),
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getChapterByUrlAndMangaId: GetChapterByUrlAndMangaId = Injekt.get(),
     private val updateMangaFromRemote: UpdateMangaFromRemote = Injekt.get(),
+    private val massImport: MassImport = Injekt.get(),
+    private val extensionManager: ExtensionManager = Injekt.get(),
 ) : StateViewModel<DeepLinkViewModel.State>(State.Loading) {
 
     companion object {
         val QUERY_KEY = CreationExtras.Key<String>()
+        val PACKAGE_KEY = CreationExtras.Key<String>()
 
         val Factory = viewModelFactory {
             initializer {
                 DeepLinkViewModel(
                     query = get(QUERY_KEY)!!,
+                    extensionPackage = get(PACKAGE_KEY),
                 )
             }
         }
@@ -45,32 +55,74 @@ class DeepLinkViewModel(
 
     init {
         viewModelScope.launchIO {
-            val source = sourceManager.getAll()
+            val resolvable = sourceManager.getAll()
                 .filterIsInstance<ResolvableSource>()
                 .firstOrNull { it.getUriType(query) != UriType.Unknown }
 
-            val manga = source?.getManga(query)?.let {
-                networkToLocalManga(it.toDomainManga(source.id, source.isNovelSource()))
+            val resolvableManga = resolvable?.getManga(query)?.let {
+                networkToLocalManga(it.toDomainManga(resolvable.id, resolvable.isNovelSource()))
             }
 
-            val chapter = if (source?.getUriType(query) == UriType.Chapter && manga != null) {
-                source.getChapter(query)?.let { getChapterFromSChapter(it, manga, source) }
+            // No ResolvableSource handled the URL (novel extensions don't implement that
+            // interface). Resolve it the way the URL mass-import flow does - fetch details for
+            // the entry's path - so a shared "open in app" link lands on the manga page.
+            // Prefer the source named by the sender's extension package; fall back to a host match.
+            val fallback = if (resolvableManga == null) {
+                resolveViaPackage() ?: resolveViaHost()
+            } else {
+                null
+            }
+
+            val manga = resolvableManga ?: fallback?.first
+
+            val chapter = if (resolvable?.getUriType(query) == UriType.Chapter && manga != null) {
+                resolvable.getChapter(query)?.let { getChapterFromSChapter(it, manga, resolvable) }
             } else {
                 null
             }
 
             mutableState.update {
-                if (manga == null) {
-                    State.NoResults
-                } else {
-                    if (chapter == null) {
-                        State.Result(manga)
-                    } else {
-                        State.Result(manga, chapter.id)
+                when {
+                    manga != null && chapter != null -> State.Result(manga, chapter.id)
+                    manga != null -> State.Result(manga)
+                    // Route an unresolved URL to the matching library's global search: a
+                    // novel-source host goes to the novel search, everything else to manga.
+                    else -> {
+                        val isNovel = fallback?.second?.isNovelSource()
+                            ?: packageSources().firstOrNull()?.isNovelSource()
+                            ?: massImport.findMatchingSource(query)?.isNovelSource()
+                            ?: false
+                        State.NoResults(isNovel = isNovel)
                     }
                 }
             }
         }
+    }
+
+    /** [CatalogueSource]s belonging to the extension package that sent the intent, if any. */
+    private fun packageSources(): List<CatalogueSource> {
+        val pkg = extensionPackage ?: return emptyList()
+        return extensionManager.installedExtensionsFlow.value
+            .firstOrNull { it.pkgName == pkg }
+            ?.sources
+            ?.filterIsInstance<CatalogueSource>()
+            .orEmpty()
+    }
+
+    private suspend fun resolveViaPackage(): Pair<Manga, CatalogueSource>? {
+        for (source in packageSources()) {
+            val manga = runCatching { massImport.resolveUrlToManga(query, source) }
+                .onFailure { logcat(LogPriority.WARN, it) { "DeepLink: pkg resolve failed on ${source.name}" } }
+                .getOrNull()
+            if (manga != null) return manga to source
+        }
+        return null
+    }
+
+    private suspend fun resolveViaHost(): Pair<Manga, CatalogueSource>? {
+        return runCatching { massImport.resolveUrlToManga(query) }
+            .onFailure { logcat(LogPriority.WARN, it) { "DeepLink: host resolve failed for $query" } }
+            .getOrNull()
     }
 
     private suspend fun getChapterFromSChapter(sChapter: SChapter, manga: Manga, source: Source): Chapter? {
@@ -88,7 +140,7 @@ class DeepLinkViewModel(
         data object Loading : State
 
         @Immutable
-        data object NoResults : State
+        data class NoResults(val isNovel: Boolean = false) : State
 
         @Immutable
         data class Result(val manga: Manga, val chapterId: Long? = null) : State

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -562,7 +562,14 @@ class MainActivity : BaseActivity() {
                 if (!query.isNullOrEmpty()) {
                     val filter = intent.getStringExtra(INTENT_SEARCH_FILTER)
                     navigator.popUntilRoot()
-                    navigator.push(GlobalSearchScreen(query, filter))
+                    // An extension's "open in app" sends the entry URL through this action (with
+                    // its own package as the filter); resolve it to the manga page instead of
+                    // dumping the raw URL into a text search.
+                    if (query.startsWith("http://") || query.startsWith("https://")) {
+                        navigator.push(DeepLinkScreen(query, filter))
+                    } else {
+                        navigator.push(GlobalSearchScreen(query, filter))
+                    }
                 }
                 null
             }

--- a/app/src/test/java/eu/kanade/domain/manga/interactor/MassImportDeeplinkTest.kt
+++ b/app/src/test/java/eu/kanade/domain/manga/interactor/MassImportDeeplinkTest.kt
@@ -3,14 +3,23 @@ package eu.kanade.domain.manga.interactor
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.massimport.DeeplinkResolver
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.source.online.HttpSource
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
 
@@ -18,7 +27,31 @@ private class FakeHttpSource(
     override val name: String,
     override val lang: String,
     override val baseUrl: String,
-) : HttpSource()
+    private val searchResultUrl: String? = null,
+) : HttpSource() {
+
+    // Path the last getMangaUpdate details fetch was asked for; lets a test assert which URL
+    // (guessed-from-path vs deeplink-canonical) resolution settled on.
+    var requestedUrl: String? = null
+        private set
+
+    override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+        val results = searchResultUrl
+            ?.let { listOf(SManga.create().apply { url = it; title = "Canonical" }) }
+            .orEmpty()
+        return MangasPage(results, false)
+    }
+
+    override suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        requestedUrl = manga.url
+        return SMangaUpdate(SManga.create().apply { url = manga.url; title = "Title" }, emptyList())
+    }
+}
 
 private class FakeDeeplinkResolver(private val deeplinkHosts: Set<String>) : DeeplinkResolver {
     override fun isDeeplinkUrl(source: CatalogueSource, url: String): Boolean {
@@ -30,10 +63,12 @@ private class FakeDeeplinkResolver(private val deeplinkHosts: Set<String>) : Dee
 class MassImportDeeplinkTest {
 
     private val source = FakeHttpSource(name = "Fake", lang = "en", baseUrl = "https://example.com")
+    private val resolvedManga = mockk<Manga>(relaxed = true)
 
     private fun massImport(
         favoriteSourceAndUrl: List<Pair<Long, String>> = emptyList(),
         deeplinkHosts: Set<String> = emptySet(),
+        source: FakeHttpSource = this.source,
     ): MassImport {
         val sourceManager = mockk<SourceManager>(relaxed = true) {
             every { getAll() } returns listOf(source)
@@ -48,7 +83,8 @@ class MassImportDeeplinkTest {
             sourcePreferences = sourcePreferences,
             deeplinkResolverFactory = { FakeDeeplinkResolver(deeplinkHosts) },
         ).also {
-            io.mockk.coEvery { mangaRepository.getFavoriteSourceAndUrl() } returns favoriteSourceAndUrl
+            coEvery { mangaRepository.getFavoriteSourceAndUrl() } returns favoriteSourceAndUrl
+            coEvery { networkToLocalManga(any<Manga>()) } returns resolvedManga
         }
     }
 
@@ -87,5 +123,39 @@ class MassImportDeeplinkTest {
 
         assertEquals(1, result.invalidUrls.size)
         assertEquals("No matching source", result.invalidUrls.first().second)
+    }
+
+    @Test
+    fun `resolveUrlToManga returns null when no installed source matches the host`() = runBlocking {
+        val massImport = massImport()
+
+        assertNull(massImport.resolveUrlToManga("https://unrelated-host.test/novel/abc"))
+    }
+
+    @Test
+    fun `resolveUrlToManga fetches the URL's own path when it is not a deeplink`() = runBlocking {
+        val massImport = massImport()
+
+        val result = massImport.resolveUrlToManga("https://example.com/novel/abc")
+
+        assertSame(resolvedManga, result?.first)
+        assertSame(source, result?.second)
+        assertEquals("/novel/abc", source.requestedUrl)
+    }
+
+    @Test
+    fun `resolveUrlToManga fetches the canonical path when the URL is a deeplink`() = runBlocking {
+        val deeplinkSource = FakeHttpSource(
+            name = "Fake",
+            lang = "en",
+            baseUrl = "https://example.com",
+            searchResultUrl = "/novel/real-slug",
+        )
+        val massImport = massImport(deeplinkHosts = setOf("example.com"), source = deeplinkSource)
+
+        val result = massImport.resolveUrlToManga("https://example.com/title/uuid-1234/shareable")
+
+        assertSame(resolvedManga, result?.first)
+        assertEquals("/novel/real-slug", deeplinkSource.requestedUrl)
     }
 }


### PR DESCRIPTION
An extension's "open in app" fires action eu.kanade.tachiyomi.SEARCH with its own package as the filter extra and the entry URL as the query. MainActivity routed that straight to GlobalSearchScreen, so every source got a text search for a raw URL string and nothing matched - DeepLinkScreen/DeepLinkViewModel were never on that path.

- MainActivity: a URL-shaped INTENT_SEARCH query now goes to DeepLinkScreen(query, filter) instead of a raw-URL text search.
- DeepLinkScreen threads the sender's extension package to the view model.
- DeepLinkViewModel: when no ResolvableSource handles the URL, resolve it via the sender extension's own sources first (ExtensionManager package match), then a host match, then fall back to global search - routing a novel-source host to the novel search. NoResults now carries isNovel.
- MassImport: add resolveUrlToManga(url) / resolveUrlToManga(url, source)
  - URL -> Manga by details-fetch of the entry path, shared with the URL mass-import flow so both agree how a pasted URL maps to a library entry.

Tests: 3 new cases in MassImportDeeplinkTest cover no-match, path-from-URL, and canonical-path-from-deeplink resolution.
