### PR TITLE
webview paged reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Webview paged reader [@mrissaoussama](https://github.com/mrissaoussama) [#420](https://github.com/tsundoku-otaku/tsundoku/pull/420)
+
+
 ### Improved
 - TTS media notification for pause/resume with headset buttons. Old notification available in advanced settings. [@mrissaoussama](https://github.com/mrissaoussama) [#421](https://github.com/tsundoku-otaku/tsundoku/pull/421)
 

--- a/app/src/main/assets/novel-reader/paged-reader.js
+++ b/app/src/main/assets/novel-reader/paged-reader.js
@@ -1,0 +1,542 @@
+// Paged-mode engine for the novel WebView reader (webview only). Installed via
+// NovelWebViewStyler.injectPagedReader().
+//
+// CSS multi-column on #__CHAPTERS_CONTAINER_ID__; page turns move it via
+// transform: translateX (not scrollLeft), so a page flip never fires a scroll event.
+// Progress persists through the same Android bridge calls scroll-tracking.js uses
+// (onScrollUpdate/onScrollProgress).
+//
+// p.lastRatio is the authoritative reading position; pageIndex is always re-derived
+// from it against the current pageCount, never the reverse - an early pageCount
+// measurement (fonts still loading) can be wrong, and deriving from a stale pageIndex
+// would compound that error.
+//
+// Crossing a page edge always does a full chapter switch (no in-DOM append), with
+// Kotlin prefetching the next/prev chapter near an edge.
+//
+// JS API: actions.nextPage()/prevPage()/goToPage(n)/setPagedConfig({...});
+// runtime.pagingEnabled/pageIndex/pageCount/progress/chapterProgress/currentChapterId
+// (same fields scroll-tracking.js publishes); config.paged.{dragCommitFraction,
+// edgeCommitFraction, edgeMaxDampedFraction, chapterTransitionHoldMs} - live-read,
+// snippet-overridable; window events __PAGE_EVENT__ { pageIndex, pageCount } and
+// __PROGRESS_EVENT__ (same shape as scroll-tracking.js).
+
+(function () {
+    window.__TSUNDOKU_OBJECT_NAME__ = window.__TSUNDOKU_OBJECT_NAME__ || {};
+    var T = window.__TSUNDOKU_OBJECT_NAME__;
+    T.runtime = T.runtime || {};
+    var runtime = T.runtime;
+
+    if (runtime.pagedReaderInstalled) {
+        return;
+    }
+    runtime.pagedReaderInstalled = true;
+
+    var PAGED_CLASS = '__PAGED_BODY_CLASS__';
+    var PAGE_EVENT = '__PAGE_EVENT__';
+    var PROGRESS_EVENT = '__PROGRESS_EVENT__';
+    var CONTAINER_ID = '__CHAPTERS_CONTAINER_ID__';
+    var NO_TRANSITION_CLASS = 'tsundoku-paged-no-transition';
+    var TRANSITION_ID = 'tsundoku-paged-chapter-transition';
+    var TRANSITION_VISIBLE_CLASS = 'tsundoku-visible';
+    var enabled = __PAGED_ENABLED__;
+
+    // User/snippet-tunable behavior constants - read live from T.config.paged everywhere below
+    // (never cached into a local var) so a change made at any point, by a snippet running before
+    // this script or one appended later from the console/dev-tools, takes effect on the very next
+    // gesture. Defaults fill in only the keys not already set (e.g. by a customJs snippet that ran
+    // earlier in this same page load, before injectPagedReader()).
+    var DEFAULT_PAGED_CONFIG = {
+        // Fraction of the WebView's width a drag must cross to commit a same-chapter page turn.
+        dragCommitFraction: __PAGED_DRAG_COMMIT_FRACTION__,
+        // Fraction of the WebView's width a drag past the first/last page must cross to commit a
+        // chapter switch. Defaults to the same value as dragCommitFraction (the "Page-turn swipe
+        // distance" pref drives both), but stays a separate key so a snippet can diverge them.
+        edgeCommitFraction: __PAGED_EDGE_COMMIT_FRACTION__,
+        // Cap (as a fraction of width) on how far the rubber-band edge drag can visually travel,
+        // however far past the edge the finger actually goes.
+        edgeMaxDampedFraction: 0.45,
+        // How long the edge chevron/title-announce transition holds before the chapter switch
+        // actually fires (swipe-past-edge and the bottom-bar arrow at the first/last page both
+        // go through this).
+        chapterTransitionHoldMs: 260,
+    };
+    T.config = T.config || {};
+    T.config.paged = (function (overrides) {
+        var merged = {};
+        for (var k in DEFAULT_PAGED_CONFIG) merged[k] = DEFAULT_PAGED_CONFIG[k];
+        for (var k2 in overrides) {
+            if (Object.prototype.hasOwnProperty.call(overrides, k2)) merged[k2] = overrides[k2];
+        }
+        return merged;
+    })(T.config.paged || {});
+    var cfg = T.config.paged;
+
+    var p = window.__tdPaged || (window.__tdPaged = {});
+    p.pageIndex = p.pageIndex || 0;
+    p.pageCount = p.pageCount || 1;
+    p.lastRatio = (typeof p.lastRatio === 'number') ? p.lastRatio : 0;
+    // Guards the ResizeObserver/window-resize auto-repaginate below from firing before
+    // restoreScrollPosition's first __tdPagedRestoreRatio call has set the real lastRatio.
+    p.restored = p.restored || false;
+
+    function container() {
+        var el = document.getElementById(CONTAINER_ID);
+        if (el) return el;
+        el = document.createElement('div');
+        el.id = CONTAINER_ID;
+        while (document.body.firstChild) {
+            el.appendChild(document.body.firstChild);
+        }
+        document.body.appendChild(el);
+        return el;
+    }
+
+    // The stable "one page" width: read from body, never from the multicol container itself
+    // (whose own clientWidth is the full multi-column box, not one column).
+    function pageWidth() {
+        return document.body.clientWidth || window.innerWidth || 1;
+    }
+
+    function applyColumnLayout() {
+        var el = container();
+        var w = pageWidth();
+        el.style.columnWidth = w + 'px';
+        el.style.MozColumnWidth = w + 'px';
+        el.style.webkitColumnWidth = w + 'px';
+        // body needs a definite height (not just html's) for its own overflow:hidden to actually
+        // clip the container - reduce by body's own margin only. Deliberately NOT by
+        // __SAFE_TOP_VAR__/__SAFE_BOTTOM_VAR__ (transient menu-bar overlays) - sizing the page to
+        // those turned every menu toggle into a repagination + ResizeObserver feedback loop.
+        var cs = window.getComputedStyle(document.body);
+        var vMargin = (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
+        document.body.style.boxSizing = 'border-box';
+        // Explicit floored px height, not `calc(100vh - Npx)`: fractional rounding there let the
+        // last line's descenders clip past the overflow:hidden edge. 1px safety buffer for the rest.
+        var innerH = window.innerHeight || document.documentElement.clientHeight;
+        document.body.style.height = Math.floor(innerH - vMargin - 1) + 'px';
+    }
+
+    function computePageCount() {
+        var el = container();
+        var w = pageWidth();
+        if (!w) return 1;
+        // ceil, not round: columns are uniform width (only the last one is partially filled with
+        // text, never narrower), so rounding down on a sub-pixel-under measurement would strand
+        // the last page's tail content past the end of the computed count.
+        return Math.max(1, Math.ceil(el.scrollWidth / w));
+    }
+
+    // Layout-based (offsetLeft/offsetParent chain), not paint-based (getBoundingClientRect):
+    // unaffected by the container's own `transform`.
+    function offsetLeftWithin(el, root) {
+        var x = 0;
+        var node = el;
+        while (node && node !== root) {
+            x += node.offsetLeft || 0;
+            node = node.offsetParent;
+        }
+        return x;
+    }
+
+    function pageOfElement(el) {
+        if (!el) return null;
+        var left = offsetLeftWithin(el, container());
+        var w = pageWidth();
+        return w ? Math.floor(left / w) : 0;
+    }
+
+    // animate=false (default) suppresses the CSS transition for restore/reflow landings;
+    // animate=true lets the container's own `transition: transform` play for a real page turn.
+    function setTransform(pageIndex, animate) {
+        var el = container();
+        var value = 'translateX(-' + (pageIndex * pageWidth()) + 'px)';
+        if (animate) {
+            el.style.transform = value;
+            return;
+        }
+        el.classList.add(NO_TRANSITION_CLASS);
+        el.style.transform = value;
+        void el.offsetHeight; // force layout before the transition is lifted next frame
+        requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+                el.classList.remove(NO_TRANSITION_CLASS);
+            });
+        });
+    }
+
+    function dispatchPageChange(pageIndex, pageCount) {
+        try {
+            window.dispatchEvent(new CustomEvent(PAGE_EVENT, {
+                detail: { pageIndex: pageIndex, pageCount: pageCount },
+            }));
+        } catch (e) {}
+    }
+
+    function reportProgress(ratio) {
+        try { Android.onScrollUpdate(ratio); } catch (e) {}
+        try { Android.onScrollProgress(ratio); } catch (e) {}
+    }
+
+    function reportPageInfo(pageIndex, pageCount) {
+        try { Android.onPageInfoChanged(pageIndex, pageCount); } catch (e) {}
+    }
+
+    // Mirrors scroll-tracking.js's publishProgress/dispatchProgress so a snippet listening for
+    // __PROGRESS_EVENT__ / reading runtime.progress doesn't need a separate paged-mode code path.
+    // ratio (0-1, same value persisted via reportProgress) stands in for both progress and
+    // chapterProgress - paged mode never has more than one chapter in the DOM (see file header),
+    // so there's no separate whole-document-vs-current-chapter distinction to make.
+    function publishProgress(ratio, pageIndex, pageCount) {
+        var chapterId = (T.currentChapter && T.currentChapter.id != null) ? T.currentChapter.id : null;
+        var isLast = pageCount <= 1 || pageIndex === pageCount - 1;
+        runtime.progress = ratio;
+        runtime.chapterProgress = ratio;
+        runtime.currentChapterId = chapterId;
+        try {
+            window.dispatchEvent(new CustomEvent(PROGRESS_EVENT, {
+                detail: {
+                    progress: ratio,
+                    chapterProgress: ratio,
+                    chapterId: chapterId,
+                    isLast: isLast,
+                },
+            }));
+        } catch (e) {}
+    }
+
+    function hideChapterTransition() {
+        var el = document.getElementById(TRANSITION_ID);
+        if (el) el.classList.remove(TRANSITION_VISIBLE_CLASS);
+    }
+
+    function landOnPage(idx, pc, animate) {
+        idx = Math.max(0, Math.min(idx, pc - 1));
+        p.pageCount = pc;
+        p.pageIndex = idx;
+        hideChapterTransition();
+        setTransform(idx, !!animate);
+        runtime.pageIndex = idx;
+        runtime.pageCount = pc;
+        dispatchPageChange(idx, pc);
+        reportPageInfo(idx, pc);
+        reportProgress(p.lastRatio);
+        publishProgress(p.lastRatio, idx, pc);
+    }
+
+    // Recomputes page count/width against the current layout and lands on the page nearest
+    // p.lastRatio (the authoritative position - see file header). `ratio`, when passed, ALSO
+    // updates lastRatio first (an explicit restore/seek); omit it to just re-derive against a
+    // possibly-changed pageCount (reflow) without changing the intended position.
+    // Deferred when a touch drag is in progress (see below) so a resize/ResizeObserver firing
+    // mid-swipe doesn't null out `drag` and snap the page under the user's finger; re-run once
+    // the drag ends.
+    var pendingRepaginateRatio;
+    var hasPendingRepaginate = false;
+
+    function repaginate(ratio) {
+        if (!enabled) return;
+        if (drag) {
+            hasPendingRepaginate = true;
+            pendingRepaginateRatio = ratio;
+            return;
+        }
+        if (typeof ratio === 'number') p.lastRatio = ratio;
+        applyColumnLayout();
+        var pc = computePageCount();
+        var idx = pc > 1 ? Math.round(p.lastRatio * pc) - 1 : 0;
+        landOnPage(idx, pc, false);
+        drag = null;
+    }
+
+    // Pull-to-refresh-style edge badge (chevron icon, no chapter title text) rather than a
+    // full-screen text overlay.
+    var CHEVRON_SVG = '<svg viewBox="0 0 24 24" width="20" height="20">' +
+        '<path d="M15 4l-8 8 8 8" fill="none" stroke="currentColor" stroke-width="2.5" ' +
+        'stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+    function chapterTransitionEl() {
+        var el = document.getElementById(TRANSITION_ID);
+        if (!el) {
+            el = document.createElement('div');
+            el.id = TRANSITION_ID;
+            el.className = 'tsundoku-paged-chapter-transition';
+            var badge = document.createElement('div');
+            badge.className = 'tsundoku-paged-transition-badge';
+            badge.innerHTML = CHEVRON_SVG;
+            el.appendChild(badge);
+            document.body.appendChild(el);
+        }
+        return el;
+    }
+
+    // side: 'start' (revealing the previous chapter, chevron points left) or 'end' (next
+    // chapter, chevron flipped to point right).
+    function setChapterTransitionSide(el, side) {
+        el.setAttribute('data-side', side);
+        el.firstElementChild.style.transform = side === 'end' ? 'scaleX(-1)' : '';
+    }
+
+    function showChapterTransition(side, thenCall) {
+        var el = chapterTransitionEl();
+        el.style.opacity = '';
+        setChapterTransitionSide(el, side);
+        void el.offsetHeight;
+        el.classList.add(TRANSITION_VISIBLE_CLASS);
+        setTimeout(thenCall, cfg.chapterTransitionHoldMs);
+    }
+
+    // Live drag-follow (finger tracking, not fling-triggered): Kotlin forwards raw touch deltas
+    // as a fraction of the WebView's own width via __tdPagedDragTo/__tdPagedDragRelease, called
+    // on every ACTION_MOVE / on ACTION_UP.
+    var drag = null;
+
+    // Diminishing-returns rubber band: x in [0, inf) -> [0, cfg.edgeMaxDampedFraction).
+    function dampenEdgeDrag(x) {
+        return cfg.edgeMaxDampedFraction * (1 - 1 / (1 + 3 * x));
+    }
+
+    window.__tdPagedDragTo = function (rawFraction) {
+        if (!enabled || !p.restored) return;
+        if (!drag) {
+            // pageWidth()/container() force a layout read - cache both for the gesture's
+            // duration instead of on every ACTION_MOVE (width doesn't change mid-touch).
+            drag = {
+                baseIndex: p.pageIndex,
+                pageCount: p.pageCount || computePageCount(),
+                width: pageWidth(),
+                el: container(),
+            };
+        }
+        var atStart = drag.baseIndex === 0;
+        var atEnd = drag.baseIndex === drag.pageCount - 1;
+        var fraction = rawFraction;
+        var edgeProgress = 0;
+        if (atStart && fraction > 0) {
+            edgeProgress = dampenEdgeDrag(fraction);
+            fraction = edgeProgress;
+        } else if (atEnd && fraction < 0) {
+            edgeProgress = dampenEdgeDrag(-fraction);
+            fraction = -edgeProgress;
+        } else {
+            fraction = Math.max(-1, Math.min(1, fraction));
+        }
+        var w = drag.width;
+        var el = drag.el;
+        el.classList.add(NO_TRANSITION_CLASS);
+        el.style.transform = 'translateX(' + (fraction * w - drag.baseIndex * w) + 'px)';
+
+        var t = chapterTransitionEl();
+        if (edgeProgress > 0) {
+            setChapterTransitionSide(t, fraction > 0 ? 'start' : 'end');
+            t.style.transition = 'none';
+            t.style.opacity = String(Math.min(1, edgeProgress / cfg.edgeCommitFraction));
+            t.classList.add(TRANSITION_VISIBLE_CLASS);
+        } else {
+            t.classList.remove(TRANSITION_VISIBLE_CLASS);
+        }
+    };
+
+    window.__tdPagedDragRelease = function (rawFraction) {
+        if (!drag) return;
+        var baseIndex = drag.baseIndex;
+        var pc = drag.pageCount;
+        var atStart = baseIndex === 0;
+        var atEnd = baseIndex === pc - 1;
+        drag = null;
+
+        function runPendingRepaginate() {
+            if (!hasPendingRepaginate) return;
+            hasPendingRepaginate = false;
+            repaginate(pendingRepaginateRatio);
+            pendingRepaginateRatio = undefined;
+        }
+
+        container().classList.remove(NO_TRANSITION_CLASS);
+        var t = chapterTransitionEl();
+        t.style.transition = '';
+        t.style.opacity = '';
+
+        if (atStart && rawFraction > cfg.edgeCommitFraction) { goToPage(-1); runPendingRepaginate(); return; }
+        if (atEnd && rawFraction < -cfg.edgeCommitFraction) { goToPage(pc); runPendingRepaginate(); return; }
+
+        t.classList.remove(TRANSITION_VISIBLE_CLASS);
+        if (!atEnd && rawFraction < -cfg.dragCommitFraction) { goToPage(baseIndex + 1); runPendingRepaginate(); return; }
+        if (!atStart && rawFraction > cfg.dragCommitFraction) { goToPage(baseIndex - 1); runPendingRepaginate(); return; }
+        landOnPage(baseIndex, pc, true);
+        runPendingRepaginate();
+    };
+
+    // target < 0 or >= pageCount always does a full chapter switch, after a brief
+    // title-announce transition. edgeTransitionPending latches so a rapid repeated
+    // trigger can't stack multiple switch calls; cleared only by the next document load.
+    var edgeTransitionPending = false;
+
+    function goToPage(target) {
+        if (!p.restored) return;
+        var pc = p.pageCount || computePageCount();
+        if (target < 0) {
+            if (edgeTransitionPending) return;
+            edgeTransitionPending = true;
+            showChapterTransition('start', function () {
+                try { Android.requestPrevChapter(); } catch (e) { edgeTransitionPending = false; hideChapterTransition(); }
+            });
+            return;
+        }
+        if (target >= pc) {
+            if (edgeTransitionPending) return;
+            edgeTransitionPending = true;
+            showChapterTransition('end', function () {
+                try { Android.loadNextChapter(); } catch (e) { edgeTransitionPending = false; hideChapterTransition(); }
+            });
+            return;
+        }
+        p.lastRatio = (target + 1) / pc;
+        landOnPage(target, pc, true);
+    }
+
+    function nextPage() { goToPage((p.pageIndex || 0) + 1); }
+    function prevPage() { goToPage((p.pageIndex || 0) - 1); }
+
+    T.actions = T.actions || {};
+    T.actions.nextPage = nextPage;
+    T.actions.prevPage = prevPage;
+    T.actions.goToPage = function (n) { goToPage(n); };
+    // Merges into config.paged in place (direct property writes on config.paged work too - this
+    // is just a one-call convenience for setting several at once). Takes effect on the next
+    // swipe/edge-cross; no reload needed.
+    T.actions.setPagedConfig = function (partial) {
+        if (!partial) return;
+        for (var k in partial) {
+            if (Object.prototype.hasOwnProperty.call(partial, k)) cfg[k] = partial[k];
+        }
+    };
+
+    // Edit mode has its own keyboard-clearance bottom padding on body that assumes normal
+    // document flow (see NovelWebViewViewer's toggleEditMode script) - that has no room to work
+    // within paged mode's fixed 100vh clip, so pagination is suspended (plain scrollable flow,
+    // same as continuous mode) for the duration of editing rather than trying to reconcile both.
+    function setSuspended(suspended) {
+        if (!enabled) return;
+        if (suspended) {
+            document.documentElement.classList.remove(PAGED_CLASS);
+            container().style.transform = '';
+        } else {
+            document.documentElement.classList.add(PAGED_CLASS);
+            repaginate();
+        }
+    }
+
+    // Called from Kotlin when an edge crossing found no adjacent chapter to switch to (already at
+    // the first/last chapter) - releases the latch and hides the chevron since no document reload
+    // is coming to clear them on its own.
+    window.__tdPagedReleaseEdgeTransition = function () {
+        edgeTransitionPending = false;
+        hideChapterTransition();
+        landOnPage(p.pageIndex, p.pageCount, true);
+    };
+
+    runtime.pagingEnabled = enabled;
+    window.__tdPagedSetSuspended = setSuspended;
+    // Guarded like goToPage/dragTo/goToElement - a seek before restore lands would get clobbered.
+    window.__tdPagedRepaginate = function (ratio) {
+        if (!p.restored) return;
+        repaginate(ratio);
+    };
+    // Called from Kotlin's TTS highlight-follow with the highlighted element: turns to the page
+    // containing it (animated), clamped within the current pageCount so it can't itself trigger a
+    // chapter switch (TTS's own chapter handoff in Kotlin already owns that).
+    window.__tdPagedGoToElement = function (el) {
+        if (!enabled || !p.restored) return;
+        var idx = pageOfElement(el);
+        if (idx === null) return;
+        var pc = p.pageCount || computePageCount();
+        idx = Math.max(0, Math.min(idx, pc - 1));
+        if (idx === p.pageIndex) return;
+        p.lastRatio = pc > 0 ? (idx + 1) / pc : 0;
+        landOnPage(idx, pc, true);
+    };
+    // Called from Kotlin's restoreScrollPosition when paged mode is active, with the saved
+    // percent (0-1) - waits for the container to have real width before landing on the target
+    // page, then signals completion the same way the scroll-mode restore does.
+    window.__tdPagedRestoreRatio = function (ratio, token) {
+        var settled = false;
+        var ro = null;
+        function done() {
+            if (window.Android && window.Android.onScrollRestoreComplete) {
+                window.Android.onScrollRestoreComplete(token);
+            }
+        }
+        function disconnectRo() {
+            if (ro) { ro.disconnect(); ro = null; }
+        }
+        function attempt() {
+            if (settled) return true;
+            if (!enabled) { settled = true; disconnectRo(); done(); return true; }
+            var w = pageWidth();
+            if (w > 0 && container().scrollWidth > 0) {
+                settled = true;
+                disconnectRo();
+                repaginate(ratio);
+                p.restored = true;
+                done();
+                // One settle pass for layout that finishes shortly after restore (e.g. a native
+                // status-bar height correcting from its initial estimate) - same ratio, just
+                // re-measured against final geometry.
+                setTimeout(function () { if (enabled) repaginate(); }, 400);
+                return true;
+            }
+            return false;
+        }
+        if (attempt()) return;
+        if (typeof ResizeObserver === 'function') {
+            ro = new ResizeObserver(function () {
+                if (attempt()) disconnectRo();
+            });
+            ro.observe(document.body);
+        }
+        // Bounded rAF retry: force-settle at the deadline rather than leaving p.restored false forever.
+        var rafRetries = 0;
+        var MAX_RAF_RETRIES = 30;
+        (function rafLoop() {
+            if (attempt()) return;
+            rafRetries++;
+            if (rafRetries < MAX_RAF_RETRIES) {
+                requestAnimationFrame(rafLoop);
+                return;
+            }
+            settled = true;
+            disconnectRo();
+            repaginate(ratio);
+            p.restored = true;
+            done();
+        })();
+    };
+
+    if (!enabled) {
+        return;
+    }
+
+    document.documentElement.classList.add(PAGED_CLASS);
+    // Structure only - no repagination here. The initial page position is always driven by
+    // Kotlin's restoreScrollPosition() calling __tdPagedRestoreRatio() right after this script
+    // evaluates; self-repaginating here too would race that call and stomp the restored position.
+    container();
+    applyColumnLayout();
+
+    if (typeof ResizeObserver === 'function') {
+        var containerResizeObserver = new ResizeObserver(function () {
+            if (!p.restored) return;
+            repaginate();
+        });
+        containerResizeObserver.observe(container());
+        p.resizeObserver = containerResizeObserver;
+    }
+
+    var resizeDebounce = null;
+    window.addEventListener('resize', function () {
+        if (!p.restored) return;
+        clearTimeout(resizeDebounce);
+        resizeDebounce = setTimeout(function () { repaginate(); }, 100);
+    });
+})();

--- a/app/src/main/assets/novel-reader/scroll-tracking.js
+++ b/app/src/main/assets/novel-reader/scroll-tracking.js
@@ -1,7 +1,8 @@
 // Page-side scroll listener for the novel WebView reader.
 // Installed once per load via NovelWebViewStyler.injectScrollTracking(), which substitutes the
 // __TSUNDOKU_OBJECT_NAME__ / __CHAPTER_DIVIDER_CLASS__ / __CHAPTER_ID_ATTR__ /
-// __INFINITE_SCROLL_ENABLED__ / __LOAD_THRESHOLD__ / __DONE_THRESHOLD__ / __PROGRESS_EVENT__ tokens.
+// __INFINITE_SCROLL_ENABLED__ / __LOAD_THRESHOLD__ / __DONE_THRESHOLD__ / __PROGRESS_EVENT__ /
+// __PAGED_ENABLED__ tokens.
 //
 // Reports to the Android JS interface:
 //   onChapterScrollUpdate(chapterId, progress)  visible chapter changed
@@ -13,13 +14,16 @@
 //   runtime.progress / runtime.chapterProgress / runtime.currentChapterId  (updated every frame)
 //   window event __PROGRESS_EVENT__  { progress, chapterProgress, chapterId, isLast }
 //     dispatched JS-side (no Kotlin bridge hop), throttled with the slider bridge.
+//
+// Skipped entirely in paged mode (no vertical scroll there - paged-reader.js owns progress
+// reporting instead).
 
 (function () {
     window.__TSUNDOKU_OBJECT_NAME__ = window.__TSUNDOKU_OBJECT_NAME__ || {};
     window.__TSUNDOKU_OBJECT_NAME__.runtime = window.__TSUNDOKU_OBJECT_NAME__.runtime || {};
     var runtime = window.__TSUNDOKU_OBJECT_NAME__.runtime;
 
-    if (runtime.infiniteScrollInstalled) {
+    if (runtime.infiniteScrollInstalled || __PAGED_ENABLED__) {
         return;
     }
     runtime.infiniteScrollInstalled = true;

--- a/app/src/main/assets/novel-reader/scroll-tracking.js
+++ b/app/src/main/assets/novel-reader/scroll-tracking.js
@@ -212,9 +212,16 @@
         var scrollY = window.scrollY || window.pageYOffset || 0;
         // An inline loading/error banner appended past the last chapter is not chapter content -
         // it must not inflate the last chapter's height and skew its progress ratio while shown.
-        var trailingBanner = document.getElementById('inline-loading') || document.getElementById('inline-error');
-        var docEnd = trailingBanner
-            ? trailingBanner.getBoundingClientRect().top + scrollY
+        // The same banner id is reused for an upward (prepend) load, where it sits at
+        // document.body.firstChild - above every divider; treating that as the document end makes
+        // docEnd ~= 0 and corrupts every boundary height. Only honour it when it actually follows
+        // the last divider in DOM order.
+        var banner = document.getElementById('inline-loading') || document.getElementById('inline-error');
+        var lastDivider = dividers[dividers.length - 1];
+        var bannerTrails = !!banner && (!lastDivider ||
+            (lastDivider.compareDocumentPosition(banner) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0);
+        var docEnd = bannerTrails
+            ? banner.getBoundingClientRect().top + scrollY
             : document.body.scrollHeight;
         var boundaries = [];
         dividers.forEach(function (divider, index) {

--- a/app/src/main/assets/novel-reader/scroll-tracking.js
+++ b/app/src/main/assets/novel-reader/scroll-tracking.js
@@ -210,6 +210,12 @@
     window.updateChapterBoundaries = function () {
         var dividers = document.querySelectorAll('.__CHAPTER_DIVIDER_CLASS__');
         var scrollY = window.scrollY || window.pageYOffset || 0;
+        // An inline loading/error banner appended past the last chapter is not chapter content -
+        // it must not inflate the last chapter's height and skew its progress ratio while shown.
+        var trailingBanner = document.getElementById('inline-loading') || document.getElementById('inline-error');
+        var docEnd = trailingBanner
+            ? trailingBanner.getBoundingClientRect().top + scrollY
+            : document.body.scrollHeight;
         var boundaries = [];
         dividers.forEach(function (divider, index) {
             var chapterId = divider.getAttribute('__CHAPTER_ID_ATTR__');
@@ -218,7 +224,7 @@
             var nextDivider = dividers[index + 1];
             var endOffset = nextDivider
                 ? nextDivider.getBoundingClientRect().top + scrollY
-                : document.body.scrollHeight;
+                : docEnd;
             boundaries.push({
                 chapterId: chapterId,
                 startOffset: startOffset,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsNovelReaderScreen.kt
@@ -162,10 +162,6 @@ object SettingsNovelReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_fullscreen),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.showPageNumber,
-                    title = stringResource(MR.strings.pref_show_page_number),
-                ),
-                Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.novelShowProgressSlider,
                     title = "Show progress slider",
                 ),
@@ -255,6 +251,10 @@ object SettingsNovelReaderScreen : SearchableSettings {
     private fun getNavigationGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_reader_navigation),
+            // This screen is a global default with no per-series rendering-mode context (see the
+            // Content group below), and paged mode only ever applies to WebView-rendered novels -
+            // so Swipe navigation stays visible regardless of the paged-mode toggle, since it
+            // remains fully functional for TextView-rendered novels either way.
             preferenceItems = listOf(
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.novelVolumeKeysScroll,
@@ -355,60 +355,111 @@ object SettingsNovelReaderScreen : SearchableSettings {
     private fun getContentGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
         val autoLoadNextAt = readerPreferences.novelAutoLoadNextChapterAt.collectAsState().value
         val markAsReadThreshold = readerPreferences.novelMarkAsReadThreshold.collectAsState().value
+        val pagedModeEnabled = readerPreferences.novelPagedMode.collectAsState().value
+        val pagedDragCommitPercent = readerPreferences.novelPagedDragCommitPercent.collectAsState().value
 
         return Preference.PreferenceGroup(
             title = "Content",
-            preferenceItems = listOf(
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelInfiniteScroll,
-                    title = "Infinite scroll",
-                    subtitle = "Load next chapter automatically while scrolling",
-                ),
-                Preference.PreferenceItem.SliderPreference(
-                    value = autoLoadNextAt,
-                    valueRange = 50..100,
-                    title = "Auto-load next chapter at",
-                    valueString = "$autoLoadNextAt%",
-                    onValueChanged = { readerPreferences.novelAutoLoadNextChapterAt.set(it) },
-                ),
-                Preference.PreferenceItem.SliderPreference(
-                    value = markAsReadThreshold,
-                    valueRange = 50..100,
-                    title = "Mark chapter as read at",
-                    valueString = "$markAsReadThreshold%",
-                    onValueChanged = { readerPreferences.novelMarkAsReadThreshold.set(it) },
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelMarkShortChapterAsRead,
-                    title = "Auto-mark short chapters as read",
-                    subtitle = "If a chapter fits the screen without scrolling, mark it read immediately",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelHideChapterTitle,
-                    title = "Hide chapter title",
-                    subtitle = "Strip chapter title from content",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelBlockMedia,
-                    title = "Block media",
-                    subtitle = "Block images and media loading in both readers",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelTextSelectable,
-                    title = "Text selectable",
-                    subtitle = "Allow selecting and copying text in the reader",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelShowRawHtml,
-                    title = "Show raw HTML",
-                    subtitle = "Display HTML source instead of rendered content",
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.novelSourceCssPriority,
-                    title = "Source CSS priority",
-                    subtitle = "Allow embedded/source CSS to override reader theme colors",
-                ),
-            ),
+            // This screen is a global default with no per-series rendering-mode context (unlike
+            // the per-series reader settings, which correctly gate on renderingMode == "webview"),
+            // and paged mode only ever applies to WebView-rendered novels - so Infinite scroll /
+            // Auto-load next chapter stay visible here regardless of the paged-mode toggle, since
+            // they remain fully functional for TextView-rendered novels either way.
+            preferenceItems = buildList {
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelInfiniteScroll,
+                        title = "Infinite scroll",
+                        subtitle = "Load next chapter automatically while scrolling (non-paged reading only)",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelPagedMode,
+                        title = "Paged mode (WebView only, experimental)",
+                        subtitle = "Swipe/tap turns a page instead of scrolling; chapter changes only past the first/last page",
+                    ),
+                )
+                if (pagedModeEnabled) {
+                    add(
+                        Preference.PreferenceItem.SwitchPreference(
+                            preference = readerPreferences.novelPagedSwipeEnabled,
+                            title = "Swipe to turn pages",
+                            subtitle = "Turn off to navigate paged mode with tap zones only",
+                        ),
+                    )
+                    add(
+                        Preference.PreferenceItem.SliderPreference(
+                            value = pagedDragCommitPercent,
+                            valueRange = 5..50,
+                            title = stringResource(TDMR.strings.pref_novel_paged_drag_commit),
+                            subtitle = stringResource(TDMR.strings.pref_novel_paged_drag_commit_summary),
+                            valueString = "$pagedDragCommitPercent%",
+                            onValueChanged = { readerPreferences.novelPagedDragCommitPercent.set(it) },
+                        ),
+                    )
+                }
+                add(
+                    Preference.PreferenceItem.SliderPreference(
+                        value = autoLoadNextAt,
+                        valueRange = 50..100,
+                        title = "Auto-load next chapter at",
+                        valueString = "$autoLoadNextAt%",
+                        onValueChanged = { readerPreferences.novelAutoLoadNextChapterAt.set(it) },
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SliderPreference(
+                        value = markAsReadThreshold,
+                        valueRange = 50..100,
+                        title = "Mark chapter as read at",
+                        valueString = "$markAsReadThreshold%",
+                        onValueChanged = { readerPreferences.novelMarkAsReadThreshold.set(it) },
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelMarkShortChapterAsRead,
+                        title = "Auto-mark short chapters as read",
+                        subtitle = "If a chapter fits the screen without scrolling, mark it read immediately",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelHideChapterTitle,
+                        title = "Hide chapter title",
+                        subtitle = "Strip chapter title from content",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelBlockMedia,
+                        title = "Block media",
+                        subtitle = "Block images and media loading in both readers",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelTextSelectable,
+                        title = "Text selectable",
+                        subtitle = "Allow selecting and copying text in the reader",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelShowRawHtml,
+                        title = "Show raw HTML",
+                        subtitle = "Display HTML source instead of rendered content",
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = readerPreferences.novelSourceCssPriority,
+                        title = "Source CSS priority",
+                        subtitle = "Allow embedded/source CSS to override reader theme colors",
+                    ),
+                )
+            },
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/NovelStatusBar.kt
@@ -88,6 +88,8 @@ val EstimatedStatusBarHeight = 40.dp
 fun NovelStatusBar(
     chapterText: String?,
     progressPercent: Int,
+    pagedPageIndex: Int = 0,
+    pagedPageCount: Int = 0,
     order: List<StatusBarItem>,
     showTime: Boolean,
     showChapter: Boolean,
@@ -190,7 +192,12 @@ fun NovelStatusBar(
                         }
 
                         StatusBarItem.PROGRESS -> if (showProgress) {
-                            Text(text = "$progressPercent%", style = labelStyle, color = contentColor)
+                            val text = if (pagedPageCount > 0) {
+                                "${(pagedPageIndex + 1).coerceAtMost(pagedPageCount)}/$pagedPageCount"
+                            } else {
+                                "$progressPercent%"
+                            }
+                            Text(text = text, style = labelStyle, color = contentColor)
                         }
 
                         StatusBarItem.BATTERY -> if (showBattery && batteryPercent >= 0) {

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/NovelReaderAppBars.kt
@@ -115,6 +115,11 @@ fun NovelReaderAppBars(
     verticalProgressSliderSize: String,
     currentProgress: Int, // 0-100 percentage
     onProgressChange: (Int) -> Unit,
+    // Paged mode (webview only): current/total page, shown instead of the percentage when
+    // pagedPageCount > 0. Dragging the slider still works in percentage terms (setProgressPercent
+    // re-derives the target page from the percent).
+    pagedPageIndex: Int = 0,
+    pagedPageCount: Int = 0,
 
     // Bottom bar - navigation
     onNextChapter: () -> Unit,
@@ -129,6 +134,9 @@ fun NovelReaderAppBars(
     onScrollToTop: () -> Unit,
     isAutoScrolling: Boolean,
     onToggleAutoScroll: () -> Unit,
+    // Auto-scroll has no paged-mode equivalent - hide the bottom-bar button rather than leave a
+    // control that does nothing while paged mode is on.
+    hideAutoScroll: Boolean = false,
     isTranslating: Boolean,
     onToggleTranslation: () -> Unit,
     onLongPressTranslation: () -> Unit,
@@ -270,6 +278,8 @@ fun NovelReaderAppBars(
                             currentProgress = currentProgress,
                             onProgressChange = onProgressChange,
                             backgroundColor = backgroundColor,
+                            pagedPageIndex = pagedPageIndex,
+                            pagedPageCount = pagedPageCount,
                         )
                     }
 
@@ -288,6 +298,7 @@ fun NovelReaderAppBars(
                         onScrollToTop = onScrollToTop,
                         isAutoScrolling = isAutoScrolling,
                         onToggleAutoScroll = onToggleAutoScroll,
+                        hideAutoScroll = hideAutoScroll,
                         isTranslating = isTranslating,
                         onToggleTranslation = onToggleTranslation,
                         onLongPressTranslation = onLongPressTranslation,
@@ -418,6 +429,7 @@ private fun NovelReaderBottomBar(
     onScrollToTop: () -> Unit,
     isAutoScrolling: Boolean,
     onToggleAutoScroll: () -> Unit,
+    hideAutoScroll: Boolean,
     isTranslating: Boolean,
     onToggleTranslation: () -> Unit,
     onLongPressTranslation: () -> Unit,
@@ -431,8 +443,11 @@ private fun NovelReaderBottomBar(
     onQuotes: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val enabledItems = remember(items, isWebView) {
-        items.filter { it.enabled && (isWebView || it.item != BottomBarItem.EDIT) }
+    val enabledItems = remember(items, isWebView, hideAutoScroll) {
+        items.filter {
+            it.enabled && (isWebView || it.item != BottomBarItem.EDIT) &&
+                (!hideAutoScroll || it.item != BottomBarItem.AUTO_SCROLL)
+        }
     }
 
     Box(modifier = modifier) {
@@ -720,10 +735,15 @@ private fun NovelProgressSlider(
     onProgressChange: (Int) -> Unit,
     backgroundColor: Color,
     modifier: Modifier = Modifier,
+    pagedPageIndex: Int = 0,
+    pagedPageCount: Int = 0,
 ) {
     val haptic = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
     val sliderDragged by interactionSource.collectIsDraggedAsState()
+    val isPaged = pagedPageCount > 0
+    val pageLabel = "${(pagedPageIndex + 1).coerceAtMost(pagedPageCount)}/$pagedPageCount"
+    val maxPageLabel = "$pagedPageCount/$pagedPageCount"
 
     LaunchedEffect(currentProgress) {
         if (sliderDragged) {
@@ -738,11 +758,11 @@ private fun NovelProgressSlider(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Current progress percentage
+        // Current progress percentage, or "page N/M" while paged mode is active
         Box(contentAlignment = Alignment.CenterEnd) {
-            Text(text = "$currentProgress%")
+            Text(text = if (isPaged) pageLabel else "$currentProgress%")
             // Taking up full length so the slider doesn't shift
-            Text(text = "100%", color = Color.Transparent)
+            Text(text = if (isPaged) maxPageLabel else "100%", color = Color.Transparent)
         }
 
         Slider(
@@ -759,7 +779,7 @@ private fun NovelProgressSlider(
             interactionSource = interactionSource,
         )
 
-        Text(text = "100%")
+        Text(text = if (isPaged) maxPageLabel else "100%")
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/NovelPage.kt
@@ -546,14 +546,20 @@ internal fun ColumnScope.NovelAppearanceTab(viewModel: ReaderSettingsViewModel, 
 @Composable
 internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, renderingMode: String) {
     val autoScrollSpeed by viewModel.preferences.novelAutoScrollSpeed.collectAsState()
+    val pagedMode by viewModel.preferences.novelPagedMode.collectAsState()
+    val isWebviewPaged = renderingMode == "webview" && pagedMode
 
-    SliderItem(
-        label = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
-        value = autoScrollSpeed,
-        valueRange = 2..20,
-        valueString = "${autoScrollSpeed / 2f}",
-        onChange = { viewModel.preferences.novelAutoScrollSpeed.set(it) },
-    )
+    // Auto-scroll has no paged-mode equivalent (continuous scroll vs. discrete page turns), so
+    // hide it rather than leave a control that does nothing while paged mode is on.
+    if (!isWebviewPaged) {
+        SliderItem(
+            label = stringResource(TDMR.strings.pref_novel_auto_scroll_speed),
+            value = autoScrollSpeed,
+            valueRange = 2..20,
+            valueString = "${autoScrollSpeed / 2f}",
+            onChange = { viewModel.preferences.novelAutoScrollSpeed.set(it) },
+        )
+    }
 
     // Volume Keys to Scroll
     CheckboxItem(
@@ -616,19 +622,13 @@ internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, re
         else -> ReaderPreferences.TappingInvertMode.entries.map { it to it.titleRes }
     }
     if (invertOptions.isNotEmpty()) {
-        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
-            Text(
-                stringResource(MR.strings.pref_read_with_tapping_inverted),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            SettingsChipRow("") {
-                invertOptions.forEach { (entry, label) ->
-                    FilterChip(
-                        selected = entry == novelNavInverted,
-                        onClick = { viewModel.preferences.novelNavInverted.set(entry) },
-                        label = { Text(stringResource(label)) },
-                    )
-                }
+        SettingsChipRow(MR.strings.pref_read_with_tapping_inverted) {
+            invertOptions.forEach { (entry, label) ->
+                FilterChip(
+                    selected = entry == novelNavInverted,
+                    onClick = { viewModel.preferences.novelNavInverted.set(entry) },
+                    label = { Text(stringResource(label)) },
+                )
             }
         }
     }
@@ -644,11 +644,15 @@ internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, re
         )
     }
 
-    // Swipe Navigation
-    CheckboxItem(
-        label = stringResource(TDMR.strings.pref_novel_swipe_navigation),
-        pref = viewModel.preferences.novelSwipeNavigation,
-    )
+    // Swipe Navigation - paged mode's swipe IS the page-turn gesture, so this has no meaning
+    // while it's on. Gated on isWebviewPaged, not the raw pref: paged mode only ever applies to
+    // webview, so this setting must stay visible for a textview-rendered novel either way.
+    if (!isWebviewPaged) {
+        CheckboxItem(
+            label = stringResource(TDMR.strings.pref_novel_swipe_navigation),
+            pref = viewModel.preferences.novelSwipeNavigation,
+        )
+    }
 
     // Text Selection
     CheckboxItem(
@@ -672,37 +676,34 @@ internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, re
         stringResource(TDMR.strings.novel_vertical_scrollbar_left) to "vertical_left",
         stringResource(TDMR.strings.novel_vertical_scrollbar_right) to "vertical_right",
     )
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Text(stringResource(TDMR.strings.pref_novel_scrollbar_mode), style = MaterialTheme.typography.bodyMedium)
-        SettingsChipRow("") {
-            scrollbarModeOptions.forEach { (label, value) ->
-                FilterChip(
-                    selected = scrollbarMode == value,
-                    onClick = {
-                        when (value) {
-                            "none" -> {
-                                viewModel.preferences.novelShowProgressSlider.set(false)
-                                viewModel.preferences.novelVerticalScrollbar.set(false)
-                            }
-                            "horizontal" -> {
-                                viewModel.preferences.novelShowProgressSlider.set(true)
-                                viewModel.preferences.novelVerticalScrollbar.set(false)
-                            }
-                            "vertical_left" -> {
-                                viewModel.preferences.novelShowProgressSlider.set(true)
-                                viewModel.preferences.novelVerticalScrollbarPosition.set("left")
-                                viewModel.preferences.novelVerticalScrollbar.set(true)
-                            }
-                            "vertical_right" -> {
-                                viewModel.preferences.novelShowProgressSlider.set(true)
-                                viewModel.preferences.novelVerticalScrollbarPosition.set("right")
-                                viewModel.preferences.novelVerticalScrollbar.set(true)
-                            }
+    SettingsChipRow(TDMR.strings.pref_novel_scrollbar_mode) {
+        scrollbarModeOptions.forEach { (label, value) ->
+            FilterChip(
+                selected = scrollbarMode == value,
+                onClick = {
+                    when (value) {
+                        "none" -> {
+                            viewModel.preferences.novelShowProgressSlider.set(false)
+                            viewModel.preferences.novelVerticalScrollbar.set(false)
                         }
-                    },
-                    label = { Text(label) },
-                )
-            }
+                        "horizontal" -> {
+                            viewModel.preferences.novelShowProgressSlider.set(true)
+                            viewModel.preferences.novelVerticalScrollbar.set(false)
+                        }
+                        "vertical_left" -> {
+                            viewModel.preferences.novelShowProgressSlider.set(true)
+                            viewModel.preferences.novelVerticalScrollbarPosition.set("left")
+                            viewModel.preferences.novelVerticalScrollbar.set(true)
+                        }
+                        "vertical_right" -> {
+                            viewModel.preferences.novelShowProgressSlider.set(true)
+                            viewModel.preferences.novelVerticalScrollbarPosition.set("right")
+                            viewModel.preferences.novelVerticalScrollbar.set(true)
+                        }
+                    }
+                },
+                label = { Text(label) },
+            )
         }
     }
 
@@ -723,13 +724,33 @@ internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, re
         }
     }
 
-    // Infinite Scroll
+    // Infinite Scroll - gated on isWebviewPaged (see Swipe Navigation above): stays fully
+    // functional, and visible, for a textview-rendered novel regardless of the paged-mode pref.
     val infiniteScrollEnabled by viewModel.preferences.novelInfiniteScroll.collectAsState()
-    CheckboxItem(
-        label = stringResource(TDMR.strings.pref_novel_infinite_scroll),
-        checked = infiniteScrollEnabled,
-        onClick = { viewModel.preferences.novelInfiniteScroll.set(!infiniteScrollEnabled) },
-    )
+    if (!isWebviewPaged) {
+        CheckboxItem(
+            label = stringResource(TDMR.strings.pref_novel_infinite_scroll),
+            checked = infiniteScrollEnabled,
+            onClick = { viewModel.preferences.novelInfiniteScroll.set(!infiniteScrollEnabled) },
+        )
+    }
+
+    // Paged Mode (WebView only, experimental) - swipe/tap turns a page instead of scrolling.
+    // The page-number display only means anything once this is on, so it's shown right here
+    // rather than in the unrelated Display group.
+    if (renderingMode == "webview") {
+        CheckboxItem(
+            label = "Paged mode (experimental)",
+            checked = pagedMode,
+            onClick = { viewModel.preferences.novelPagedMode.set(!pagedMode) },
+        )
+        if (pagedMode) {
+            CheckboxItem(
+                label = "Swipe to turn pages",
+                pref = viewModel.preferences.novelPagedSwipeEnabled,
+            )
+        }
+    }
 
     // Auto-load next chapter at percentage (only relevant when infinite scroll is enabled)
     val autoLoadAt by viewModel.preferences.novelAutoLoadNextChapterAt.collectAsState()
@@ -739,7 +760,7 @@ internal fun ColumnScope.NovelControlsTab(viewModel: ReaderSettingsViewModel, re
             viewModel.preferences.novelAutoLoadNextChapterAt.set(95)
         }
     }
-    if (infiniteScrollEnabled) {
+    if (infiniteScrollEnabled && !isWebviewPaged) {
         val effectiveAutoLoadAt = if (autoLoadAt > 0) autoLoadAt else 95
         Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
             Text(stringResource(TDMR.strings.pref_novel_auto_load_next_at), style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1738,7 +1738,7 @@ class ReaderActivity : BaseActivity() {
                 return@launch
             }
             resetNovelPageInfoIfPaged()
-            viewModel.loadNextChapter()
+            if (!viewModel.loadNextChapter()) return@launch
             (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("next")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
             val isNovelViewer = viewModel.state.value.viewer is NovelViewer ||
@@ -1771,7 +1771,7 @@ class ReaderActivity : BaseActivity() {
                 return@launch
             }
             resetNovelPageInfoIfPaged()
-            viewModel.loadPreviousChapter()
+            if (!viewModel.loadPreviousChapter()) return@launch
             (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("prev")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
             val isNovelViewer = viewModel.state.value.viewer is NovelViewer ||

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -200,6 +200,7 @@ class ReaderActivity : BaseActivity() {
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
 
     private var loadingIndicator: ReaderProgressIndicator? = null
+    private var adjacentChapterProgressIndicator: ReaderProgressIndicator? = null
     private var ttsNotificationSyncJob: Job? = null
 
     private val ttsNotificationControlReceiver = object : BroadcastReceiver() {
@@ -303,15 +304,31 @@ class ReaderActivity : BaseActivity() {
             .map { it.isLoadingAdjacentChapter }
             .distinctUntilChanged()
             .onEach { isLoading ->
-                // Skip loading dialog for infinite scroll - the viewer handles inline indicators
                 val isNovelViewer = viewModel.state.value.viewer is NovelViewer ||
                     viewModel.state.value.viewer is NovelWebViewViewer
+                if (!isNovelViewer) {
+                    return@onEach
+                }
+                // Paged mode always does a full loadAdjacent switch, never an inline append, so
+                // it needs this indicator even with infinite scroll on.
                 val infiniteScrollEnabled = readerPreferences.novelInfiniteScroll.get()
-                if (isNovelViewer && infiniteScrollEnabled) {
-                    // Don't show popup for infinite scroll - viewer shows inline indicators
+                val isPagedMode = readerPreferences.novelPagedMode.get() &&
+                    viewModel.state.value.viewer is NovelWebViewViewer
+                if (infiniteScrollEnabled && !isPagedMode) {
                     return@onEach
                 }
                 setProgressDialog(isLoading)
+            }
+            .launchIn(lifecycleScope)
+
+        viewModel.state
+            .map { it.isLoadingAdjacentChapter }
+            .distinctUntilChanged()
+            .onEach { isLoading ->
+                if (isLoading || pendingAdjacentNavDirection == 0) return@onEach
+                val direction = pendingAdjacentNavDirection
+                pendingAdjacentNavDirection = 0
+                if (direction > 0) loadNextChapterInternal() else loadPreviousChapterInternal()
             }
             .launchIn(lifecycleScope)
 
@@ -498,6 +515,8 @@ class ReaderActivity : BaseActivity() {
                 NovelStatusBar(
                     chapterText = chapterText,
                     progressPercent = state.novelProgressPercent,
+                    pagedPageIndex = effectivePagedPageIndex(state),
+                    pagedPageCount = effectivePagedPageCount(state),
                     order = statusBarOrder,
                     showTime = novelStatusBarShowTime,
                     showChapter = showChapterSegment,
@@ -819,6 +838,7 @@ class ReaderActivity : BaseActivity() {
 
         if (isNovelViewer) {
             var isAutoScrolling by remember { mutableStateOf(false) }
+            val novelPagedModeState by readerPreferences.novelPagedMode.collectAsState()
 
             // Get common callbacks that work for both viewer types
             val onScrollToTop: () -> Unit = {
@@ -950,6 +970,8 @@ class ReaderActivity : BaseActivity() {
                 progressSliderMode = progressSliderMode,
                 verticalProgressSliderSize = verticalProgressSliderSize,
                 currentProgress = novelProgressFromState,
+                pagedPageIndex = effectivePagedPageIndex(state),
+                pagedPageCount = effectivePagedPageCount(state),
                 onProgressChange = { newProgress ->
                     viewModel.updateNovelProgressPercent(newProgress)
                     // A seek is an explicit position choice; a running autoscroll would immediately
@@ -973,35 +995,75 @@ class ReaderActivity : BaseActivity() {
                 },
 
                 onNextChapter = {
-                    loadNextChapter()
-                    // Sync slider after navigation
-                    lifecycleScope.launch {
-                        delay(100)
-                        val viewer = viewModel.state.value.viewer
-                        val progress = when (viewer) {
-                            is NovelViewer -> viewer.getProgressPercent()
-                            is NovelWebViewViewer -> viewer.getProgressPercent()
-                            else -> 0
+                    val viewer = viewModel.state.value.viewer
+                    when {
+                        viewer is NovelWebViewViewer && viewer.isPagedModeActive() -> {
+                            // Paged mode: the bottom-bar arrows turn a page, same as tap zones/volume
+                            // keys; paged-reader.js itself handles overflow past the last page as a
+                            // chapter switch, so this never needs to fall through to loadNextChapter().
+                            viewer.turnPage(forward = true)
                         }
-                        viewModel.updateNovelProgressPercent(progress)
+                        viewer is NovelWebViewViewer -> {
+                            // No poll-after-delay needed here: restoreScrollPosition() already pushes
+                            // the new chapter's progress via onNovelProgressChanged the moment its
+                            // document finishes loading, regardless of how long that takes - a fixed
+                            // delay here could only either duplicate that (harmless) or fire first and
+                            // re-apply a stale value from the outgoing chapter (a real, if brief, wrong
+                            // slider read).
+                            loadNextChapter()
+                        }
+                        else -> {
+                            loadNextChapter()
+                            // Sync slider after navigation
+                            lifecycleScope.launch {
+                                delay(100)
+                                val progress = (viewModel.state.value.viewer as? NovelViewer)?.getProgressPercent() ?: 0
+                                viewModel.updateNovelProgressPercent(progress)
+                            }
+                        }
                     }
                 },
-                enabledNext = state.viewerChapters?.nextChapter != null,
+                // In paged mode the arrows turn a page first, only falling through to a chapter
+                // change once the current chapter's last/first page is reached - so they must stay
+                // enabled while pages remain, even with no next/previous chapter to fall through to.
+                // effectivePagedPageCount(state) == 0 means onPageInfoChanged hasn't reported yet
+                // (right after a chapter switch) - assume enabled rather than flashing disabled on
+                // a true last/first chapter for the moment before the real page count arrives.
+                enabledNext = state.viewerChapters?.nextChapter != null ||
+                    (
+                        isPagedActive(state) &&
+                            (
+                                effectivePagedPageCount(state) == 0 ||
+                                    effectivePagedPageIndex(state) < effectivePagedPageCount(state) - 1
+                                )
+                        ),
                 onPreviousChapter = {
-                    loadPreviousChapter()
-                    // Sync slider after navigation
-                    lifecycleScope.launch {
-                        delay(100)
-                        val viewer = viewModel.state.value.viewer
-                        val progress = when (viewer) {
-                            is NovelViewer -> viewer.getProgressPercent()
-                            is NovelWebViewViewer -> viewer.getProgressPercent()
-                            else -> 0
+                    val viewer = viewModel.state.value.viewer
+                    when {
+                        viewer is NovelWebViewViewer && viewer.isPagedModeActive() -> {
+                            viewer.turnPage(forward = false)
                         }
-                        viewModel.updateNovelProgressPercent(progress)
+                        viewer is NovelWebViewViewer -> {
+                            // See onNextChapter above: restoreScrollPosition() already syncs the
+                            // slider eagerly, no delay-then-poll needed.
+                            loadPreviousChapter()
+                        }
+                        else -> {
+                            loadPreviousChapter()
+                            // Sync slider after navigation
+                            lifecycleScope.launch {
+                                delay(100)
+                                val progress = (viewModel.state.value.viewer as? NovelViewer)?.getProgressPercent() ?: 0
+                                viewModel.updateNovelProgressPercent(progress)
+                            }
+                        }
                     }
                 },
-                enabledPrevious = state.viewerChapters?.prevChapter != null,
+                enabledPrevious = state.viewerChapters?.prevChapter != null ||
+                    (
+                        isPagedActive(state) &&
+                            (effectivePagedPageCount(state) == 0 || effectivePagedPageIndex(state) > 0)
+                        ),
 
                 orientation = ReaderOrientation.fromPreference(
                     viewModel.getMangaOrientation(resolveDefault = false),
@@ -1011,6 +1073,7 @@ class ReaderActivity : BaseActivity() {
                 onScrollToTop = onScrollToTop,
                 isAutoScrolling = isAutoScrolling,
                 onToggleAutoScroll = onToggleAutoScroll,
+                hideAutoScroll = state.viewer is NovelWebViewViewer && novelPagedModeState,
                 isTranslating = state.isTranslating,
                 onToggleTranslation = viewModel::toggleTranslation,
                 onLongPressTranslation = viewModel::openTranslationLanguageDialog,
@@ -1619,13 +1682,20 @@ class ReaderActivity : BaseActivity() {
     }
 
     /**
-     * Called from the presenter whenever it's loading the next or previous chapter. It shows or
-     * dismisses a non-cancellable dialog to prevent user interaction according to the value of
-     * [show]. This is only used when the next/previous buttons on the toolbar are clicked; the
-     * other cases are handled with chapter transitions on the viewers and chapter preloading.
+     * Called from the presenter whenever it's loading the next or previous chapter. Only used for
+     * the toolbar next/prev buttons and paged-mode edge crossings; other cases show their own
+     * inline indicators.
      */
-    @Suppress("UNUSED_PARAMETER")
     private fun setProgressDialog(show: Boolean) {
+        if (show) {
+            if (adjacentChapterProgressIndicator == null) {
+                adjacentChapterProgressIndicator = ReaderProgressIndicator(this)
+                binding.readerContainer.addView(adjacentChapterProgressIndicator)
+            }
+        } else {
+            adjacentChapterProgressIndicator?.let { binding.readerContainer.removeView(it) }
+            adjacentChapterProgressIndicator = null
+        }
     }
 
     /**
@@ -1659,6 +1729,15 @@ class ReaderActivity : BaseActivity() {
 
     private fun loadNextChapterInternal() {
         lifecycleScope.launch {
+            if (viewModel.state.value.isLoadingAdjacentChapter) {
+                // Don't drop this navigation silently - a paged-mode edge-crossing swipe (or the
+                // toolbar button) racing an in-flight adjacent-chapter load (e.g. TTS auto-play's
+                // own handoff) would otherwise be swallowed with no feedback and leave a paged
+                // edge-crossing latch pending on the unrelated load's completion.
+                pendingAdjacentNavDirection = 1
+                return@launch
+            }
+            resetNovelPageInfoIfPaged()
             viewModel.loadNextChapter()
             (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("next")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
@@ -1677,7 +1756,21 @@ class ReaderActivity : BaseActivity() {
      */
     internal fun loadPreviousChapter() {
         stopNovelTtsForManualNav()
+        loadPreviousChapterInternal()
+    }
+
+    // Tracks a nav request dropped because isLoadingAdjacentChapter was already true: 1 = next,
+    // -1 = previous, 0 = none pending. Replayed once that in-flight load finishes (see the
+    // isLoadingAdjacentChapter collector in onCreate).
+    private var pendingAdjacentNavDirection = 0
+
+    private fun loadPreviousChapterInternal() {
         lifecycleScope.launch {
+            if (viewModel.state.value.isLoadingAdjacentChapter) {
+                pendingAdjacentNavDirection = -1
+                return@launch
+            }
+            resetNovelPageInfoIfPaged()
             viewModel.loadPreviousChapter()
             (viewModel.state.value.viewer as? NovelWebViewViewer)?.onChapterNavigate("prev")
             // Only reset to page 0 if NOT using infinite scroll for novel viewers
@@ -1716,8 +1809,8 @@ class ReaderActivity : BaseActivity() {
      * Called from the novel viewer to save reading progress with a percentage.
      * Progress is stored as percentage (0-100) in last_page_read.
      */
-    fun saveNovelProgress(page: ReaderPage, progressPercentage: Int) {
-        viewModel.saveNovelProgress(page, progressPercentage)
+    fun saveNovelProgress(page: ReaderPage, progressPercentage: Int, backwardJumpAllowancePercent: Int = 10) {
+        viewModel.saveNovelProgress(page, progressPercentage, backwardJumpAllowancePercent)
     }
 
     /**
@@ -1727,6 +1820,30 @@ class ReaderActivity : BaseActivity() {
     fun onNovelProgressChanged(progress: Float) {
         val percentage = (progress * 100).roundToInt().coerceIn(0, 100)
         viewModel.updateNovelProgressPercent(percentage)
+    }
+
+    fun onNovelPageInfoChanged(pageIndex: Int, pageCount: Int) {
+        viewModel.updateNovelPageInfo(pageIndex, pageCount)
+    }
+
+    // Guards against novelPageIndex/novelPageCount left over from a previous webview+paged
+    // session - the viewer never resets that state on its own (paged-reader.js just stops
+    // calling onPageInfoChanged when disabled/torn down), so it's only trustworthy while the
+    // ACTIVE viewer is actually paged.
+    private fun isPagedActive(state: ReaderViewModel.State) =
+        (state.viewer as? NovelWebViewViewer)?.isPagedModeActive() == true
+    private fun effectivePagedPageIndex(state: ReaderViewModel.State) =
+        if (isPagedActive(state)) state.novelPageIndex else 0
+    private fun effectivePagedPageCount(state: ReaderViewModel.State) =
+        if (isPagedActive(state)) state.novelPageCount else 0
+
+    // Called right before a paged-mode chapter switch starts: the new chapter's page info only
+    // arrives later (async, once __tdPagedRestoreRatio finishes), so without this the status bar
+    // would keep showing the outgoing chapter's page index/count in the meantime.
+    private fun resetNovelPageInfoIfPaged() {
+        if (isPagedActive(viewModel.state.value)) {
+            viewModel.updateNovelPageInfo(0, 0)
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -767,7 +767,7 @@ class ReaderViewModel @JvmOverloads constructor(
      * Saves reading progress for novel chapters using percentage (0-100).
      * Used by NovelViewer to save scroll position.
      */
-    fun saveNovelProgress(page: ReaderPage, progressPercentage: Int) {
+    fun saveNovelProgress(page: ReaderPage, progressPercentage: Int, backwardJumpAllowancePercent: Int = 10) {
         val selectedChapter = page.chapter
 
         if (incognitoMode) return
@@ -782,10 +782,13 @@ class ReaderViewModel @JvmOverloads constructor(
                 // Skip save if progress hasn't changed at all
                 if (clampedProgress == currentProgress) return@withLock
 
-                // Reject large backward jumps (>10%), including spurious 0% reports that
-                // fire during relayout/recreation (e.g. orientation lock). A 0 used to be
-                // exempted here, which let a transient 0 wipe real progress on reopen.
-                if (clampedProgress < currentProgress - 10) {
+                // Reject large backward jumps, including spurious 0% reports that fire during
+                // relayout/recreation (e.g. orientation lock). A 0 used to be exempted here,
+                // which let a transient 0 wipe real progress on reopen. The allowance is normally
+                // 10%; paged mode passes ceil(100/pageCount)% instead (see
+                // NovelWebViewViewer.saveProgress), since one page of a short chapter can
+                // legitimately be a >10% jump - but only that much, not an unconditional bypass.
+                if (clampedProgress < currentProgress - backwardJumpAllowancePercent) {
                     logcat(LogPriority.DEBUG) {
                         "NovelProgress: Skipping save - new progress $clampedProgress% is much less than current $currentProgress%"
                     }
@@ -839,6 +842,10 @@ class ReaderViewModel @JvmOverloads constructor(
         val clamped = progress.coerceIn(0, 100)
         mutableState.update { it.copy(novelProgressPercent = clamped) }
         novelScrollProgress = clamped
+    }
+
+    fun updateNovelPageInfo(pageIndex: Int, pageCount: Int) {
+        mutableState.update { it.copy(novelPageIndex = pageIndex, novelPageCount = pageCount) }
     }
 
     private fun downloadNextChapters() {
@@ -1588,6 +1595,11 @@ class ReaderViewModel @JvmOverloads constructor(
          * Current reading progress for novel viewer (0-100 percentage).
          */
         val novelProgressPercent: Int = 0,
+        /**
+         * Current/total page in the novel webview paged reader (0/0 when paged mode is off).
+         */
+        val novelPageIndex: Int = 0,
+        val novelPageCount: Int = 0,
 
         /**
          * Whether translation is enabled for the current chapter.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -409,7 +409,17 @@ class ReaderViewModel @JvmOverloads constructor(
         chapter: ReaderChapter,
         forceFromSource: Boolean = false,
     ): ViewerChapters {
-        loader.loadChapter(chapter, forceFromSource)
+        // Capture instead of letting this propagate immediately, so viewerChapters below still
+        // updates to the errored chapter (chapter.state is already Error(e), set by loader) and the
+        // viewer gets a chance to show it via setChapters.
+        val loadError = try {
+            loader.loadChapter(chapter, forceFromSource)
+            null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            e
+        }
 
         val chapterPos = chapterList.indexOf(chapter)
         val newChapters = ViewerChapters(
@@ -431,6 +441,8 @@ class ReaderViewModel @JvmOverloads constructor(
                 )
             }
         }
+
+        if (loadError != null) throw loadError
 
         // Prioritize this chapter for translation if it's a novel and translation is enabled
         enqueueTranslationIfNeeded(chapter)
@@ -464,12 +476,17 @@ class ReaderViewModel @JvmOverloads constructor(
     /**
      * Called when the user is going to load the prev/next chapter through the toolbar buttons.
      */
-    private suspend fun loadAdjacent(chapter: ReaderChapter) {
-        val loader = loader ?: return
+    private suspend fun loadAdjacent(chapter: ReaderChapter): Boolean {
+        val loader = loader ?: return false
+        if (state.value.isLoadingAdjacentChapter) return false
 
         logcat { "Loading adjacent ${chapter.chapter.url}" }
 
         mutableState.update { it.copy(isLoadingAdjacentChapter = true) }
+        // loadChapter already surfaces a failure to the viewer (chapter.state = Error triggers
+        // displayError() via setChapters), so this catch only needs to stop the caller from
+        // treating the switch as successful - see the false return below.
+        var success = true
         try {
             withIOContext {
                 loadChapter(loader, chapter)
@@ -479,9 +496,11 @@ class ReaderViewModel @JvmOverloads constructor(
                 throw e
             }
             logcat(LogPriority.ERROR, e)
+            success = false
         } finally {
             mutableState.update { it.copy(isLoadingAdjacentChapter = false) }
         }
+        return success
     }
 
     /**
@@ -1063,17 +1082,17 @@ class ReaderViewModel @JvmOverloads constructor(
     /**
      * Called from the activity to load and set the next chapter as active.
      */
-    suspend fun loadNextChapter() {
-        val nextChapter = state.value.viewerChapters?.nextChapter ?: return
-        loadAdjacent(nextChapter)
+    suspend fun loadNextChapter(): Boolean {
+        val nextChapter = state.value.viewerChapters?.nextChapter ?: return false
+        return loadAdjacent(nextChapter)
     }
 
     /**
      * Called from the activity to load and set the previous chapter as active.
      */
-    suspend fun loadPreviousChapter() {
-        val prevChapter = state.value.viewerChapters?.prevChapter ?: return
-        loadAdjacent(prevChapter)
+    suspend fun loadPreviousChapter(): Boolean {
+        val prevChapter = state.value.viewerChapters?.prevChapter ?: return false
+        return loadAdjacent(prevChapter)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -301,6 +301,19 @@ class ReaderPreferences(
     // Infinite scroll - automatically load next/previous chapters
     val novelInfiniteScroll: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_infinite_scroll", false)
 
+    // Paged mode (webview only) - swipe/tap left-right turns a page instead of scrolling;
+    // chapter navigation happens only when a page turn overflows past the first/last page.
+    val novelPagedMode: Preference<Boolean> = preferenceStore.getBoolean("pref_novel_paged_mode", false)
+
+    // Whether swipe/drag turns a page while paged mode is on (tap zones always work regardless -
+    // this only controls the swipe gesture, for users who want tap-only navigation).
+    val novelPagedSwipeEnabled: Preference<Boolean> =
+        preferenceStore.getBoolean("pref_novel_paged_swipe_enabled", true)
+
+    // Swipe distance (percent of width) needed to commit a page turn in paged mode
+    val novelPagedDragCommitPercent: Preference<Int> =
+        preferenceStore.getInt("pref_novel_paged_drag_commit_percent", 15)
+
     // Keep chapters loaded in memory (0 = only current, 1 = current + prev, 2 = current + next, 3 = both)
     val novelKeepChaptersLoaded: Preference<Int> = preferenceStore.getInt("pref_novel_keep_chapters_loaded", 0)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ChapterQueue.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ChapterQueue.kt
@@ -44,6 +44,24 @@ class ChapterQueue<T>(private val idOf: (T) -> Long?) {
 
     fun indexOf(chapterId: Long): Int = items.indexOfFirst { idOf(it) == chapterId }
 
+    /** Removes and returns the most recently appended item, leaving `currentIndex` untouched. */
+    fun removeLast(): T? {
+        if (items.isEmpty()) return null
+        val removed = items.removeAt(items.size - 1)
+        idOf(removed)?.let { ids.remove(it) }
+        return removed
+    }
+
+    fun removeById(chapterId: Long?): T? {
+        if (chapterId == null) return null
+        val index = indexOf(chapterId)
+        if (index < 0) return null
+        val removed = items.removeAt(index)
+        ids.remove(chapterId)
+        if (index <= currentIndex) currentIndex = (currentIndex - 1).coerceAtLeast(0)
+        return removed
+    }
+
     fun removeFirst(): T? {
         if (items.isEmpty()) return null
         val removed = items.removeAt(0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ErrorFormatter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ErrorFormatter.kt
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
 
 object ErrorFormatter {
 
@@ -56,6 +57,7 @@ object ErrorFormatter {
     fun categorize(e: Throwable): Category = when (e) {
         is UnknownHostException -> Category.NetworkHostNotFound
         is SocketTimeoutException -> Category.NetworkTimeout
+        is TimeoutException -> Category.NetworkTimeout
         is ConnectException -> Category.NetworkRefused
         is FileNotFoundException -> Category.FileNotFound
         is IOException -> Category.NetworkIO

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/NovelProgress.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/NovelProgress.kt
@@ -15,10 +15,15 @@ object NovelProgress {
     const val DONE_THRESHOLD = 0.99f
 
     /**
-     * After a failed next-chapter append, suppress auto-load for this long so a chapter that keeps
-     * failing at the bottom can't respawn a request every scroll frame. Shared by both renderers.
+     * Minimum non-whitespace length for extracted chapter text to count as real content.
+     * Deliberately low - some real chapters are only a sentence or two; this only catches
+     * near-empty output, not "suspiciously short".
      */
-    const val NEXT_LOAD_RETRY_COOLDOWN_MS = 15_000L
+    const val MIN_USABLE_CONTENT_CHARS = 10
+
+    /** True when [text] has enough extracted (post-pipeline) content to display/append. */
+    fun isUsableChapterText(text: String?): Boolean =
+        text != null && text.count { !it.isWhitespace() } >= MIN_USABLE_CONTENT_CHARS
 
     /** Snap a near-complete ratio to a clean 1f so the stored percent lands on 100. */
     fun snapProgress(progress: Float): Float = if (progress >= DONE_THRESHOLD) 1f else progress

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextViewInlineFeedback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelTextViewInlineFeedback.kt
@@ -1,13 +1,22 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text.textview
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
+import android.graphics.Typeface
 import android.view.Gravity
+import android.view.View
+import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.ErrorFormatter
+import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.localized
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.novel.TDMR
 
 internal class NovelTextViewInlineFeedback(
     private val context: Context,
@@ -16,7 +25,7 @@ internal class NovelTextViewInlineFeedback(
 ) {
 
     private var inlineLoadingView: TextView? = null
-    private var inlineErrorView: TextView? = null
+    private var inlineErrorView: View? = null
 
     fun showInlineLoading(isPrepend: Boolean) {
         if (inlineLoadingView != null) return
@@ -40,12 +49,15 @@ internal class NovelTextViewInlineFeedback(
         inlineLoadingView = null
     }
 
-    @android.annotation.SuppressLint("SetTextI18n")
     fun showInlineError(message: String, isPrepend: Boolean, onRetry: (() -> Unit)? = null) {
         inlineErrorView?.let { contentContainer.removeView(it) }
 
-        inlineErrorView = TextView(context).apply {
-            text = if (onRetry != null) "$message (tap to retry)" else "$message (tap to dismiss)"
+        val view = TextView(context).apply {
+            text = if (onRetry != null) {
+                context.stringResource(TDMR.strings.novel_inline_tap_to_retry, message)
+            } else {
+                context.stringResource(TDMR.strings.novel_inline_tap_to_dismiss, message)
+            }
             textSize = 14f
             setTextColor(0xFFFF5252.toInt())
             setBackgroundColor(0x1AFF5252)
@@ -64,20 +76,105 @@ internal class NovelTextViewInlineFeedback(
                 onRetry?.invoke()
             }
         }
+        inlineErrorView = view
 
-        val view = inlineErrorView ?: return
         if (isPrepend) {
             contentContainer.addView(view, 0)
         } else {
             contentContainer.addView(view)
         }
 
-        scope.launch {
-            delay(AUTO_DISMISS_MS)
-            if (inlineErrorView == view) {
-                contentContainer.removeView(view)
-                inlineErrorView = null
+        // A retryable banner stays until tapped - that's the only way to retry.
+        if (onRetry == null) {
+            scope.launch {
+                delay(AUTO_DISMISS_MS)
+                if (inlineErrorView == view) {
+                    contentContainer.removeView(view)
+                    inlineErrorView = null
+                }
             }
+        }
+    }
+
+    /** Rich variant for an actual load failure: real category/summary + Retry + Copy, not a generic string. */
+    fun showInlineError(error: Throwable, isPrepend: Boolean, onRetry: (() -> Unit)? = null) {
+        inlineErrorView?.let { contentContainer.removeView(it) }
+        val fmt = ErrorFormatter.format(error)
+
+        val container = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setBackgroundColor(0x1AFF5252)
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                topMargin = 48
+                bottomMargin = 48
+            }
+            setPadding(24, 24, 24, 24)
+        }
+
+        val categoryView = TextView(context).apply {
+            text = fmt.category.localized(context)
+            textSize = 14f
+            setTextColor(0xFFFF5252.toInt())
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+        }
+        val summaryView = TextView(context).apply {
+            text = fmt.summary
+            textSize = 13f
+            setTextColor(0xFF888888.toInt())
+            gravity = Gravity.CENTER
+            setPadding(0, 8, 0, 16)
+        }
+
+        val buttonRow = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+        }
+
+        if (onRetry != null) {
+            val retryButton = Button(context).apply {
+                text = context.stringResource(TDMR.strings.novel_error_retry)
+                isAllCaps = false
+                textSize = 13f
+                setTextColor(0xFF4A90D9.toInt())
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                ).apply { marginEnd = 16 }
+                setOnClickListener {
+                    contentContainer.removeView(container)
+                    inlineErrorView = null
+                    onRetry.invoke()
+                }
+            }
+            buttonRow.addView(retryButton)
+        }
+
+        val copyButton = Button(context).apply {
+            text = context.stringResource(TDMR.strings.novel_error_copy_details)
+            isAllCaps = false
+            textSize = 13f
+            setOnClickListener {
+                val cm = context.getSystemService(ClipboardManager::class.java)
+                cm.setPrimaryClip(ClipData.newPlainText("error", fmt.stackTrace))
+                context.toast(context.stringResource(TDMR.strings.novel_error_copied))
+            }
+        }
+        buttonRow.addView(copyButton)
+
+        container.addView(categoryView)
+        container.addView(summaryView)
+        container.addView(buttonRow)
+
+        inlineErrorView = container
+        if (isPrepend) {
+            contentContainer.addView(container, 0)
+        } else {
+            contentContainer.addView(container)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -152,9 +152,9 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
     // Latched once the novel has no further chapter to append.
     private var reachedNovelEnd = false
 
-    // Suppresses auto-load for NEXT_LOAD_RETRY_COOLDOWN_MS after a failure so a chapter that keeps
-    // timing out at the bottom can't respawn a request every scroll frame.
-    private var lastNextLoadFailedAt = 0L
+    // Set after a failed infinite-scroll append; blocks auto-append retries until the user taps
+    // the inline error banner (never auto-retries on its own).
+    private var nextLoadRequiresManualRetry = false
 
     // Blocks flushing the backward-entry 1f baseline until a real scroll sample replaces it.
     private var awaitingFirstScrollSample = false
@@ -333,12 +333,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 // chunks and during pause/resume, causing the scroll listener to start a
                 // visible chapter fetch while TTS still owns the chapter transition.
                 val ttsIsDrivingChapterHandoff = ttsController.isTtsAutoPlay
-                val inFailureCooldown =
-                    System.currentTimeMillis() - lastNextLoadFailedAt < NovelProgress.NEXT_LOAD_RETRY_COOLDOWN_MS
                 if (!isRestoringScroll && !ttsIsDrivingChapterHandoff && chapterProgress >= effectiveThreshold &&
                     !isLoadingNext &&
                     !reachedNovelEnd &&
-                    !inFailureCooldown &&
+                    !nextLoadRequiresManualRetry &&
                     onLastLoaded
                 ) {
                     logcat(LogPriority.DEBUG) {
@@ -550,7 +548,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             logcat(LogPriority.ERROR) {
                 "NovelViewer: loadNext failed, no anchor (loadedCount=${loadedChapters.size})"
             }
-            inlineFeedback.showInlineError("No anchor chapter for infinite scroll", isPrepend = false)
+            inlineFeedback.showInlineError(
+                activity.stringResource(TDMR.strings.novel_error_no_anchor_chapter),
+                isPrepend = false,
+            )
             return
         }
 
@@ -564,7 +565,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         }
 
         val retry = {
-            lastNextLoadFailedAt = 0L
+            nextLoadRequiresManualRetry = false
             loadNextChapterIfAvailable()
         }
         var loadFailed = false
@@ -574,7 +575,12 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                 val preparedChapter = activity.viewModel.prepareNextChapterForInfiniteScroll(anchor) ?: run {
                     logcat(LogPriority.WARN) { "NovelViewer: No next chapter after ${anchor.chapter.name}" }
                     // Surface once, then latch so the scroll listener stops re-triggering.
-                    if (!reachedNovelEnd) inlineFeedback.showInlineError("No next chapter available", isPrepend = false)
+                    if (!reachedNovelEnd) {
+                        inlineFeedback.showInlineError(
+                            activity.stringResource(TDMR.strings.novel_error_no_next_chapter_available),
+                            isPrepend = false,
+                        )
+                    }
                     reachedNovelEnd = true
                     return@launch
                 }
@@ -589,15 +595,28 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     return@launch
                 }
                 val page = preparedChapter.pages?.firstOrNull() ?: run {
-                    logcat(LogPriority.ERROR) { "NovelViewer: No page in prepared next chapter" }
+                    val prepareError = (preparedChapter.state as? ReaderChapter.State.Error)?.error
+                    logcat(LogPriority.ERROR) { "NovelViewer: No page in prepared next chapter, prepareError=$prepareError" }
                     loadFailed = true
-                    inlineFeedback.showInlineError("No page in next chapter", isPrepend = false, onRetry = retry)
+                    if (prepareError != null) {
+                        inlineFeedback.showInlineError(prepareError, isPrepend = false, onRetry = retry)
+                    } else {
+                        inlineFeedback.showInlineError(
+                            activity.stringResource(TDMR.strings.novel_error_no_page_in_next_chapter),
+                            isPrepend = false,
+                            onRetry = retry,
+                        )
+                    }
                     return@launch
                 }
                 val loader = page.chapter.pageLoader ?: run {
                     logcat(LogPriority.ERROR) { "NovelViewer: No loader for next chapter" }
                     loadFailed = true
-                    inlineFeedback.showInlineError("No loader for next chapter", isPrepend = false, onRetry = retry)
+                    inlineFeedback.showInlineError(
+                        activity.stringResource(TDMR.strings.novel_error_no_loader_next_chapter),
+                        isPrepend = false,
+                        onRetry = retry,
+                    )
                     return@launch
                 }
 
@@ -606,38 +625,47 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     "NovelViewer: loading page for next ${preparedChapter.chapter.id}, state=${page.status}"
                 }
 
-                val loaded = try {
-                    awaitPageText(page = page, loader = loader, timeoutMs = 30_000)
+                val loadError: Throwable? = try {
+                    val loaded = awaitPageText(page = page, loader = loader, timeoutMs = 30_000)
+                    if (loaded) {
+                        null
+                    } else {
+                        (page.status as? Page.State.Error)?.error
+                            ?: Exception(activity.stringResource(TDMR.strings.novel_error_couldnt_load_next_chapter))
+                    }
                 } catch (_: TimeoutCancellationException) {
                     logcat(LogPriority.ERROR) { "NovelViewer: Timed out loading next chapter page after 30s" }
-                    false
+                    java.util.concurrent.TimeoutException(
+                        activity.stringResource(TDMR.strings.novel_error_timeout_next_chapter),
+                    )
                 } catch (_: CancellationException) {
-                    // Reader was closed/navigated away; don't surface as an error or latch a cooldown.
                     logcat(LogPriority.DEBUG) { "NovelViewer: loadNext cancelled" }
                     return@launch
                 } catch (e: Exception) {
                     logcat(LogPriority.ERROR) { "NovelViewer: Error loading next chapter page: ${e.message}" }
-                    false
+                    e
                 }
 
-                // Covers both a thrown failure and a page cached in Error state (returns false
-                // without throwing), so a chapter that keeps failing always latches the cooldown.
-                if (!loaded) {
+                if (loadError != null) {
                     loadFailed = true
-                    inlineFeedback.showInlineError("Couldn't load next chapter", isPrepend = false, onRetry = retry)
+                    inlineFeedback.showInlineError(
+                        loadError,
+                        isPrepend = false,
+                        onRetry = retry,
+                    )
                     return@launch
                 }
 
                 logcat(LogPriority.DEBUG) { "NovelViewer: appending chapter ${preparedChapter.chapter.id}" }
                 displayChapter(preparedChapter, page)
-                lastNextLoadFailedAt = 0L
                 logcat(LogPriority.INFO) {
                     "NovelViewer: Successfully appended next chapter ${preparedChapter.chapter.name}"
                 }
             } finally {
                 inlineFeedback.hideInlineLoading()
                 isLoadingNext = false
-                if (loadFailed) lastNextLoadFailedAt = System.currentTimeMillis()
+                // displayChapter's own usability check can still set this back to true afterward.
+                nextLoadRequiresManualRetry = loadFailed
             }
         }
     }
@@ -1385,6 +1413,15 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
 
     override fun setChapters(chapters: ViewerChapters) {
         renderGeneration++
+        // A getPageList failure leaves the chapter in Error state with no pages - must be checked
+        // before the null-pages early return below, which would otherwise swallow it silently.
+        val chapterLoadError = (chapters.currChapter.state as? ReaderChapter.State.Error)?.error
+        if (chapterLoadError != null) {
+            hideLoadingIndicator()
+            abortPendingTtsOnLoadFailure()
+            displayError(chapterLoadError)
+            return
+        }
         val page = chapters.currChapter.pages?.firstOrNull() ?: return
 
         loadJob?.cancel()
@@ -1533,7 +1570,7 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         )
         scope.launch {
             val pre = withContext(Dispatchers.Default) { contentPipeline.preTranslate(rawContent, cfg) }
-            if (activity.isTranslationEnabled() && !preferences.novelShowRawHtml.get()) {
+            val finalProcessed = if (activity.isTranslationEnabled() && !preferences.novelShowRawHtml.get()) {
                 val chapterId = chapter.chapter.id
                 val labelRes = if (activity.hasCachedTranslation(chapterId)) {
                     TDMR.strings.novel_chapter_translating_from_cache
@@ -1541,14 +1578,41 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
                     TDMR.strings.novel_chapter_translating_from_api
                 }
                 block.showPlaceholder(activity.stringResource(labelRes))
-                val translated = withContext(Dispatchers.Default) {
+                withContext(Dispatchers.Default) {
                     contentPipeline.finalize(pre, cfg) { activity.translateContentIfEnabled(it, chapterId) }
                 }
-                setChapterContent(loadedChapter, translated)
             } else {
-                val processed = withContext(Dispatchers.Default) { contentPipeline.finalize(pre, cfg) }
-                setChapterContent(loadedChapter, processed)
+                withContext(Dispatchers.Default) { contentPipeline.finalize(pre, cfg) }
             }
+
+            // Raw HTML wasn't blank, but the pipeline's selectors can still extract it to nothing;
+            // header/block were already attached above, so undo that instead of displaying it empty.
+            if (!NovelProgress.isUsableChapterText(finalProcessed.text)) {
+                logcat(LogPriority.ERROR) {
+                    "NovelViewer: Chapter ${chapter.chapter.name} extracted to unusable content"
+                }
+                contentContainer.removeView(headerView)
+                contentContainer.removeView(block.container)
+                loadedChapter.separatorView?.let { contentContainer.removeView(it) }
+                chapterQueue.removeById(chapter.chapter.id)
+                if (!isAppend) {
+                    currentChapterIndex = (loadedChapters.size - 1).coerceAtLeast(0)
+                }
+                if (isAppend) {
+                    nextLoadRequiresManualRetry = true
+                    inlineFeedback.showInlineError(
+                        activity.stringResource(TDMR.strings.novel_error_empty_chapter),
+                        isPrepend = false,
+                        onRetry = { nextLoadRequiresManualRetry = false; loadNextChapterIfAvailable() },
+                    )
+                } else {
+                    abortPendingTtsOnLoadFailure()
+                    displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+                }
+                return@launch
+            }
+
+            setChapterContent(loadedChapter, finalProcessed)
         }
 
         applyBackgroundColor()
@@ -1878,6 +1942,23 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             ).apply { bottomMargin = 32 }
         }
 
+        val buttonRow = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+        }
+
+        val retryButton = android.widget.Button(activity).apply {
+            text = activity.stringResource(TDMR.strings.novel_error_retry)
+            isAllCaps = false
+            textSize = 14f
+            setTextColor(0xFF4A90D9.toInt())
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { marginEnd = 16 }
+            setOnClickListener { activity.viewModel.reloadChapter(fromSource = false) }
+        }
+
         val copyButton = android.widget.Button(activity).apply {
             text = activity.stringResource(TDMR.strings.novel_error_copy_details)
             isAllCaps = false
@@ -1893,9 +1974,12 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
             }
         }
 
+        buttonRow.addView(retryButton)
+        buttonRow.addView(copyButton)
+
         errorContainer.addView(categoryView)
         errorContainer.addView(summaryView)
-        errorContainer.addView(copyButton)
+        errorContainer.addView(buttonRow)
 
         contentContainer.removeAllViews()
         contentContainer.addView(errorContainer)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/textview/NovelViewer.kt
@@ -1530,6 +1530,10 @@ class NovelViewer(val activity: ReaderActivity) : Viewer {
         val isAppend = loadedChapters.isNotEmpty() && preferences.novelInfiniteScroll.get()
 
         reachedNovelEnd = false
+        // A fresh chapter load (toolbar next/prev) clears a prior auto-append failure latch that
+        // would otherwise stick forever once its inline retry banner is destroyed. On an append the
+        // caller's finally block owns this flag.
+        if (!isAppend) nextLoadRequiresManualRetry = false
 
         chapterQueue.append(loadedChapter)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMeta.kt
@@ -16,6 +16,9 @@ internal object NovelWebViewChapterMeta {
     const val CHAPTER_DIVIDER_CLASS = "tsundoku-chapter-divider"
     const val TSUNDOKU_CHAPTERS_CONTAINER_ID = "tsundoku-chapters-container"
 
+    // Paged mode: class toggled on <html> by paged-reader.js, and the CSS multicol target.
+    const val PAGED_BODY_CLASS = "tsundoku-paged"
+
     const val TSUNDOKU_OBJECT_NAME = "Tsundoku"
     const val TSUNDOKU_NOVEL_URL_KEY = "novelUrl"
     const val TSUNDOKU_CURRENT_CHAPTER_KEY = "currentChapter"
@@ -28,6 +31,7 @@ internal object NovelWebViewChapterMeta {
     const val TSUNDOKU_IMMERSIVE_KEY = "immersive"
     const val TSUNDOKU_TTS_STATE_KEY = "ttsState"
     const val TSUNDOKU_LOADING_CHAPTER_KEY = "loadingChapter"
+    const val TSUNDOKU_PAGING_ENABLED_KEY = "pagingEnabled"
 
     // Event names dispatched on `window` so plugins/snippets can subscribe with addEventListener.
     const val EVENT_MENU_VISIBILITY = "tsundoku:menuvisibilitychange"
@@ -35,8 +39,14 @@ internal object NovelWebViewChapterMeta {
     const val EVENT_CHAPTER_LOADING = "tsundoku:chapterloading"
     const val EVENT_TTS_STATE = "tsundoku:ttsstatechange"
 
-    // Fired page-side (scroll-tracking.js) as reading progress advances, throttled with the slider
-    // bridge. Dispatched from JS, not Kotlin, so there is no per-frame bridge hop.
+    // Fired page-side (paged-reader.js) whenever the current page or page count changes: a page
+    // turn, a repagination after reflow/rotation/append, or an explicit goToPage.
+    const val EVENT_PAGE_CHANGE = "tsundoku:pagechange"
+
+    // Fired page-side (scroll-tracking.js, or paged-reader.js when paged mode is active) as reading
+    // progress advances, throttled with the slider bridge. Dispatched from JS, not Kotlin, so there
+    // is no per-frame bridge hop. Same detail shape `{progress, chapterProgress, chapterId, isLast}`
+    // in both modes - a snippet can bind one listener regardless of which mode is active.
     const val EVENT_PROGRESS = "tsundoku:progresschange"
 
     // Safe-area CSS custom properties: the reader menu bar heights the page must clear (0 while the
@@ -199,6 +209,7 @@ internal object NovelWebViewChapterMeta {
         val chaptersInOrder: List<ReaderChapter>,
         val isEditingMode: Boolean,
         val isInfiniteScroll: Boolean,
+        val isPagedMode: Boolean,
         val textSelectionBlocked: Boolean,
         val forcedLowercase: Boolean,
         val menuVisible: Boolean = false,
@@ -219,6 +230,7 @@ internal object NovelWebViewChapterMeta {
             window.$TSUNDOKU_OBJECT_NAME.runtime = window.$TSUNDOKU_OBJECT_NAME.runtime || {};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_IS_EDIT_MODE_KEY = ${context.isEditingMode};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_IS_INF_SCROLL_KEY = ${context.isInfiniteScroll};
+            window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_PAGING_ENABLED_KEY = ${context.isPagedMode};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_TEXT_SELECTION_BLOCKED_KEY = ${context.textSelectionBlocked};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_FORCED_LOWERCASE_KEY = ${context.forcedLowercase};
             window.$TSUNDOKU_OBJECT_NAME.runtime.$TSUNDOKU_MENU_VISIBLE_KEY = ${context.menuVisible};

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilder.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.CHAPTER_TITLE_ATTR
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.CHAPTER_URL_ATTR
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_CHAPTER_ATTR
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_CHAPTERS_CONTAINER_ID
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.htmlAttributeEscape
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.quoteForJson
 
@@ -124,6 +125,77 @@ internal object NovelWebViewDocumentBuilder {
                     tsundoku-chapter {
                         display: block;
                         contain: content;
+                    }
+                    /* body keeps the user's margin (that's the paged reading gutter) but still needs
+                       its own overflow:hidden - its box is only pageWidth wide, so without this the
+                       overflowing multicol columns bleed text into the margin on either side. */
+                    html.tsundoku-paged {
+                        height: 100%;
+                        overflow: hidden;
+                        margin: 0;
+                    }
+                    html.tsundoku-paged body {
+                        overflow: hidden;
+                    }
+                    html.tsundoku-paged #$TSUNDOKU_CHAPTERS_CONTAINER_ID {
+                        column-gap: 0;
+                        column-fill: auto;
+                        height: 100%;
+                        box-sizing: border-box;
+                        will-change: transform;
+                        transition: transform 220ms ease;
+                    }
+                    /* Suppressed via JS (transition: none) around any non-user-turn transform change
+                       (restore, resize/rotation repagination, chapter append) - see setTransform(). */
+                    html.tsundoku-paged #$TSUNDOKU_CHAPTERS_CONTAINER_ID.tsundoku-paged-no-transition {
+                        transition: none;
+                    }
+                    html.tsundoku-paged img,
+                    html.tsundoku-paged table,
+                    html.tsundoku-paged pre,
+                    html.tsundoku-paged blockquote,
+                    html.tsundoku-paged figure {
+                        break-inside: avoid;
+                    }
+                    /* The infinite-scroll chapter-boundary marker (chapterDividerCss above) renders
+                       as a visible hr-like line in continuous mode; in paged mode it would show up
+                       as a stray horizontal line mid-page instead of a clean boundary, so keep it
+                       invisible here regardless of infinite scroll. */
+                    html.tsundoku-paged .$CHAPTER_DIVIDER_CLASS {
+                        visibility: hidden !important;
+                        height: 0 !important;
+                        margin: 0 !important;
+                        padding: 0 !important;
+                        border: none !important;
+                    }
+                    /* Pull-to-refresh-style edge badge - icon only, no chapter title text. */
+                    .tsundoku-paged-chapter-transition {
+                        position: fixed;
+                        top: 0;
+                        bottom: 0;
+                        width: 72px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        opacity: 0;
+                        pointer-events: none;
+                        transition: opacity 150ms ease;
+                        z-index: 2147483647;
+                    }
+                    .tsundoku-paged-chapter-transition[data-side="start"] { left: 0; }
+                    .tsundoku-paged-chapter-transition[data-side="end"] { right: 0; }
+                    .tsundoku-paged-chapter-transition.tsundoku-visible {
+                        opacity: 1;
+                    }
+                    .tsundoku-paged-transition-badge {
+                        width: 40px;
+                        height: 40px;
+                        border-radius: 50%;
+                        background: rgba(128, 128, 128, 0.4);
+                        color: inherit;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
                     }
                     img {
                         max-width: 100%;

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewInlineFeedback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewInlineFeedback.kt
@@ -1,14 +1,24 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.text.webview
 
+import android.content.Context
+import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.ErrorFormatter
+import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.localized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.novel.TDMR
 
 internal class NovelWebViewInlineFeedback(
+    private val context: Context,
     private val scope: CoroutineScope,
     private val evaluateJs: (String) -> Unit,
 ) {
+
+    private var pendingRetry: (() -> Unit)? = null
+    private var autoDismissJob: Job? = null
 
     fun showInlineLoading(isPrepend: Boolean) {
         val js = """
@@ -43,12 +53,23 @@ internal class NovelWebViewInlineFeedback(
         evaluateJs(js)
     }
 
-    fun showInlineError(message: String, isPrepend: Boolean) {
+    /** When [onRetry] is non-null the banner persists (no auto-dismiss) until it's tapped. */
+    fun showInlineError(message: String, isPrepend: Boolean, onRetry: (() -> Unit)? = null) {
+        autoDismissJob?.cancel()
+        pendingRetry = onRetry
+
         scope.launch(Dispatchers.Main) {
-            val escapedMessage = message
-                .replace("\\", "\\\\")
-                .replace("'", "\\'")
-                .replace("\n", "\\n")
+            val label = if (onRetry != null) {
+                context.stringResource(TDMR.strings.novel_inline_tap_to_retry, message)
+            } else {
+                context.stringResource(TDMR.strings.novel_inline_tap_to_dismiss, message)
+            }
+            val escapedLabel = label.jsEscape()
+            val onClickJs = if (onRetry != null) {
+                "errorDiv.remove(); if (window.Android && window.Android.retryInlineError) window.Android.retryInlineError();"
+            } else {
+                "errorDiv.remove();"
+            }
 
             val js = """
                 (function() {
@@ -61,8 +82,8 @@ internal class NovelWebViewInlineFeedback(
                     errorDiv.style.color = '#FF5252';
                     errorDiv.style.backgroundColor = 'rgba(255, 82, 82, 0.1)';
                     errorDiv.style.cursor = 'pointer';
-                    errorDiv.innerHTML = '$escapedMessage (tap to dismiss)';
-                    errorDiv.onclick = function() { errorDiv.remove(); };
+                    errorDiv.innerHTML = '$escapedLabel';
+                    errorDiv.onclick = function() { $onClickJs };
 
                     if ($isPrepend) {
                         document.body.insertBefore(errorDiv, document.body.firstChild);
@@ -73,10 +94,99 @@ internal class NovelWebViewInlineFeedback(
             """.trimIndent()
             evaluateJs(js)
 
-            delay(AUTO_DISMISS_MS)
-            evaluateJs("document.getElementById('$ID_INLINE_ERROR')?.remove();")
+            if (onRetry == null) {
+                autoDismissJob = scope.launch(Dispatchers.Main) {
+                    delay(AUTO_DISMISS_MS)
+                    evaluateJs("document.getElementById('$ID_INLINE_ERROR')?.remove();")
+                }
+            }
         }
     }
+
+    /** Rich variant for an actual load failure: real category/summary + Retry + Copy, not a generic string. */
+    fun showInlineError(error: Throwable, isPrepend: Boolean, onRetry: (() -> Unit)? = null) {
+        autoDismissJob?.cancel()
+        pendingRetry = onRetry
+        val fmt = ErrorFormatter.format(error)
+
+        scope.launch(Dispatchers.Main) {
+            val escapedCategory = fmt.category.localized(context).jsEscape()
+            val escapedSummary = fmt.summary.jsEscape()
+            val retryLabel = context.stringResource(TDMR.strings.novel_error_retry).jsEscape()
+            val copyLabel = context.stringResource(TDMR.strings.novel_error_copy_details).jsEscape()
+            val base64Trace = android.util.Base64.encodeToString(
+                fmt.stackTrace.toByteArray(Charsets.UTF_8),
+                android.util.Base64.NO_WRAP,
+            )
+
+            val retryBtnJs = if (onRetry != null) {
+                """
+                var retryBtn = document.createElement('button');
+                retryBtn.textContent = '$retryLabel';
+                retryBtn.style.cssText = 'margin:0 6px;padding:6px 14px;border-radius:6px;border:1px solid #4a90d9;background:transparent;color:#4a90d9;font-size:13px;';
+                retryBtn.onclick = function() {
+                    errorDiv.remove();
+                    if (window.Android && window.Android.retryInlineError) window.Android.retryInlineError();
+                };
+                btnRow.appendChild(retryBtn);
+                """.trimIndent()
+            } else {
+                ""
+            }
+
+            val js = """
+                (function() {
+                    var errorDiv = document.getElementById('$ID_INLINE_ERROR');
+                    if (errorDiv) errorDiv.remove();
+                    errorDiv = document.createElement('div');
+                    errorDiv.id = '$ID_INLINE_ERROR';
+                    errorDiv.style.textAlign = 'center';
+                    errorDiv.style.padding = '16px';
+                    errorDiv.style.backgroundColor = 'rgba(255, 82, 82, 0.1)';
+
+                    var categoryDiv = document.createElement('div');
+                    categoryDiv.textContent = '$escapedCategory';
+                    categoryDiv.style.cssText = 'color:#FF5252;font-weight:bold;font-size:14px;margin-bottom:6px;';
+                    errorDiv.appendChild(categoryDiv);
+
+                    var summaryDiv = document.createElement('div');
+                    summaryDiv.textContent = '$escapedSummary';
+                    summaryDiv.style.cssText = 'color:#888;font-size:13px;margin-bottom:10px;word-break:break-word;';
+                    errorDiv.appendChild(summaryDiv);
+
+                    var btnRow = document.createElement('div');
+                    $retryBtnJs
+                    var copyBtn = document.createElement('button');
+                    copyBtn.textContent = '$copyLabel';
+                    copyBtn.style.cssText = 'margin:0 6px;padding:6px 14px;border-radius:6px;border:1px solid #555;background:transparent;color:inherit;font-size:13px;';
+                    copyBtn.onclick = function() {
+                        if (window.Android && window.Android.copyToClipboard) window.Android.copyToClipboard('$base64Trace');
+                    };
+                    btnRow.appendChild(copyBtn);
+                    errorDiv.appendChild(btnRow);
+
+                    if ($isPrepend) {
+                        document.body.insertBefore(errorDiv, document.body.firstChild);
+                    } else {
+                        document.body.appendChild(errorDiv);
+                    }
+                })();
+            """.trimIndent()
+            evaluateJs(js)
+        }
+    }
+
+    /** Called from the JS bridge when the user taps a retryable inline error banner. */
+    fun retryPendingError() {
+        val retry = pendingRetry ?: return
+        pendingRetry = null
+        retry()
+    }
+
+    private fun String.jsEscape(): String = this
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
 
     companion object {
         const val ID_INLINE_LOADING = "inline-loading"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewPreferenceObserver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewPreferenceObserver.kt
@@ -16,6 +16,7 @@ internal class NovelWebViewPreferenceObserver(
     private val onChapterReloadRequested: () -> Unit,
     private val onBlockMediaChanged: (Boolean) -> Unit,
     private val onTtsSettingsChanged: () -> Unit,
+    private val onPagedDragCommitPercentChanged: (Int) -> Unit,
 ) {
 
     @OptIn(FlowPreview::class)
@@ -67,11 +68,19 @@ internal class NovelWebViewPreferenceObserver(
         }
 
         scope.launch {
-            // Infinite scroll is a structural change (single document vs. multi-chapter appends),
-            // so reload the whole view for a consistent state instead of patching it live.
-            preferences.novelInfiniteScroll.changes()
+            // Infinite scroll and paged mode are both structural changes (single document vs.
+            // multi-chapter appends; continuous scroll vs. CSS-column pagination), so reload the
+            // whole view for a consistent state instead of patching either live.
+            merge(
+                preferences.novelInfiniteScroll.changes().drop(1),
+                preferences.novelPagedMode.changes().drop(1),
+            ).collect { onChapterReloadRequested() }
+        }
+
+        scope.launch {
+            preferences.novelPagedDragCommitPercent.changes()
                 .drop(1)
-                .collect { onChapterReloadRequested() }
+                .collect { percent -> onPagedDragCommitPercentChanged(percent) }
         }
 
         scope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewStyler.kt
@@ -12,6 +12,9 @@ import eu.kanade.tachiyomi.ui.reader.viewer.text.shared.ThemeUtils
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.CHAPTER_DIVIDER_CLASS
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.CHAPTER_ID_ATTR
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.CHAPTER_TAG_NAME
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.EVENT_PAGE_CHANGE
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.PAGED_BODY_CLASS
+import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_CHAPTERS_CONTAINER_ID
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.TSUNDOKU_OBJECT_NAME
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.quoteForJson
 import kotlinx.serialization.json.Json
@@ -273,6 +276,26 @@ internal class NovelWebViewStyler(
         evaluateJs(js)
     }
 
+    fun injectPagedReader() {
+        val js = NovelWebViewJsAssets.loadWith(
+            activity,
+            "paged-reader.js",
+            mapOf(
+                "TSUNDOKU_OBJECT_NAME" to TSUNDOKU_OBJECT_NAME,
+                "CHAPTERS_CONTAINER_ID" to TSUNDOKU_CHAPTERS_CONTAINER_ID,
+                "PAGED_BODY_CLASS" to PAGED_BODY_CLASS,
+                "PAGE_EVENT" to EVENT_PAGE_CHANGE,
+                "PROGRESS_EVENT" to NovelWebViewChapterMeta.EVENT_PROGRESS,
+                "PAGED_ENABLED" to preferences.novelPagedMode.get().toString(),
+                "PAGED_DRAG_COMMIT_FRACTION" to (preferences.novelPagedDragCommitPercent.get() / 100.0).toString(),
+                "PAGED_EDGE_COMMIT_FRACTION" to (preferences.novelPagedDragCommitPercent.get() / 100.0).toString(),
+                "SAFE_TOP_VAR" to NovelWebViewChapterMeta.CSS_VAR_SAFE_TOP,
+                "SAFE_BOTTOM_VAR" to NovelWebViewChapterMeta.CSS_VAR_SAFE_BOTTOM,
+            ),
+        )
+        evaluateJs(js)
+    }
+
     fun injectScrollTracking() {
         val autoLoadThreshold = preferences.novelAutoLoadNextChapterAt.get()
         val effectiveThreshold = if (autoLoadThreshold > 0) autoLoadThreshold / 100.0 else 0.95
@@ -287,6 +310,7 @@ internal class NovelWebViewStyler(
                 "LOAD_THRESHOLD" to effectiveThreshold.toString(),
                 "DONE_THRESHOLD" to NovelProgress.DONE_THRESHOLD.toString(),
                 "PROGRESS_EVENT" to NovelWebViewChapterMeta.EVENT_PROGRESS,
+                "PAGED_ENABLED" to preferences.novelPagedMode.get().toString(),
             ),
         )
         evaluateJs(js)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -1600,6 +1600,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         lastSavedProgress = 0f
         lastPersistedPercent = -1
         reachedNovelEnd = false
+        // Fresh document: a prior auto-append failure latch is stale. Without this, switching
+        // chapters via the toolbar (instead of tapping the inline retry banner) destroys the banner
+        // DOM but leaves the flag set, permanently disabling infinite-scroll auto-append.
+        nextLoadRequiresManualRetry = false
         webView.loadDataWithBaseURL(resolveWebViewBaseUrl(chapterPath), html, "text/html", "UTF-8", null)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -157,13 +157,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     // Latched once the novel has no further chapter to append.
     private var reachedNovelEnd = false
 
-    // Suppresses auto-append for NEXT_LOAD_RETRY_COOLDOWN_MS after a failure; the JS load guard
-    // clears each finally, so without this a chapter that keeps timing out re-fires every frame.
-    private var lastNextLoadFailedAt = 0L
-
-    // True while a delayed JS-latch release is queued for the current cooldown, so the JS load latch
-    // is held (not re-fired every scroll frame) and released exactly once when the cooldown ends.
-    private var cooldownReleaseScheduled = false
+    // Set after a failed infinite-scroll append; blocks auto-append retries until the user taps
+    // the inline error banner (never auto-retries on its own).
+    private var nextLoadRequiresManualRetry = false
 
     // Lightweight property accessors so existing call sites keep working.
     // Mutations should go through chapterQueue's methods (append / prepend /
@@ -258,6 +254,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     private val inlineFeedback by lazy {
         NovelWebViewInlineFeedback(
+            context = activity,
             scope = scope,
             evaluateJs = { js -> evaluateJavascriptSafe(js, null) },
         )
@@ -1198,6 +1195,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     override fun setChapters(chapters: ViewerChapters) {
+        // A getPageList failure leaves the chapter in Error state with no pages - must be checked
+        // before the null-pages early return below, which would otherwise swallow it silently.
+        val chapterLoadError = (chapters.currChapter.state as? ReaderChapter.State.Error)?.error
+        if (chapterLoadError != null) {
+            hideLoadingIndicator()
+            displayError(chapterLoadError)
+            return
+        }
         val page = chapters.currChapter.pages?.firstOrNull()
         val chapterId = chapters.currChapter.chapter.id
         if (page == null || chapterId == null) {
@@ -1296,7 +1301,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     ) {
         val rawContent = page.text
         if (rawContent.isNullOrBlank()) {
-            displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+            // An append/prepend failure must not wipe the whole multi-chapter DOM with a full-page error.
+            if (!isAppendOrPrepend) {
+                displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+            }
             return
         }
 
@@ -1333,6 +1341,22 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
             val processed = withContext(Dispatchers.Default) {
                 contentPipeline.process(rawContent, cfg, translator)
+            }
+            // Raw HTML wasn't blank, but the pipeline's selectors can still extract it to nothing.
+            if (!NovelProgress.isUsableChapterText(processed.text)) {
+                withContext(Dispatchers.Main) {
+                    if (!isAppendOrPrepend) {
+                        displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+                    } else {
+                        inlineFeedback.hideInlineLoading(isPrepend = isPrepend)
+                        inlineFeedback.showInlineError(
+                            activity.stringResource(TDMR.strings.novel_error_empty_chapter),
+                            isPrepend = isPrepend,
+                            onRetry = if (!isPrepend) ::retryAppendNextChapter else null,
+                        )
+                    }
+                }
+                return@launch
             }
 
             // For infinite-scroll appends/prepends, prefix every tsundoku-novel-image://
@@ -1801,7 +1825,8 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
               .err { max-width: 600px; margin: 0 auto; text-align: center; padding-top: 10vh; }
               .category { color: #ff5555; font-size: 18px; font-weight: bold; margin-bottom: 12px; }
               .summary { color: #888; font-size: 14px; margin-bottom: 24px; word-break: break-word; }
-              .copy-btn { background: transparent; color: $textColorHex; border: 1px solid #555; border-radius: 8px; padding: 10px 20px; font-size: 14px; cursor: pointer; margin-bottom: 20px; }
+              .copy-btn, .retry-btn { background: transparent; color: $textColorHex; border: 1px solid #555; border-radius: 8px; padding: 10px 20px; font-size: 14px; cursor: pointer; margin-bottom: 12px; margin-right: 8px; }
+              .retry-btn { border-color: #4a90d9; color: #4a90d9; }
               details { text-align: left; margin-top: 4px; }
               summary { cursor: pointer; color: #777; font-size: 13px; padding: 8px 0; user-select: none; }
               pre { background: rgba(0,0,0,0.25); color: #bbb; padding: 12px; border-radius: 6px; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 280px; overflow-y: auto; margin: 0; }
@@ -1811,13 +1836,21 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             <div class="err">
               <div class="category">$escapedCategory</div>
               <div class="summary">$escapedSummary</div>
-              <button class="copy-btn" onclick="copyErr()">Copy error details</button>
+              <div>
+                <button class="retry-btn" onclick="retryErr()">${HtmlUtils.escapeHtml(activity.stringResource(TDMR.strings.novel_error_retry))}</button>
+                <button class="copy-btn" onclick="copyErr()">${HtmlUtils.escapeHtml(activity.stringResource(TDMR.strings.novel_error_copy_details))}</button>
+              </div>
               <details>
-                <summary>Technical details</summary>
+                <summary>${HtmlUtils.escapeHtml(activity.stringResource(TDMR.strings.novel_error_technical_details))}</summary>
                 <pre>$escapedTrace</pre>
               </details>
             </div>
             <script>
+            function retryErr() {
+              if (window.Android && window.Android.retryChapterLoad) {
+                window.Android.retryChapterLoad();
+              }
+            }
             function copyErr() {
               if (window.Android && window.Android.copyToClipboard) {
                 window.Android.copyToClipboard('$base64Trace');
@@ -2213,28 +2246,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     if (handoffState.isIdle) {
                         scope.launch { preFetchNextChapterForTts() }
                     }
-                } else if (System.currentTimeMillis() - lastNextLoadFailedAt <
-                    NovelProgress.NEXT_LOAD_RETRY_COOLDOWN_MS
-                ) {
-                    // Keep the JS load latch held (JS set it before this call) so it stops re-firing
-                    // loadNextChapter every scroll frame during the cooldown; schedule a single
-                    // release for when the cooldown expires so it can't become permanent.
-                    if (!cooldownReleaseScheduled) {
-                        cooldownReleaseScheduled = true
-                        val remaining = NovelProgress.NEXT_LOAD_RETRY_COOLDOWN_MS -
-                            (System.currentTimeMillis() - lastNextLoadFailedAt)
-                        webView.postDelayed({
-                            cooldownReleaseScheduled = false
-                            setJsLoadingNext()
-                        }, remaining.coerceAtLeast(0))
-                    }
-                    logcat(LogPriority.DEBUG) { "NovelWebViewViewer: loadNextChapter ignored, in failure cooldown" }
+                } else if (nextLoadRequiresManualRetry) {
+                    // Awaiting an explicit tap on the inline error banner's retry.
+                    logcat(LogPriority.DEBUG) { "NovelWebViewViewer: loadNextChapter ignored, awaiting manual retry" }
                 } else if (!isLoadingNext) {
                     isLoadingNext = true
                     appendJob = scope.launch {
                         try {
                             val ok = appendNextChapterIfAvailable()
-                            lastNextLoadFailedAt = if (ok) 0L else System.currentTimeMillis()
+                            nextLoadRequiresManualRetry = !ok
                         } finally {
                             isLoadingNext = false
                             setJsLoadingNext()
@@ -2290,6 +2310,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 cm.setPrimaryClip(android.content.ClipData.newPlainText("error", text))
                 activity.toast(activity.stringResource(TDMR.strings.novel_error_copied))
             }
+        }
+
+        @JavascriptInterface
+        fun retryInlineError() {
+            activity.runOnUiThread { inlineFeedback.retryPendingError() }
+        }
+
+        @JavascriptInterface
+        fun retryChapterLoad() {
+            activity.runOnUiThread { activity.viewModel.reloadChapter(fromSource = false) }
         }
 
         @JavascriptInterface
@@ -2412,21 +2442,24 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     private suspend fun awaitPageText(page: ReaderPage, loader: PageLoader, timeoutMs: Long): Boolean =
         NovelPageLoader.awaitPageText("NovelWebViewViewer", page, loader, timeoutMs, scope)
 
+    /** @return false if content was rejected (empty/unusable); caller shows its own error for that. */
     private suspend fun displayContentImmediate(
         chapter: ReaderChapter,
         page: ReaderPage,
         isAppendOrPrepend: Boolean,
         isPrepend: Boolean,
-    ) {
-        if (isDestroyed) return
+    ): Boolean {
+        if (isDestroyed) return false
 
         val rawContent = page.text
         if (rawContent.isNullOrBlank()) {
-            displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
-            return
+            if (!isAppendOrPrepend) {
+                displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+            }
+            return false
         }
 
-        val chapterId = chapter.chapter.id ?: return
+        val chapterId = chapter.chapter.id ?: return false
 
         val cfg = ContentConfig.from(
             preferences,
@@ -2438,6 +2471,13 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             if (activity.isTranslationEnabled()) { c -> activity.translateContentIfEnabled(c, chapterId) } else null
         val processed = withContext(Dispatchers.Default) {
             contentPipeline.process(rawContent, cfg, translator)
+        }
+        // Raw HTML wasn't blank, but the pipeline's selectors can still extract it to nothing.
+        if (!NovelProgress.isUsableChapterText(processed.text)) {
+            if (!isAppendOrPrepend) {
+                displayError(Exception(activity.stringResource(TDMR.strings.novel_error_empty_chapter)))
+            }
+            return false
         }
         imageCache.schedulePrefetch(processed.text, chapterId, page.chapter.pageLoader)
 
@@ -2466,6 +2506,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 chapterQueue.reset(chapter)
             }
         }
+        return true
     }
 
     /**
@@ -2525,14 +2566,22 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 logcat(LogPriority.DEBUG) {
                     "NovelWebViewViewer: using pre-fetched chapter $nextId (${preparedChapter.chapter.name})"
                 }
-                try {
+                val displayed = try {
                     displayContentImmediate(preparedChapter, page, isAppendOrPrepend = true, isPrepend = false)
-                    logcat(LogPriority.INFO) {
-                        "NovelWebViewViewer: Successfully appended pre-fetched chapter ${preparedChapter.chapter.name}"
-                    }
                 } finally {
                     if (!silent) inlineFeedback.hideInlineLoading(isPrepend = false)
                     setJsLoadingNext()
+                }
+                if (!displayed) {
+                    inlineFeedback.showInlineError(
+                        activity.stringResource(TDMR.strings.novel_error_couldnt_load_next_chapter),
+                        isPrepend = false,
+                        onRetry = ::retryAppendNextChapter,
+                    )
+                    return false
+                }
+                logcat(LogPriority.INFO) {
+                    "NovelWebViewViewer: Successfully appended pre-fetched chapter ${preparedChapter.chapter.name}"
                 }
             }
             // Already loaded counts as success; the caller still advances TTS onto it.
@@ -2559,7 +2608,11 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             logcat(LogPriority.ERROR) {
                 "NovelWebViewViewer: appendNext failed, no anchor chapter (loadedCount=${loadedChapters.size})"
             }
-            inlineFeedback.showInlineError("No anchor chapter for infinite scroll", isPrepend = false)
+            inlineFeedback.showInlineError(
+                activity.stringResource(TDMR.strings.novel_error_no_anchor_chapter),
+                isPrepend = false,
+                onRetry = ::retryAppendNextChapter,
+            )
             return false
         }
         logcat(LogPriority.DEBUG) {
@@ -2569,14 +2622,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         val preparedChapter = activity.viewModel.prepareNextChapterForInfiniteScroll(anchor) ?: run {
             logcat(LogPriority.WARN) { "NovelWebViewViewer: No next chapter available after ${anchor.chapter.name}" }
             // Surface once, then latch so the scroll handler stops re-triggering at the last chapter.
-            if (!reachedNovelEnd) inlineFeedback.showInlineError("No next chapter available", isPrepend = false)
+            if (!reachedNovelEnd) {
+                inlineFeedback.showInlineError(
+                    activity.stringResource(TDMR.strings.novel_error_no_next_chapter_available),
+                    isPrepend = false,
+                )
+            }
             reachedNovelEnd = true
             setJsNoMoreChapters(true)
             return false
         }
         val nextId = preparedChapter.chapter.id ?: run {
             logcat(LogPriority.ERROR) { "NovelWebViewViewer: prepared next chapter has null id" }
-            inlineFeedback.showInlineError("Chapter has no id", isPrepend = false)
+            inlineFeedback.showInlineError(
+                activity.stringResource(TDMR.strings.novel_error_chapter_no_id),
+                isPrepend = false,
+                onRetry = ::retryAppendNextChapter,
+            )
             return false
         }
         logcat(LogPriority.DEBUG) { "NovelWebViewViewer: prepared next=$nextId/${preparedChapter.chapter.name}" }
@@ -2587,13 +2649,26 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         }
 
         val page = preparedChapter.pages?.firstOrNull() ?: run {
-            logcat(LogPriority.ERROR) { "NovelWebViewViewer: No page in prepared next chapter" }
-            inlineFeedback.showInlineError("No page in next chapter", isPrepend = false)
+            val prepareError = (preparedChapter.state as? ReaderChapter.State.Error)?.error
+            logcat(LogPriority.ERROR) { "NovelWebViewViewer: No page in prepared next chapter, prepareError=$prepareError" }
+            if (prepareError != null) {
+                inlineFeedback.showInlineError(prepareError, isPrepend = false, onRetry = ::retryAppendNextChapter)
+            } else {
+                inlineFeedback.showInlineError(
+                    activity.stringResource(TDMR.strings.novel_error_no_page_in_next_chapter),
+                    isPrepend = false,
+                    onRetry = ::retryAppendNextChapter,
+                )
+            }
             return false
         }
         val loader = page.chapter.pageLoader ?: run {
             logcat(LogPriority.ERROR) { "NovelWebViewViewer: No page loader for next chapter" }
-            inlineFeedback.showInlineError("No loader for next chapter", isPrepend = false)
+            inlineFeedback.showInlineError(
+                activity.stringResource(TDMR.strings.novel_error_no_loader_next_chapter),
+                isPrepend = false,
+                onRetry = ::retryAppendNextChapter,
+            )
             return false
         }
 
@@ -2602,27 +2677,48 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             logcat(LogPriority.DEBUG) {
                 "NovelWebViewViewer: loading page for next chapter $nextId, state=${page.status}"
             }
-            val loaded = try {
-                awaitPageText(page = page, loader = loader, timeoutMs = 30_000)
+            val loadError: Throwable? = try {
+                val loaded = awaitPageText(page = page, loader = loader, timeoutMs = 30_000)
+                if (loaded) {
+                    null
+                } else {
+                    (page.status as? Page.State.Error)?.error
+                        ?: Exception(activity.stringResource(TDMR.strings.novel_error_couldnt_load_next_chapter))
+                }
             } catch (_: TimeoutCancellationException) {
                 logcat(LogPriority.ERROR) { "NovelWebViewViewer: Timed out loading next chapter page after 30s" }
-                inlineFeedback.showInlineError("Timeout loading next chapter", isPrepend = false)
-                false
+                java.util.concurrent.TimeoutException(
+                    activity.stringResource(TDMR.strings.novel_error_timeout_next_chapter),
+                )
             } catch (_: CancellationException) {
                 logcat(LogPriority.DEBUG) { "NovelWebViewViewer: appendNext cancelled" }
-                false
+                return false
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR) { "NovelWebViewViewer: Error loading next chapter page: ${e.message}" }
-                inlineFeedback.showInlineError("Error: ${e.message ?: "Unknown error"}", isPrepend = false)
-                false
+                e
             }
 
-            if (!loaded) return false
+            if (loadError != null) {
+                inlineFeedback.showInlineError(
+                    loadError,
+                    isPrepend = false,
+                    onRetry = ::retryAppendNextChapter,
+                )
+                return false
+            }
 
             logcat(LogPriority.DEBUG) {
                 "NovelWebViewViewer: appending content for chapter $nextId ts=${System.currentTimeMillis()} ttsCurrentChunkIndex=${ttsController.ttsCurrentChunkIndex} ttsResumeChunkIndex=${ttsController.ttsResumeChunkIndex} ttsPlaybackChapterIndex=${ttsController.ttsPlaybackChapterIndex} ttsPlaybackChapterId=${ttsController.ttsPlaybackChapterId}"
             }
-            displayContentImmediate(preparedChapter, page, isAppendOrPrepend = true, isPrepend = false)
+            val displayed = displayContentImmediate(preparedChapter, page, isAppendOrPrepend = true, isPrepend = false)
+            if (!displayed) {
+                inlineFeedback.showInlineError(
+                    activity.stringResource(TDMR.strings.novel_error_couldnt_load_next_chapter),
+                    isPrepend = false,
+                    onRetry = ::retryAppendNextChapter,
+                )
+                return false
+            }
             logcat(LogPriority.INFO) {
                 "NovelWebViewViewer: Successfully appended next chapter ${preparedChapter.chapter.name}"
             }
@@ -2630,6 +2726,22 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         } finally {
             if (!silent) inlineFeedback.hideInlineLoading(isPrepend = false)
             setJsLoadingNext()
+        }
+    }
+
+    /** Retries a failed infinite-scroll append; only invoked from the inline error banner's tap. */
+    private fun retryAppendNextChapter() {
+        if (isLoadingNext) return
+        nextLoadRequiresManualRetry = false
+        isLoadingNext = true
+        appendJob = scope.launch {
+            try {
+                val ok = appendNextChapterIfAvailable()
+                nextLoadRequiresManualRetry = !ok
+            } finally {
+                isLoadingNext = false
+                setJsLoadingNext()
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewViewer.kt
@@ -65,6 +65,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.quoteForJson
 import eu.kanade.tachiyomi.ui.reader.viewer.text.webview.NovelWebViewChapterMeta.unescapeJsResult
 import eu.kanade.tachiyomi.util.system.toast
+import kotlin.math.ceil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -95,6 +96,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         const val SEEK_ECHO_SUPPRESS_MS = 350L
         const val AUTO_SCROLL_START_VERIFY_MS = 400L
         const val AUTO_SCROLL_MAX_START_ATTEMPTS = 3
+        const val PAGED_CHAPTER_SWITCH_WATCHDOG_MS = 8_000L
 
         const val TTS_TEXT_EXTRACTION_JS = """
             (function() {
@@ -180,6 +182,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         }
     private var isDestroyed = false
     private var isEditingMode = false
+    // Debounces paged mode's next/prev bridge calls, which skip the isLoadingNext guard below.
+    // Cleared once the new chapter's document commits (DocState.READY/ERROR).
+    private var pagedChapterSwitchPending = false
+
+    // Last non-zero page count reported by paged-reader.js, independent of the ViewModel's
+    // novelPageCount (which gets zeroed synchronously on chapter switch - see saveProgress()).
+    private var lastKnownPagedPageCount = 0
+
+    // Mode the currently-rendered DOM was built in (not a live pref read - can diverge from it).
+    private var loadedDocumentIsPaged = false
 
     private var isAutoScrolling = false
     private var autoScrollStartAttempt = 0
@@ -267,6 +279,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 velocityY: Float,
             ): Boolean {
                 if (isEditingMode) return false
+                // Paged mode's own touch tracking (see the touch listener below) already drives
+                // and resolves the whole gesture live; this fling callback would otherwise fire
+                // on release too and double-turn the page, so it's a pure no-op while paged.
+                if (isPagedModeActive()) return true
                 if (!preferences.novelSwipeNavigation.get()) return false
                 return handleNovelFlingGesture(
                     e1,
@@ -345,7 +361,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 }
 
                 override fun onLastChunkDone() {
-                    val nextAlreadyLoaded = preferences.novelInfiniteScroll.get() &&
+                    val nextAlreadyLoaded = preferences.novelInfiniteScroll.get() && !isPagedModeActive() &&
                         loadedChapters.getOrNull(ttsController.ttsPlaybackChapterIndex + 1) != null
                     if (nextAlreadyLoaded) {
                         unloadReadChaptersAndStartNextTts()
@@ -437,7 +453,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
                 state.currentEl = target;
                 if ($keepInView) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+                    var pagedActive = window.$TSUNDOKU_OBJECT_NAME &&
+                        window.$TSUNDOKU_OBJECT_NAME.runtime &&
+                        window.$TSUNDOKU_OBJECT_NAME.runtime.pagingEnabled;
+                    if (pagedActive && window.__tdPagedGoToElement) {
+                        window.__tdPagedGoToElement(target);
+                    } else {
+                        target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+                    }
                 }
             })();
         """.trimIndent()
@@ -465,7 +488,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         }
 
         scope.launch {
-            if (preferences.novelInfiniteScroll.get()) {
+            // Paged mode never appends into the DOM (see loadNextChapter()'s JS-interface guard) -
+            // always fall through to the full chapter-switch handoff below, same as infinite
+            // scroll being off.
+            if (preferences.novelInfiniteScroll.get() && !isPagedModeActive()) {
                 // TTS owns the chapter transition here; suppress the visible "Loading…"
                 // banner so it doesn't flash while the cache hits (or the fresh fetch
                 // runs in the background). Errors still surface via showInlineError.
@@ -679,14 +705,21 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     // inject only on the first genuine chapter load.
                     if (docState != DocState.LOADING_REAL) return
                     docState = DocState.READY
+                    pagedChapterSwitchPending = false
 
                     styler.injectScript { buildTsundokuScript() }
                     styler.injectScrollTracking()
+                    loadedDocumentIsPaged = isPagedModeActive()
+                    if (loadedDocumentIsPaged) styler.injectPagedReader()
                     // Fresh DOM lost the --tsundoku-safe-* vars and menuVisible flag; re-apply them.
                     pushReaderChrome()
                     restoreScrollPosition()
                     syncShortChapterProgressIfNeeded()
-                    if (!preferences.novelInfiniteScroll.get()) {
+                    // Paged mode's own edge-swipe chevron replaces this button; it would also
+                    // render inert here anyway since paged-reader.js already moved body's content
+                    // into the page container by this point, leaving the button appended outside
+                    // it and clipped by body's paged overflow:hidden.
+                    if (!preferences.novelInfiniteScroll.get() && !isPagedModeActive()) {
                         styler.injectNextChapterButton(currentChapters?.nextChapter != null)
                     }
                     if (isEditingMode) {
@@ -791,7 +824,10 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
             isLongClickable = true
 
-            setOnTouchListener { _, event ->
+            setOnTouchListener { view, event ->
+                if (isPagedModeActive() && preferences.novelPagedSwipeEnabled.get() && !isEditingMode) {
+                    handlePagedDragTouch(event, view.width)
+                }
                 gestureDetector.onTouchEvent(event)
                 false
             }
@@ -825,7 +861,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         NovelWebViewPreferenceObserver(
             preferences = preferences,
             scope = scope,
-            onStyleChanged = { styler.injectStyles() },
+            onStyleChanged = {
+                styler.injectStyles()
+                if (isPagedModeActive()) {
+                    evaluateJavascriptSafe("if (window.__tdPagedRepaginate) window.__tdPagedRepaginate();")
+                }
+            },
             onScriptChanged = {
                 val isAppend = preferences.novelInfiniteScroll.get() && loadedChapterIds.size > 1
                 styler.injectScript(isAppend = isAppend, reapplyChangedOnly = true) { buildTsundokuScript() }
@@ -844,6 +885,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             },
             onTtsSettingsChanged = {
                 if (ttsController.ttsInitialized) ttsController.applySettings()
+            },
+            onPagedDragCommitPercentChanged = { percent ->
+                val fraction = percent / 100.0
+                evaluateJavascriptSafe(
+                    "if (window.$TSUNDOKU_OBJECT_NAME && window.$TSUNDOKU_OBJECT_NAME.actions && " +
+                        "window.$TSUNDOKU_OBJECT_NAME.actions.setPagedConfig) " +
+                        "window.$TSUNDOKU_OBJECT_NAME.actions.setPagedConfig(" +
+                        "{dragCommitFraction: $fraction, edgeCommitFraction: $fraction});",
+                )
             },
         ).observe()
     }
@@ -867,6 +917,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             activity.onNovelProgressChanged(progress)
             isRestoringScroll = true
             val token = ++scrollRestoreToken
+
+            if (isPagedModeActive()) {
+                evaluateJavascriptSafe(
+                    "if (window.__tdPagedRestoreRatio) window.__tdPagedRestoreRatio($progress, $token);",
+                )
+                webView.postDelayed({ liftRestoreGuard(token) }, 3000)
+                return
+            }
 
             // Apply the saved ratio once the content has a scrollable range: immediately if laid
             // out, else a ResizeObserver waits for the body height. onScrollRestoreComplete lifts
@@ -915,9 +973,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         } else {
             isRestoringScroll = true
             val token = ++scrollRestoreToken
-            webView.scrollTo(0, 0)
             lastSavedProgress = 0f
             activity.onNovelProgressChanged(0f)
+            if (isPagedModeActive()) {
+                evaluateJavascriptSafe(
+                    "if (window.__tdPagedRestoreRatio) window.__tdPagedRestoreRatio(0, $token);",
+                )
+                webView.postDelayed({ liftRestoreGuard(token) }, 3000)
+                return
+            }
+            webView.scrollTo(0, 0)
             // Hold the guard past the scrollTo(0,0) settle so it can't persist 0 over a read chapter.
             webView.postDelayed({ liftRestoreGuard(token) }, 300)
         }
@@ -991,7 +1056,23 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         currentPage?.let { page ->
             val progressValue = NovelProgress.progressToPercent(lastSavedProgress)
             lastPersistedPercent = progressValue
-            activity.saveNovelProgress(page, progressValue)
+            // Paged mode's reports are always a deliberate page-turn ratio, never a relayout
+            // blip, so a legitimate single-page-back turn in a short chapter isn't rejected by
+            // the backward-jump guard the way a spurious continuous-scroll 0% would be. The
+            // allowance is sized to exactly one page (never more), not an unconditional bypass -
+            // an actual spurious backward report in paged mode should still be caught.
+            // Uses lastKnownPagedPageCount, not the ViewModel's novelPageCount: the latter is
+            // zeroed synchronously by resetNovelPageInfoIfPaged() the moment a chapter switch
+            // starts, before the outgoing chapter's WebView can be guaranteed done reporting -
+            // reading it here would size a straggler's allowance off 0 (falling through to the
+            // stricter 10% default) instead of the outgoing chapter's own page count.
+            val pageCount = lastKnownPagedPageCount
+            val backwardJumpAllowance = if (isPagedModeActive() && pageCount > 1) {
+                ceil(100.0 / pageCount).toInt()
+            } else {
+                10
+            }
+            activity.saveNovelProgress(page, progressValue, backwardJumpAllowance)
             logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Saving progress $progressValue%" }
         }
     }
@@ -1032,10 +1113,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         if (!shouldAutoMarkShortChapter(page)) return
         if (page.status != Page.State.Ready || page.text.isNullOrBlank()) return
 
+        val isPaged = isPagedModeActive()
         evaluateJavascriptSafe(
             """
             (function() {
                 function checkIfShortChapter() {
+                    if ($isPaged) {
+                        // Paged mode never has scroll room (docHeight - viewport is always ~0),
+                        // so "short" means "fits on one page" instead. Require p.restored: before
+                        // that, pageCount still holds its unmeasured default of 1.
+                        var pd = window.__tdPaged;
+                        return !!(pd && pd.restored && typeof pd.pageCount === 'number' && pd.pageCount <= 1);
+                    }
                     var docHeight = Math.max(
                         document.documentElement.scrollHeight,
                         document.body ? document.body.scrollHeight : 0
@@ -1050,15 +1139,27 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                         Android.markChapterAsShort();
                     }
                 }
+                var debounceTimer = null;
                 var resizeObserver = new ResizeObserver(function() {
-                    tryMarkShort();
-                    if (called) resizeObserver.disconnect();
+                    clearTimeout(debounceTimer);
+                    debounceTimer = setTimeout(function() {
+                        tryMarkShort();
+                        if (called) resizeObserver.disconnect();
+                    }, 450);
                 });
                 resizeObserver.observe(document.body);
-                setTimeout(function() {
+                function finish() {
                     tryMarkShort();
                     resizeObserver.disconnect();
-                }, 500);
+                }
+                function deadline(remainingRetries) {
+                    if ($isPaged && !called && !(window.__tdPaged && window.__tdPaged.restored) && remainingRetries > 0) {
+                        setTimeout(function() { deadline(remainingRetries - 1); }, 150);
+                        return;
+                    }
+                    finish();
+                }
+                setTimeout(function() { deadline(14); }, 900);
             })();
             """.trimIndent(),
             null,
@@ -1097,13 +1198,19 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     override fun setChapters(chapters: ViewerChapters) {
-        val page = chapters.currChapter.pages?.firstOrNull() ?: return
-        val chapterId = chapters.currChapter.chapter.id ?: return
+        val page = chapters.currChapter.pages?.firstOrNull()
+        val chapterId = chapters.currChapter.chapter.id
+        if (page == null || chapterId == null) {
+            releasePagedChapterSwitchIfPending()
+            return
+        }
 
         loadJob?.cancel()
 
         currentPage = page
         currentChapters = chapters
+        lastPreloadRequestedNextChapterId = null
+        lastPreloadRequestedPrevChapterId = null
 
         val isPrepend = isInfiniteScrollPrepend
         isInfiniteScrollPrepend = false
@@ -1115,12 +1222,15 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             if (index >= 0) {
                 currentChapterIndex = index
             }
+            releasePagedChapterSwitchIfPending()
             return
         }
 
         ttsController.stop()
 
-        if (!preferences.novelInfiniteScroll.get() || loadedChapterIds.isEmpty()) {
+        // Paged mode always does a full chapter switch (never an append), same as infinite
+        // scroll being off, so the queue resets here too regardless of the underlying pref.
+        if (!preferences.novelInfiniteScroll.get() || loadedDocumentIsPaged || loadedChapterIds.isEmpty()) {
             chapterQueue.clear()
             currentChapterIndex = 0
         }
@@ -1139,6 +1249,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             if (loader == null) {
                 logcat(LogPriority.ERROR) { "NovelWebViewViewer: No page loader available" }
                 if (!isPrepend) hideLoadingIndicator()
+                releasePagedChapterSwitchIfPending()
                 return@launch
             }
 
@@ -1502,6 +1613,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             },
             isEditingMode = isEditingMode,
             isInfiniteScroll = preferences.novelInfiniteScroll.get(),
+            isPagedMode = isPagedModeActive(),
             textSelectionBlocked = !preferences.novelTextSelectable.get(),
             forcedLowercase = preferences.novelForceTextLowercase.get(),
             menuVisible = activity.viewModel.state.value.menuVisible,
@@ -1658,6 +1770,7 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // transition. ERROR keeps webChapterContentReady true (so a failed load can't block
         // infinite-scroll appends forever) while marking the body un-appendable.
         docState = DocState.ERROR
+        releasePagedChapterSwitchIfPending()
 
         val theme = preferences.novelTheme.get()
         val backgroundColor = preferences.novelBackgroundColor.get()
@@ -1724,6 +1837,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
     override fun handleKeyEvent(event: KeyEvent): Boolean {
         val isUp = event.action == KeyEvent.ACTION_UP
+        // Paged mode's page turn doesn't need the menu hidden first, unlike continuous scroll.
+        val volumeKeysActive = preferences.novelVolumeKeysScroll.get() && !isEditingMode &&
+            (isPagedModeActive() || !activity.viewModel.state.value.menuVisible)
 
         when (event.keyCode) {
             KeyEvent.KEYCODE_MENU -> {
@@ -1731,14 +1847,14 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 return true
             }
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
-                if (preferences.novelVolumeKeysScroll.get() && !activity.viewModel.state.value.menuVisible) {
+                if (volumeKeysActive) {
                     if (!isUp) pageScrollBy(1, 0.3)
                     return true
                 }
                 return false
             }
             KeyEvent.KEYCODE_VOLUME_UP -> {
-                if (preferences.novelVolumeKeysScroll.get() && !activity.viewModel.state.value.menuVisible) {
+                if (volumeKeysActive) {
                     if (!isUp) pageScrollBy(-1, 0.3)
                     return true
                 }
@@ -1837,6 +1953,9 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         val script = """
             (function() {
+                if (window.__tdPagedSetSuspended) {
+                    window.__tdPagedSetSuspended('$isEditing' === 'true');
+                }
                 function enableEdit() {
                     document.designMode = 'off';
                     var styleId = '${ID_EDIT_MODE_STYLE}';
@@ -1941,6 +2060,37 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         }
 
         @JavascriptInterface
+        fun onPageInfoChanged(pageIndex: Int, pageCount: Int) {
+            activity.runOnUiThread {
+                if (pageCount > 0) lastKnownPagedPageCount = pageCount
+                activity.onNovelPageInfoChanged(pageIndex, pageCount)
+                // Prefetch the neighbor chapter(s) once the reader nears an edge, so a chapter-switch
+                // triggered by paging past it (always a full switch now, never an append) is fast.
+                // A single-page chapter is simultaneously at both edges, so both are checked
+                // independently rather than an if/else-if that can only ever pick one.
+                // Reads the ViewModel's viewerChapters, not this viewer's own (possibly stale)
+                // currentChapters - see loadNextChapter()'s matching comment.
+                val chapters = activity.viewModel.state.value.viewerChapters
+                if (pageIndex >= pageCount - 1) {
+                    val next = chapters?.nextChapter
+                    val nextId = next?.chapter?.id
+                    if (next != null && nextId != lastPreloadRequestedNextChapterId) {
+                        lastPreloadRequestedNextChapterId = nextId
+                        activity.requestPreloadChapter(next)
+                    }
+                }
+                if (pageIndex <= 0) {
+                    val prev = chapters?.prevChapter
+                    val prevId = prev?.chapter?.id
+                    if (prev != null && prevId != lastPreloadRequestedPrevChapterId) {
+                        lastPreloadRequestedPrevChapterId = prevId
+                        activity.requestPreloadChapter(prev)
+                    }
+                }
+            }
+        }
+
+        @JavascriptInterface
         fun onScrollProgress(progress: Float) {
             activity.runOnUiThread {
                 if (isRestoringScroll) return@runOnUiThread
@@ -2023,6 +2173,18 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         @JavascriptInterface
         fun loadNextChapter() {
             activity.runOnUiThread {
+                // Paged mode never appends into the DOM (in-place append fights the page-index
+                // math and caused real progress bugs) - always a full chapter switch, regardless
+                // of infinite scroll; Kotlin prefetches the next chapter ahead of time instead
+                // (see onPageInfoChanged below) so the switch is still fast.
+                if (isPagedModeActive()) {
+                    // Check the ViewModel's viewerChapters, not this viewer's own (possibly
+                    // stale) currentChapters, matching what activity.loadNextChapter() reads -
+                    // otherwise the latch could be set and never cleared.
+                    val hasNext = activity.viewModel.state.value.viewerChapters?.nextChapter != null
+                    if (beginPagedEdgeCrossing(hasNext)) activity.loadNextChapter()
+                    return@runOnUiThread
+                }
                 logcat(LogPriority.DEBUG) {
                     "NovelWebViewViewer: loadNextChapter triggered, infiniteScroll=${preferences.novelInfiniteScroll.get()}, isLoadingNext=$isLoadingNext, loadedCount=${loadedChapterIds.size}"
                 }
@@ -2095,9 +2257,12 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                 logcat(LogPriority.DEBUG) { "NovelWebViewViewer: Chapter marked as short (fits in viewport)" }
 
                 // Chapter fits in viewport → no scroll events fire → threshold never reached.
-                // Trigger infinite scroll append manually.
-                if (preferences.novelInfiniteScroll.get() && !isLoadingNext && !ttsController.isTtsAutoPlay &&
-                    !webChapterIsError
+                // Trigger infinite scroll append manually. Paged mode's own "fits on one page"
+                // check reuses this same short-chapter path but must never append (see
+                // loadNextChapter()'s JS-interface guard) - a paged chapter switch happens on the
+                // next explicit page turn past this single page instead.
+                if (preferences.novelInfiniteScroll.get() && !isPagedModeActive() && !isLoadingNext &&
+                    !ttsController.isTtsAutoPlay && !webChapterIsError
                 ) {
                     isLoadingNext = true
                     appendJob = scope.launch {
@@ -2134,7 +2299,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
 
         @JavascriptInterface
         fun requestPrevChapter() {
-            activity.runOnUiThread { activity.loadPreviousChapter() }
+            activity.runOnUiThread {
+                if (isPagedModeActive()) {
+                    // See loadNextChapter()'s matching comment: check the ViewModel's viewerChapters,
+                    // not this viewer's own currentChapters, so this gate can't diverge from what
+                    // activity.loadPreviousChapter() below actually acts on.
+                    val hasPrev = activity.viewModel.state.value.viewerChapters?.prevChapter != null
+                    if (!beginPagedEdgeCrossing(hasPrev)) return@runOnUiThread
+                }
+                activity.loadPreviousChapter()
+            }
         }
 
         @JavascriptInterface
@@ -2175,6 +2349,52 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
             "(function(){ if (window.$TSUNDOKU_OBJECT_NAME && window.$TSUNDOKU_OBJECT_NAME.runtime && window.$TSUNDOKU_OBJECT_NAME.runtime.setNoMoreChapters) window.$TSUNDOKU_OBJECT_NAME.runtime.setNoMoreChapters($value); })();",
             null,
         )
+    }
+
+    // Releases paged-reader.js's edgeTransitionPending latch and hides its chevron when an edge
+    // crossing found no adjacent chapter - no document reload is coming to clear them on its own.
+    private fun releasePagedEdgeTransition() {
+        evaluateJavascriptSafe(
+            "(function(){ if (window.__tdPagedReleaseEdgeTransition) window.__tdPagedReleaseEdgeTransition(); })();",
+            null,
+        )
+    }
+
+    private fun releasePagedChapterSwitchIfPending() {
+        if (pagedChapterSwitchPending) {
+            pagedChapterSwitchPending = false
+            releasePagedEdgeTransition()
+        }
+    }
+
+    // Shared by loadNextChapter()/requestPrevChapter(): latches pagedChapterSwitchPending and
+    // arms the watchdog, or releases the edge transition when there's no adjacent chapter to
+    // switch to. Returns false when the caller should not proceed with the switch.
+    private fun beginPagedEdgeCrossing(hasAdjacentChapter: Boolean): Boolean {
+        if (pagedChapterSwitchPending) return false
+        if (!hasAdjacentChapter) {
+            releasePagedEdgeTransition()
+            return false
+        }
+        pagedChapterSwitchPending = true
+        schedulePagedChapterSwitchWatchdog()
+        return true
+    }
+
+    // Safety net for pagedChapterSwitchPending: normally cleared by onPageFinished (success) or
+    // displayError (failure), but a switch that silently no-ops before reaching either of those -
+    // e.g. ReaderViewModel.loadAdjacent's own early-return paths - would otherwise leave the latch
+    // stuck true forever, permanently blocking every later paged edge-crossing in both directions.
+    private fun schedulePagedChapterSwitchWatchdog() {
+        webView.postDelayed({
+            if (pagedChapterSwitchPending) {
+                logcat(LogPriority.WARN) {
+                    "NovelWebViewViewer: paged chapter switch watchdog released a stuck latch"
+                }
+                pagedChapterSwitchPending = false
+                releasePagedEdgeTransition()
+            }
+        }, PAGED_CHAPTER_SWITCH_WATCHDOG_MS)
     }
 
     // Lift the scroll-restore guard for [token] only if it's still the latest restore, and tell the
@@ -2421,13 +2641,89 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
     }
 
     /**
-     * Scroll by [fraction] of the viewport in [direction] (+1 down, -1 up). Uses window.innerHeight
-     * (CSS pixels) rather than container.height (device pixels): window.scrollBy expects CSS pixels,
-     * so passing device pixels overshoots by devicePixelRatio and skips content between taps.
+     * Scroll by [fraction] of the viewport in [direction] (+1 down/forward, -1 up/back). Uses
+     * window.innerHeight (CSS pixels) rather than container.height (device pixels): window.scrollBy
+     * expects CSS pixels, so passing device pixels overshoots by devicePixelRatio and skips content
+     * between taps.
+     *
+     * In paged mode this instead turns exactly one page via the paged-reader.js engine, which
+     * handles overflow past the first/last page as a chapter switch itself - same single call site
+     * for tap zones, volume keys, and the bottom-bar prev/next arrows.
      */
     private fun pageScrollBy(direction: Int, fraction: Double = 0.9) {
+        if (isPagedModeActive()) {
+            val action = if (direction < 0) "prevPage" else "nextPage"
+            evaluateJavascriptSafe(
+                "if (window.$TSUNDOKU_OBJECT_NAME && window.$TSUNDOKU_OBJECT_NAME.actions && " +
+                    "window.$TSUNDOKU_OBJECT_NAME.actions.$action) " +
+                    "window.$TSUNDOKU_OBJECT_NAME.actions.$action();",
+            )
+            return
+        }
         val sign = if (direction < 0) "-" else ""
         evaluateJavascriptSafe("window.scrollBy(0, $sign(window.innerHeight * $fraction));")
+    }
+
+    /** True when this viewer's page-turn calls (tap zones, volume keys, bottom-bar arrows) should
+     * turn a page instead of scrolling/changing chapter. Used by ReaderActivity to route the
+     * bottom-bar prev/next chapter arrows through the same page-turn call when active. */
+    fun isPagedModeActive(): Boolean = preferences.novelPagedMode.get()
+
+    /** Turns one page forward/back; called by the bottom-bar prev/next arrows when paged mode is
+     * active. Overflow past the first/last page is handled inside paged-reader.js as a chapter
+     * switch, same as tap zones/volume keys. */
+    fun turnPage(forward: Boolean) = pageScrollBy(if (forward) 1 else -1)
+
+    private var lastPreloadRequestedNextChapterId: Long? = null
+    private var lastPreloadRequestedPrevChapterId: Long? = null
+
+    private var pagedDragStartX = 0f
+    private var pagedDragStartY = 0f
+    private var pagedDragDetermined = false
+    private var pagedDragActive = false
+
+    // Live finger-follow for paged mode: forwards each touch move as a fraction of the WebView's
+    // own width to paged-reader.js's __tdPagedDragTo, which drives the transform in real time
+    // (LNReader-style, instead of only reacting after a completed fling).
+    private fun handlePagedDragTouch(event: MotionEvent, viewWidthPx: Int) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                pagedDragStartX = event.x
+                pagedDragStartY = event.y
+                pagedDragDetermined = false
+                pagedDragActive = false
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val dx = event.x - pagedDragStartX
+                val dy = event.y - pagedDragStartY
+                if (!pagedDragDetermined) {
+                    val slop = android.view.ViewConfiguration.get(activity).scaledTouchSlop
+                    if (kotlin.math.abs(dx) > slop || kotlin.math.abs(dy) > slop) {
+                        pagedDragDetermined = true
+                        pagedDragActive = kotlin.math.abs(dx) > kotlin.math.abs(dy)
+                    }
+                }
+                if (pagedDragActive && viewWidthPx > 0) {
+                    val fraction = dx / viewWidthPx.toFloat()
+                    evaluateJavascriptSafe("if (window.__tdPagedDragTo) window.__tdPagedDragTo($fraction);")
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (pagedDragActive && viewWidthPx > 0) {
+                    // A cancelled gesture (parent intercept, multi-touch conflict, system gesture)
+                    // isn't a real release - always snap back to the current page instead of
+                    // committing whatever fraction the finger happened to be at.
+                    val fraction = if (event.actionMasked == MotionEvent.ACTION_CANCEL) {
+                        0f
+                    } else {
+                        (event.x - pagedDragStartX) / viewWidthPx.toFloat()
+                    }
+                    evaluateJavascriptSafe("if (window.__tdPagedDragRelease) window.__tdPagedDragRelease($fraction);")
+                }
+                pagedDragDetermined = false
+                pagedDragActive = false
+            }
+        }
     }
 
     fun toggleAutoScroll() {
@@ -2534,6 +2830,16 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
         // Suppress the scroll->slider echo so the async, throttled onScrollUpdate from this
         // programmatic scroll can't fight the user's finger.
         lastUserSeekAt = System.currentTimeMillis()
+
+        if (isPagedModeActive()) {
+            // Dragging the slider is the paged-mode jump-to-page mechanism: convert the percent
+            // to a page via the same ratio math restoreScrollPosition uses, against the CURRENT
+            // pageCount (not a raw saved page index), so it's correct regardless of font size etc.
+            evaluateJavascriptSafe(
+                "if (window.__tdPagedRepaginate) window.__tdPagedRepaginate($progress / 100);",
+            )
+            return
+        }
 
         evaluateJavascriptSafe(
             """
@@ -2738,11 +3044,21 @@ class NovelWebViewViewer(val activity: ReaderActivity) : Viewer {
                     });
                 }
                 var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-                for (var i = 0; i < elements.length; i++) {
-                    var rect = elements[i].getBoundingClientRect();
-                    if (rect.bottom > 0 && rect.top < viewportHeight) {
-                        return i;
+                var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+                function onCurrentPage(el) {
+                    // getClientRects (per fragment), not getBoundingClientRect: a paragraph split
+                    // across a page break has a bounding box spanning both pages.
+                    var rects = el.getClientRects();
+                    for (var j = 0; j < rects.length; j++) {
+                        var r = rects[j];
+                        if (r.bottom > 0 && r.top < viewportHeight && r.right > 0 && r.left < viewportWidth) {
+                            return true;
+                        }
                     }
+                    return false;
+                }
+                for (var i = 0; i < elements.length; i++) {
+                    if (onCurrentPage(elements[i])) return i;
                 }
                 return 0;
             })();

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ChapterQueueTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/ChapterQueueTest.kt
@@ -116,6 +116,26 @@ class ChapterQueueTest {
     }
 
     @Test
+    fun `removeLast pops tail without moving cursor`() {
+        val q = queue()
+        q.append(Item(1))
+        q.append(Item(2))
+        q.append(Item(3))
+        q.currentIndex = 0
+        assertEquals(Item(3), q.removeLast())
+        assertEquals(2, q.size)
+        assertEquals(0, q.currentIndex)
+        assertEquals(Item(1), q.current())
+        assertFalse(q.contains(3))
+    }
+
+    @Test
+    fun `removeLast on empty returns null`() {
+        val q = queue()
+        assertNull(q.removeLast())
+    }
+
+    @Test
     fun `removeFirstN drops requested count`() {
         val q = queue()
         for (i in 1L..5L) q.append(Item(i))

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/NovelProgressTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/shared/NovelProgressTest.kt
@@ -70,4 +70,32 @@ class NovelProgressTest {
         assertEquals(emptyList<Int>(), NovelProgress.forwardChaptersToMarkRead(-1, 2, 5))
         assertEquals(emptyList<Int>(), NovelProgress.forwardChaptersToMarkRead(9, 12, 4))
     }
+
+    @Test
+    fun `isUsableChapterText rejects null, empty and whitespace-only text`() {
+        assertFalse(NovelProgress.isUsableChapterText(null))
+        assertFalse(NovelProgress.isUsableChapterText(""))
+        assertFalse(NovelProgress.isUsableChapterText("   \n\t  "))
+    }
+
+    @Test
+    fun `isUsableChapterText rejects near-empty content that slipped past a raw-blank check`() {
+        // A source returning a template/interstitial page can extract down to just a few
+        // characters even though the raw HTML wasn't blank.
+        assertFalse(NovelProgress.isUsableChapterText("..."))
+        assertFalse(NovelProgress.isUsableChapterText("N/A"))
+    }
+
+    @Test
+    fun `isUsableChapterText does not count whitespace toward the minimum`() {
+        // 9 non-whitespace chars padded with spaces must still fail (< 10).
+        assertFalse(NovelProgress.isUsableChapterText("a b c d e f g h i"))
+        // 10 non-whitespace chars must pass.
+        assertTrue(NovelProgress.isUsableChapterText("a b c d e f g h i j"))
+    }
+
+    @Test
+    fun `isUsableChapterText accepts a genuinely short real chapter`() {
+        assertTrue(NovelProgress.isUsableChapterText("The end. There was nothing more to say."))
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewChapterMetaTest.kt
@@ -203,6 +203,7 @@ class NovelWebViewChapterMetaTest {
                 chaptersInOrder = emptyList(),
                 isEditingMode = false,
                 isInfiniteScroll = true,
+                isPagedMode = false,
                 textSelectionBlocked = false,
                 forcedLowercase = false,
             ),
@@ -231,6 +232,7 @@ class NovelWebViewChapterMetaTest {
                 chaptersInOrder = emptyList(),
                 isEditingMode = false,
                 isInfiniteScroll = false,
+                isPagedMode = false,
                 textSelectionBlocked = false,
                 forcedLowercase = false,
                 menuVisible = true,
@@ -254,6 +256,7 @@ class NovelWebViewChapterMetaTest {
                 chaptersInOrder = emptyList(),
                 isEditingMode = true,
                 isInfiniteScroll = false,
+                isPagedMode = false,
                 textSelectionBlocked = true,
                 forcedLowercase = true,
             ),
@@ -264,5 +267,36 @@ class NovelWebViewChapterMetaTest {
         assertTrue(script.contains(".textSelectionBlocked = true"))
         assertTrue(script.contains(".forcedLowercase = true"))
         assertFalse(script.contains(".isEditMode = false"))
+    }
+
+    @Test
+    fun `buildTsundokuScript reflects isPagedMode on the pagingEnabled runtime key`() {
+        val pagedOn = NovelWebViewChapterMeta.buildTsundokuScript(
+            NovelWebViewChapterMeta.TsundokuScriptContext(
+                novelUrl = null,
+                currentChapter = null,
+                chaptersInOrder = emptyList(),
+                isEditingMode = false,
+                isInfiniteScroll = false,
+                isPagedMode = true,
+                textSelectionBlocked = false,
+                forcedLowercase = false,
+            ),
+        )
+        assertTrue(pagedOn.contains(".pagingEnabled = true"))
+
+        val pagedOff = NovelWebViewChapterMeta.buildTsundokuScript(
+            NovelWebViewChapterMeta.TsundokuScriptContext(
+                novelUrl = null,
+                currentChapter = null,
+                chaptersInOrder = emptyList(),
+                isEditingMode = false,
+                isInfiniteScroll = false,
+                isPagedMode = false,
+                textSelectionBlocked = false,
+                forcedLowercase = false,
+            ),
+        )
+        assertTrue(pagedOff.contains(".pagingEnabled = false"))
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/text/webview/NovelWebViewDocumentBuilderTest.kt
@@ -136,10 +136,53 @@ class NovelWebViewDocumentBuilderTest {
     }
 
     @Test
-    fun `assemble does not produce chapter divider without infinite scroll`() {
+    fun `assemble does not produce the divider's visible-boundary rule without infinite scroll`() {
         val html = NovelWebViewDocumentBuilder.assemble(
             minimalInput(infiniteScrollEnabled = false),
         )
-        assertFalse(html.contains("tsundoku-chapter-divider"))
+        // The infinite-scroll-only visible hr-style boundary rule must be absent; the always-shipped
+        // paged-mode override (which forces the divider invisible under html.tsundoku-paged
+        // regardless of infinite scroll, see NovelWebViewDocumentBuilder.kt) legitimately still
+        // mentions the class name, so this checks for the divider *element* markup instead of the
+        // bare class-name substring.
+        assertFalse(html.contains("<div class=\"${NovelWebViewChapterMeta.CHAPTER_DIVIDER_CLASS}\""))
+    }
+
+    // Paged mode CSS: always embedded, gated at runtime by the .tsundoku-paged class
+
+    @Test
+    fun `assemble always embeds the paged-mode clip and column CSS`() {
+        val html = NovelWebViewDocumentBuilder.assemble(minimalInput())
+        assertTrue(html.contains("html.tsundoku-paged"))
+        assertTrue(html.contains("html.tsundoku-paged body"))
+        assertTrue(html.contains("html.tsundoku-paged #${NovelWebViewChapterMeta.TSUNDOKU_CHAPTERS_CONTAINER_ID}"))
+    }
+
+    @Test
+    fun `assemble avoids splitting media elements across a page break`() {
+        val html = NovelWebViewDocumentBuilder.assemble(minimalInput())
+        val styleSection = html.substringAfter("<style>").substringBefore("</style>")
+        val breakRule = Regex(
+            "html\\.tsundoku-paged[^{]*\\{[^}]*break-inside:\\s*avoid",
+            RegexOption.DOT_MATCHES_ALL,
+        )
+        assertTrue(breakRule.containsMatchIn(styleSection)) {
+            "Expected a break-inside: avoid rule scoped to .tsundoku-paged, got: $styleSection"
+        }
+        for (tag in listOf("img", "table", "pre", "blockquote", "figure")) {
+            assertTrue("html.tsundoku-paged $tag" in styleSection) { "Missing paged break-inside rule for <$tag>" }
+        }
+    }
+
+    @Test
+    fun `assemble forces the chapter divider invisible under paged mode regardless of infinite scroll`() {
+        val html = NovelWebViewDocumentBuilder.assemble(
+            minimalInput(infiniteScrollEnabled = true),
+        )
+        assertTrue(
+            html.contains(
+                "html.tsundoku-paged .${NovelWebViewChapterMeta.CHAPTER_DIVIDER_CLASS}",
+            ),
+        )
     }
 }

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -553,6 +553,8 @@
     <string name="tts_prev_paragraph">Previous paragraph</string>
     <string name="tts_next_paragraph">Next paragraph</string>
     <string name="pref_novel_infinite_scroll">Infinite scroll (auto-load next chapter)</string>
+    <string name="pref_novel_paged_drag_commit">Page-turn swipe distance</string>
+    <string name="pref_novel_paged_drag_commit_summary">How far a swipe must cross the screen to turn a page</string>
     <string name="pref_novel_progress_slider">Show progress slider</string>
     <string name="pref_novel_scrollbar_mode">Progress slider</string>
     <string name="novel_scrollbar_none">None</string>

--- a/i18n-novel/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-novel/src/commonMain/moko-resources/base/strings.xml
@@ -967,6 +967,17 @@
     <string name="novel_error_cat_source_unsupported">Source does not support this operation</string>
     <string name="novel_error_cat_out_of_memory">Out of memory — chapter may be too large</string>
     <string name="novel_error_cat_unknown">Error (%s)</string>
+    <string name="novel_error_retry">Retry</string>
+    <string name="novel_inline_tap_to_retry">%1$s (tap to retry)</string>
+    <string name="novel_inline_tap_to_dismiss">%1$s (tap to dismiss)</string>
+    <string name="novel_error_no_anchor_chapter">No chapter to continue from for infinite scroll</string>
+    <string name="novel_error_no_next_chapter_available">No next chapter available</string>
+    <string name="novel_error_chapter_no_id">Next chapter has no id</string>
+    <string name="novel_error_no_page_in_next_chapter">No page found in next chapter</string>
+    <string name="novel_error_no_loader_next_chapter">No loader available for next chapter</string>
+    <string name="novel_error_timeout_next_chapter">Timed out loading next chapter</string>
+    <string name="novel_error_couldnt_load_next_chapter">Couldn\'t load next chapter</string>
+    <string name="novel_error_generic_next_chapter">Error: %1$s</string>
 
     <string name="pref_novel_status_bar">Reading status bar</string>
     <string name="pref_novel_status_bar_show_time">Show current time</string>


### PR DESCRIPTION
Added paged webview reader
- enabled in reader settings dialog or pref screen
- disabled some features like auto scroll when paged reading is on
- can set swipe to switch page distance in novel read pref screen
- added specific js events and css classes specifically for paged reading
```
JS API: actions.nextPage()/prevPage()/goToPage(n)/setPagedConfig({...});
// runtime.pagingEnabled/pageIndex/pageCount
 window events __PAGE_EVENT__ { pageIndex, pageCount } and
// __PROGRESS_EVENT__ 
```
