### PR TITLE
fix epub parser including novel title in chapter title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - TTS media notification for pause/resume with headset buttons. Old notification available in advanced settings. [@mrissaoussama](https://github.com/mrissaoussama) [#421](https://github.com/tsundoku-otaku/tsundoku/pull/421)
 
 ### Fixed
+- EPUB parser no longer includes novel title in chapter title [@mrissaoussama](https://github.com/mrissaoussama) [#422](https://github.com/tsundoku-otaku/tsundoku/pull/422)
 - Fix extension restoring from cold state [@mrissaoussama](https://github.com/mrissaoussama) [#422](https://github.com/tsundoku-otaku/tsundoku/pull/422)
 
 

--- a/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
@@ -194,4 +194,28 @@ class EpubReaderNormalizeTocTest {
 
         assertEquals(listOf("Some Book Title", "Front Matter", "Chapter 1: Foo"), result)
     }
+
+    // Depth gaps: an NCX/nav grouping node with no <navLabel>/<content> is skipped as an entry but its
+    // children still get emitted at depth+1, so the first entry can start at depth > 0, or a jump can
+    // skip a level. normalizeByDepth pads these gaps; computeSiblingPresence must not crash on them.
+
+    @Test
+    fun `toc whose first entry starts below depth zero does not crash`() {
+        val result = normalize(
+            "Orphan Chapter 1" to 1,
+            "Orphan Chapter 2" to 1,
+        )
+
+        assertEquals(listOf("Orphan Chapter 1", "Orphan Chapter 2"), result)
+    }
+
+    @Test
+    fun `toc with a mid-list jump of two depth levels does not crash`() {
+        val result = normalize(
+            "Book" to 0,
+            "Deep Chapter" to 2,
+        )
+
+        assertEquals(listOf("Book", "Book - Deep Chapter"), result)
+    }
 }

--- a/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
@@ -167,7 +167,6 @@ class EpubReaderNormalizeTocTest {
         )
     }
 
-
     @Test
     fun `a lone root with no sibling is not used as an ancestor prefix for its descendants`() {
         val result = normalize(
@@ -216,6 +215,7 @@ class EpubReaderNormalizeTocTest {
             "Deep Chapter" to 2,
         )
 
-        assertEquals(listOf("Book", "Book - Deep Chapter"), result)
+        // "Book" is a lone root (no sibling), so it must not become an ancestor prefix.
+        assertEquals(listOf("Book", "Deep Chapter"), result)
     }
 }

--- a/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderNormalizeTocTest.kt
@@ -108,9 +108,20 @@ class EpubReaderNormalizeTocTest {
             "Erster Teil" to 0,
             "Kapitel 1" to 1,
             "第1章" to 1,
+            "Zweiter Teil" to 0,
+            "Kapitel 2" to 1,
         )
 
-        assertEquals(listOf("Erster Teil", "Erster Teil - Kapitel 1", "Erster Teil - 第1章"), result)
+        assertEquals(
+            listOf(
+                "Erster Teil",
+                "Erster Teil - Kapitel 1",
+                "Erster Teil - 第1章",
+                "Zweiter Teil",
+                "Zweiter Teil - Kapitel 2",
+            ),
+            result,
+        )
     }
 
     @Test
@@ -119,9 +130,20 @@ class EpubReaderNormalizeTocTest {
             "Book I" to 0,
             "Part A" to 1,
             "Chapter 1" to 2,
+            "Part B" to 1,
+            "Book II" to 0,
         )
 
-        assertEquals(listOf("Book I", "Book I - Part A", "Book I - Part A - Chapter 1"), result)
+        assertEquals(
+            listOf(
+                "Book I",
+                "Book I - Part A",
+                "Book I - Part A - Chapter 1",
+                "Book I - Part B",
+                "Book II",
+            ),
+            result,
+        )
     }
 
     @Test
@@ -130,8 +152,46 @@ class EpubReaderNormalizeTocTest {
         val result = normalize(
             "Volume 1" to 0,
             "Chapter 1: The Beginning" to 1,
+            "Volume 2" to 0,
+            "Chapter 1: The Sequel" to 1,
         )
 
-        assertEquals(listOf("Volume 1", "Volume 1 - Chapter 1: The Beginning"), result)
+        assertEquals(
+            listOf(
+                "Volume 1",
+                "Volume 1 - Chapter 1: The Beginning",
+                "Volume 2",
+                "Volume 2 - Chapter 1: The Sequel",
+            ),
+            result,
+        )
+    }
+
+
+    @Test
+    fun `a lone root with no sibling is not used as an ancestor prefix for its descendants`() {
+        val result = normalize(
+            "Some Book Title" to 0,
+            "Synopsis" to 1,
+            "Chapter 1: Foo" to 1,
+            "Chapter 2: Bar" to 1,
+            "Chapter 3: Baz" to 1,
+        )
+
+        assertEquals(
+            listOf("Some Book Title", "Synopsis", "Chapter 1: Foo", "Chapter 2: Bar", "Chapter 3: Baz"),
+            result,
+        )
+    }
+
+    @Test
+    fun `a lone root nested several levels deep is still not prefixed when no level has a sibling`() {
+        val result = normalize(
+            "Some Book Title" to 0,
+            "Front Matter" to 1,
+            "Chapter 1: Foo" to 2,
+        )
+
+        assertEquals(listOf("Some Book Title", "Front Matter", "Chapter 1: Foo"), result)
     }
 }

--- a/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
@@ -81,7 +81,6 @@ class EpubReaderTocParseTest {
 
     @Test
     fun `ncx root navPoint wrapping the entire toc is not prefixed onto every chapter`() {
-
         val navMap = ncx(
             """
             <ncx><navMap>
@@ -104,6 +103,31 @@ class EpubReaderTocParseTest {
             listOf("Some Book Title", "Synopsis", "Copyright", "Chapter 1: Foo", "Chapter 2: Bar"),
             names,
         )
+    }
+
+    @Test
+    fun `ncx grouping navPoint with no content is skipped but its children still normalize`() {
+        // The outer navPoint carries a <navLabel> but no <content>, so it is not emitted as an entry
+        // while its children are still walked at depth + 1. The TOC then starts at depth 1 with no
+        // depth-0 entry; normalization must handle that gap instead of throwing.
+        val navMap = ncx(
+            """
+            <ncx><navMap>
+              <navPoint><navLabel><text>Untitled Group</text></navLabel>
+                <navPoint><navLabel><text>Chapter 1</text></navLabel><content src="c1.xhtml"/></navPoint>
+                <navPoint><navLabel><text>Chapter 2</text></navLabel><content src="c2.xhtml"/></navPoint>
+              </navPoint>
+            </navMap></ncx>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNcxNavMap(navMap, "toc.ncx", identityResolve)
+
+        assertEquals(listOf("Chapter 1", "Chapter 2"), toc.map { it.title })
+        assertEquals(listOf(1, 1), toc.map { it.depth })
+
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(listOf("Chapter 1", "Chapter 2"), names)
     }
 
     @Test

--- a/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
+++ b/app/src/test/java/mihon/core/archive/EpubReaderTocParseTest.kt
@@ -80,6 +80,33 @@ class EpubReaderTocParseTest {
     }
 
     @Test
+    fun `ncx root navPoint wrapping the entire toc is not prefixed onto every chapter`() {
+
+        val navMap = ncx(
+            """
+            <ncx><navMap>
+              <navPoint><navLabel><text>Some Book Title</text></navLabel><content src="half-title.xhtml"/>
+                <navPoint><navLabel><text>Synopsis</text></navLabel><content src="synopsis.xhtml"/></navPoint>
+                <navPoint><navLabel><text>Copyright</text></navLabel><content src="copyright.xhtml"/></navPoint>
+                <navPoint><navLabel><text>Chapter 1: Foo</text></navLabel><content src="chap1.xhtml"/></navPoint>
+                <navPoint><navLabel><text>Chapter 2: Bar</text></navLabel><content src="chap2.xhtml"/></navPoint>
+              </navPoint>
+            </navMap></ncx>
+            """.trimIndent(),
+        )
+
+        val toc = EpubReader.buildTocFromNcxNavMap(navMap, "toc.ncx", identityResolve)
+
+        assertEquals(listOf(0, 1, 1, 1, 1), toc.map { it.depth })
+
+        val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
+        assertEquals(
+            listOf("Some Book Title", "Synopsis", "Copyright", "Chapter 1: Foo", "Chapter 2: Bar"),
+            names,
+        )
+    }
+
+    @Test
     fun `fragment-only ncx entry reuses the previous file path`() {
         val navMap = ncx(
             """
@@ -138,6 +165,7 @@ class EpubReaderTocParseTest {
                 <li><span>Section</span>
                   <ol><li><a href="c1.xhtml">Chapter 1</a></li></ol>
                 </li>
+                <li><a href="appendix.xhtml">Appendix</a></li>
               </ol></nav>
             </body></html>
             """.trimIndent(),
@@ -145,13 +173,13 @@ class EpubReaderTocParseTest {
 
         val toc = EpubReader.buildTocFromNavList(root, "nav.xhtml", identityResolve)
 
-        assertEquals(listOf("Section", "Chapter 1"), toc.map { it.title })
-        assertEquals(listOf(0, 1), toc.map { it.depth })
-        assertEquals(listOf(0, 1), toc.map { it.order })
-        assertEquals(listOf("c1.xhtml", "c1.xhtml"), toc.map { it.href })
+        assertEquals(listOf("Section", "Chapter 1", "Appendix"), toc.map { it.title })
+        assertEquals(listOf(0, 1, 0), toc.map { it.depth })
+        assertEquals(listOf(0, 1, 2), toc.map { it.order })
+        assertEquals(listOf("c1.xhtml", "c1.xhtml", "appendix.xhtml"), toc.map { it.href })
 
         val names = EpubReader.normalizeTableOfContents(toc).map { it.title }
-        assertEquals(listOf("Section", "Section - Chapter 1"), names)
+        assertEquals(listOf("Section", "Section - Chapter 1", "Appendix"), names)
     }
 
     @Test

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -651,6 +651,8 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
 
         private fun normalizeByDepth(toc: List<EpubChapter>): List<EpubChapter> {
+
+            val hasSibling = computeSiblingPresence(toc)
             val ancestors = mutableListOf<String>()
 
             return toc.mapIndexed { index, chapter ->
@@ -668,9 +670,28 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
                     else -> rawTitle
                 }
 
-                ancestors.add(rawTitle)
+                ancestors.add(if (hasSibling[index]) rawTitle else "")
                 chapter.copy(title = normalizedTitle)
             }
+        }
+
+        /**
+         * For each TOC entry, returns whether it has at least one sibling under the same parent
+         * (same nesting depth, same ancestor chain), based on [EpubChapter.depth].
+         */
+        private fun computeSiblingPresence(toc: List<EpubChapter>): BooleanArray {
+            val parentIndexOf = IntArray(toc.size)
+            val stack = mutableListOf<Int>()
+
+            toc.forEachIndexed { index, chapter ->
+                val depth = chapter.depth.coerceAtLeast(0)
+                if (stack.size > depth) stack.subList(depth, stack.size).clear()
+                parentIndexOf[index] = if (depth == 0) -1 else stack.getOrElse(depth - 1) { -1 }
+                if (stack.size == depth) stack.add(index) else stack[depth] = index
+            }
+
+            val childCountByParent = parentIndexOf.toList().groupingBy { it }.eachCount()
+            return BooleanArray(toc.size) { index -> (childCountByParent[parentIndexOf[index]] ?: 0) > 1 }
         }
 
         private fun normalizeByHeuristic(toc: List<EpubChapter>): List<EpubChapter> {

--- a/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/EpubReader.kt
@@ -651,7 +651,6 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
 
         private fun normalizeByDepth(toc: List<EpubChapter>): List<EpubChapter> {
-
             val hasSibling = computeSiblingPresence(toc)
             val ancestors = mutableListOf<String>()
 
@@ -677,17 +676,23 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
 
         /**
          * For each TOC entry, returns whether it has at least one sibling under the same parent
-         * (same nesting depth, same ancestor chain), based on [EpubChapter.depth].
+         * (same ancestor chain), based on [EpubChapter.depth]. Tolerates gaps in the depth sequence
+         * (an entry that is 2+ levels deeper than the previous one, or a first entry at depth > 0) —
+         * these occur when [buildTocFromNcxNavMap] skips a label-only grouping navPoint but still
+         * emits its children at depth + 1.
          */
         private fun computeSiblingPresence(toc: List<EpubChapter>): BooleanArray {
             val parentIndexOf = IntArray(toc.size)
-            val stack = mutableListOf<Int>()
+            // Monotonic stack of ancestor indices with strictly increasing depth; parent is the top.
+            val ancestors = mutableListOf<Int>()
 
             toc.forEachIndexed { index, chapter ->
                 val depth = chapter.depth.coerceAtLeast(0)
-                if (stack.size > depth) stack.subList(depth, stack.size).clear()
-                parentIndexOf[index] = if (depth == 0) -1 else stack.getOrElse(depth - 1) { -1 }
-                if (stack.size == depth) stack.add(index) else stack[depth] = index
+                while (ancestors.isNotEmpty() && toc[ancestors.last()].depth.coerceAtLeast(0) >= depth) {
+                    ancestors.removeAt(ancestors.lastIndex)
+                }
+                parentIndexOf[index] = ancestors.lastOrNull() ?: -1
+                ancestors.add(index)
             }
 
             val childCountByParent = parentIndexOf.toList().groupingBy { it }.eachCount()


### PR DESCRIPTION


 fixes some epubs causing chapter name to include novel title

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
